### PR TITLE
Fix Orchestrator Context Blindness

### DIFF
--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -189,25 +189,15 @@ def _build_graph_messages(
         seeded.append(latest_user_message)
         return seeded
 
-    if checkpointer_available and checkpoint_has_state:
-        if history_messages and _is_ambiguous_followup(objective):
-            anchor_seed = _build_langchain_messages(history_messages[-MAX_CHECKPOINT_ANCHOR_MESSAGES:])
-            if anchor_seed:
-                seeded_history = _append_latest_if_missing(anchor_seed)
-                logger.info(
-                    "Using checkpoint state with anchor seed: %s messages",
-                    len(seeded_history),
-                )
-                return seeded_history
-        # Default mode: prevent exponential message duplication by relying on checkpoint state.
-        logger.info("Using checkpoint state only")
-        return [latest_user_message]
-
     if history_messages:
         seeded_history = _build_langchain_messages(history_messages)
         seeded_history = _append_latest_if_missing(seeded_history)
         logger.info(f"Using injected history: {len(seeded_history)} messages")
         return seeded_history
+
+    if checkpointer_available and checkpoint_has_state:
+        logger.info("Using checkpoint state only")
+        return [latest_user_message]
 
     # عند غياب checkpointer (أو تعطل تهيئته) وعدم وجود تاريخ مرسل، نمرّر الرسالة الحالية فقط.
     logger.warning("No context available - cold start")

--- a/telemetry_evidence.txt
+++ b/telemetry_evidence.txt
@@ -25,3 +25,21 @@
 [TELEMETRY] INGRESS | conversation_id=999 | thread_id='999' | messages_in_request=0
 [TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
 [TELEMETRY] CHECKPOINTER NOT IN SCOPE
+[TELEMETRY] INGRESS | conversation_id=123 | thread_id='u1:c123' | messages_in_request=0
+[TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
+[TELEMETRY] CHECKPOINTER NOT IN SCOPE
+[TELEMETRY] INGRESS | conversation_id=456 | thread_id='u1:c456' | messages_in_request=0
+[TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
+[TELEMETRY] CHECKPOINTER NOT IN SCOPE
+[TELEMETRY] INGRESS | conversation_id=999 | thread_id='u1:c999' | messages_in_request=0
+[TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
+[TELEMETRY] CHECKPOINTER NOT IN SCOPE
+[TELEMETRY] INGRESS | conversation_id=123 | thread_id='u1:c123' | messages_in_request=0
+[TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
+[TELEMETRY] CHECKPOINTER NOT IN SCOPE
+[TELEMETRY] INGRESS | conversation_id=456 | thread_id='u1:c456' | messages_in_request=0
+[TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
+[TELEMETRY] CHECKPOINTER NOT IN SCOPE
+[TELEMETRY] INGRESS | conversation_id=999 | thread_id='u1:c999' | messages_in_request=0
+[TELEMETRY] PRE-INVOKE | messages type=list | count=1 | last_msg=content='hello' additional_kwargs={} response_metadata={}
+[TELEMETRY] CHECKPOINTER NOT IN SCOPE

--- a/tests/unit/test_chat_context_seed_strategy.py
+++ b/tests/unit/test_chat_context_seed_strategy.py
@@ -90,9 +90,9 @@ def test_build_graph_messages_uses_checkpoint_only_for_explicit_queries() -> Non
         checkpointer_available=True,
         checkpoint_has_state=True,
     )
-    assert len(messages) == 1
-    assert isinstance(messages[0], HumanMessage)
-    assert messages[0].content == "ما هي عاصمة فرنسا؟"
+    assert len(messages) == 3
+    assert isinstance(messages[2], HumanMessage)
+    assert messages[2].content == "ما هي عاصمة فرنسا؟"
 
 
 def test_build_graph_messages_avoids_duplicate_latest_user_turn() -> None:


### PR DESCRIPTION
Fix context blindness in orchestrator chat endpoints by unconditionally prioritizing explicit history messages.

---
*PR created automatically by Jules for task [16923826777465561116](https://jules.google.com/task/16923826777465561116) started by @HOUSSAM16ai*