### PR TITLE
Harden CI workflows against empty pytest suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          run_pytest() {
+            set +e
+            "$@"
+            pytest_exit_code=$?
+            set -e
+
+            if [ "$pytest_exit_code" -eq 5 ]; then
+              echo "::warning::pytest collected no tests; treating as a non-blocking skip."
+              return 0
+            fi
+
+            return "$pytest_exit_code"
+          }
+
           if python -m pytest --help | grep -q -- "--cov"; then
-            python -m pytest -v \
+            run_pytest python -m pytest -v \
               --cov=app \
               --cov-report=xml:coverage.xml \
               --cov-report=term-missing \
@@ -159,7 +173,7 @@ jobs:
               --tb=short
           else
             echo "::warning::pytest-cov plugin is unavailable; running test suite without coverage."
-            python -m pytest -v --durations=10 --tb=short
+            run_pytest python -m pytest -v --durations=10 --tb=short
           fi
       - name: Upload coverage artifact
         if: always()

--- a/.github/workflows/comprehensive_testing.yml
+++ b/.github/workflows/comprehensive_testing.yml
@@ -81,6 +81,11 @@ jobs:
             exit 0
           fi
 
+          if ! find "${{ matrix.suite.path }}" -type f \( -name "test_*.py" -o -name "*_test.py" \) | grep -q .; then
+            echo "ℹ️ No pytest files found under ${{ matrix.suite.path }}. Skipping suite=${{ matrix.suite.name }}."
+            exit 0
+          fi
+
           command=(python -m pytest "${{ matrix.suite.path }}" -v)
           if [ -n "${{ matrix.suite.marker }}" ]; then
             command+=(-m "${{ matrix.suite.marker }}")
@@ -97,7 +102,19 @@ jobs:
           read -r -a extra_args <<< "${suite_extra_args}"
           command+=("${extra_args[@]}")
 
+          set +e
           "${command[@]}"
+          test_exit_code=$?
+          set -e
+
+          if [ "$test_exit_code" -eq 5 ]; then
+            echo "ℹ️ Pytest collected no tests for suite=${{ matrix.suite.name }}. Treating as skipped."
+            exit 0
+          fi
+
+          if [ "$test_exit_code" -ne 0 ]; then
+            exit "$test_exit_code"
+          fi
 
       - name: Upload suite artifacts
         if: always()


### PR DESCRIPTION
### Motivation

- Prevent spurious CI failures when `pytest` collects zero tests (exit code 5) for certain matrix entries or environments, so workflows skip non-applicable suites instead of failing the job.

### Description

- Added a `run_pytest` wrapper to `.github/workflows/ci.yml` that runs `pytest`, treats exit code `5` (no tests collected) as a non-blocking skip, and preserves failing behavior for other non-zero exit codes.
- Updated `.github/workflows/comprehensive_testing.yml` matrix runner to skip a matrix suite when the target directory is missing or contains no `test_*.py`/`*_test.py` files, and to explicitly treat `pytest` exit code `5` as a skipped suite while failing on other errors.
- Changes are limited to CI workflow logic and do not alter application source code or tests.

### Testing

- Parsed all workflow YAML files with `yaml.safe_load` to validate syntax; result: all workflows parsed successfully. (passed)
- Ran `ruff check .`; result: all ruff checks passed locally. (passed)
- Executed architecture guardrails and fitness scripts (`python scripts/ci_guardrails.py`, `check_no_app_imports_in_microservices.py`, `check_route_registry_parity.py`, `check_tracing_gate.py`); result: guardrails and fitness checks passed. (passed)
- Ran gateway contract verification and its pytest contract tests (`scripts/fitness/check_gateway_provider_contracts.py` + `pytest tests/contracts/test_gateway_provider_contracts.py`); result: 2 tests passed. (passed)
- Ran `python scripts/validate_structure.py`; result: validation completed with non-blocking warnings but overall success. (passed with warnings)
- Ran `mypy app/ microservices/` as informational; result: repository-wide typing errors remain and are unrelated to the workflow changes (not addressed by this PR). (informational)

Files changed: `.github/workflows/ci.yml`, `.github/workflows/comprehensive_testing.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e91a6f34832ca7f6f838b4fc95ab)