### PR TITLE
Fix Context Blindness Catastrophe in Orchestrator Service

### DIFF
--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -173,15 +173,22 @@ def _build_graph_messages(
 ) -> list[HumanMessage | AIMessage]:
     """يبني رسائل الإدخال للرسم البياني مع مسار احتياطي صريح ضد عمى السياق."""
     latest_user_message = HumanMessage(content=objective)
+
+    if history_messages:
+        seeded_history = _build_langchain_messages(history_messages)
+        seeded_history.append(latest_user_message)
+        logger.info(f"Using injected history: {len(seeded_history)} messages")
+        return seeded_history
+
     if checkpointer_available and checkpoint_has_state:
         # Prevent context amnesia and exponential message duplication in LangGraph
         # by relying purely on the checkpointer to manage history. Do not inject manually.
+        logger.info("Using checkpoint state only")
         return [latest_user_message]
 
-    # عند غياب checkpointer (أو تعطل تهيئته)، نمرّر نافذة تاريخية محدودة صراحةً.
-    seeded_history = _build_langchain_messages(history_messages)
-    seeded_history.append(latest_user_message)
-    return seeded_history
+    # عند غياب checkpointer (أو تعطل تهيئته) وعدم وجود تاريخ مرسل، نمرّر الرسالة الحالية فقط.
+    logger.warning("No context available - cold start")
+    return [latest_user_message]
 
 
 def _question_contains_explicit_entity(question: str) -> bool:

--- a/microservices/orchestrator_service/src/core/database.py
+++ b/microservices/orchestrator_service/src/core/database.py
@@ -103,8 +103,16 @@ async def init_db() -> None:
         }
         _postgres_pool = AsyncConnectionPool(**pool_kwargs)
         await _postgres_pool.open()
+
+        async with _postgres_pool.connection() as conn:
+            await conn.execute("SELECT 1")
+
         postgres_checkpointer = AsyncPostgresSaver(_postgres_pool)
         await postgres_checkpointer.setup()
+
+        test_config = {"configurable": {"thread_id": "test_init"}}
+        checkpoint = await postgres_checkpointer.aget(test_config)
+        logger.info(f"Checkpointer OK: {checkpoint is not None}")
 
         logger.info("Database initialized successfully.")
     except Exception as e:

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -473,7 +473,6 @@ class ChatFallbackNode:
             "الإجابة": fallback_response,
             "المصدر": "chat_fallback",
         }
-        import json
 
         from langchain_core.messages import AIMessage
 

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -482,7 +482,7 @@ class ChatFallbackNode:
             # Context blindness fix: We must explicitly inject our final response into state.messages
             # so that LangGraph's native Postgres checkpointer natively tracks it as AIMessage
             # without manual extraction from DB for subsequent turns.
-            "messages": [AIMessage(content=json.dumps(final_resp, ensure_ascii=False))],
+            "messages": [AIMessage(content=fallback_response, additional_kwargs={"structured": final_resp})],
         }
 
 
@@ -564,6 +564,16 @@ class QueryRewriterNode:
             content = getattr(message, "content", "")
             if role not in {"human", "user", "ai", "assistant"}:
                 continue
+
+            # Try extracting from structured kwargs first
+            additional = getattr(message, "additional_kwargs", {})
+            if isinstance(additional, dict) and "structured" in additional:
+                structured = additional["structured"]
+                if isinstance(structured, dict):
+                    text = structured.get("الإجابة") or str(structured)
+                    if text and len(text) <= 220:
+                        return text[:220].strip()
+
             if not isinstance(content, str):
                 continue
             text = content.strip()

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -481,7 +481,9 @@ class ChatFallbackNode:
             # Context blindness fix: We must explicitly inject our final response into state.messages
             # so that LangGraph's native Postgres checkpointer natively tracks it as AIMessage
             # without manual extraction from DB for subsequent turns.
-            "messages": [AIMessage(content=fallback_response, additional_kwargs={"structured": final_resp})],
+            "messages": [
+                AIMessage(content=fallback_response, additional_kwargs={"structured": final_resp})
+            ],
         }
 
 


### PR DESCRIPTION
Fix severe context blindness bugs in the Orchestrator service by ensuring proper checkpointer initialization, context history seeding, and safe message serialization/extraction.

---
*PR created automatically by Jules for task [17470439405666389551](https://jules.google.com/task/17470439405666389551) started by @HOUSSAM16ai*