### PR TITLE
Send client context messages to chat WS and improve orchestrator entity anchoring with assistant fallback

### DIFF
--- a/frontend/public/js/legacy-app.jsx
+++ b/frontend/public/js/legacy-app.jsx
@@ -154,6 +154,29 @@ const { useState, useEffect, useRef, useCallback, memo } = React;
         // Helper to generate unique IDs
         const generateId = () => Math.random().toString(36).substr(2, 9) + Date.now().toString(36);
 
+        const buildClientContextMessages = (messages, currentQuestion, maxItems = 30) => {
+            const safeMessages = Array.isArray(messages) ? messages : [];
+            const normalizedHistory = safeMessages
+                .filter(
+                    (item) =>
+                        item &&
+                        (item.role === 'user' || item.role === 'assistant') &&
+                        typeof item.content === 'string' &&
+                        item.content.trim().length > 0
+                )
+                .map((item) => ({
+                    role: item.role,
+                    content: item.content.trim(),
+                }));
+
+            const questionText = typeof currentQuestion === 'string' ? currentQuestion.trim() : '';
+            if (questionText.length > 0) {
+                normalizedHistory.push({ role: 'user', content: questionText });
+            }
+
+            return normalizedHistory.slice(-maxItems);
+        };
+
         const App = () => {
             const [token, setToken] = useState(localStorage.getItem('token'));
             const [user, setUser] = useState(null);
@@ -571,7 +594,12 @@ const { useState, useEffect, useRef, useCallback, memo } = React;
                     return;
                 }
 
-                const payload = { question };
+                const clientContextMessages = buildClientContextMessages(messages, question);
+
+                const payload = {
+                    question,
+                    client_context_messages: clientContextMessages,
+                };
                 if (conversationId !== null && conversationId !== undefined) {
                     const normalizedConversationId = Number.parseInt(String(conversationId), 10);
                     payload.conversation_id = Number.isNaN(normalizedConversationId)
@@ -914,7 +942,12 @@ const { useState, useEffect, useRef, useCallback, memo } = React;
                     return;
                 }
 
-                const payload = { question };
+                const clientContextMessages = buildClientContextMessages(messages, question);
+
+                const payload = {
+                    question,
+                    client_context_messages: clientContextMessages,
+                };
                 if (conversationId !== null && conversationId !== undefined) {
                     const normalizedConversationId = Number.parseInt(String(conversationId), 10);
                     payload.conversation_id = Number.isNaN(normalizedConversationId)

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -295,13 +295,7 @@ def _extract_recent_entity_anchor(history_messages: list[dict[str, str]] | None)
         "يقوم",
     }
 
-    for message in reversed(history_messages):
-        if message.get("role") != "user":
-            continue
-        content = str(message.get("content", "")).strip()
-        if not content:
-            continue
-
+    def _extract_from_text(content: str) -> str | None:
         english_entities = re.findall(
             r"\b(?:France|Algeria|Egypt|Morocco|Tunisia|Germany|Spain)\b",
             content,
@@ -317,10 +311,30 @@ def _extract_recent_entity_anchor(history_messages: list[dict[str, str]] | None)
         candidate_tokens = [
             token for token in arabic_tokens if len(token) > 2 and token not in stop_words
         ]
-        if not candidate_tokens:
-            continue
+        if candidate_tokens:
+            return candidate_tokens[-1]
+        return None
 
-        return candidate_tokens[-1]
+    for message in reversed(history_messages):
+        if message.get("role") != "user":
+            continue
+        content = str(message.get("content", "")).strip()
+        if not content:
+            continue
+        extracted = _extract_from_text(content)
+        if extracted:
+            return extracted
+
+    # Forensic fallback: if user turns were trimmed/lost, use assistant turns as a backup anchor source.
+    for message in reversed(history_messages):
+        if message.get("role") != "assistant":
+            continue
+        content = str(message.get("content", "")).strip()
+        if not content:
+            continue
+        extracted = _extract_from_text(content)
+        if extracted:
+            return extracted
     return None
 
 
@@ -1302,6 +1316,15 @@ async def _stream_chat_langgraph(
         )
     context_gap_reason = _context_gap_reason_for_followup(objective, safe_history)
     if context_gap_reason is not None:
+        history_size = len(safe_history)
+        logger.warning(
+            "[CONTEXT_GUARD] blocked ambiguous follow-up without anchor. conv_id=%s thread_id=%s reason=%s history_size=%s objective=%s",
+            conversation_id,
+            thread_id,
+            context_gap_reason,
+            history_size,
+            objective[:120],
+        )
         await websocket.send_json(
             {
                 "type": "context_missing",
@@ -1309,19 +1332,21 @@ async def _stream_chat_langgraph(
                     "code": context_gap_reason,
                     "message": "تعذّر تحديد الكيان المرجعي من السياق الحالي.",
                     "conversation_id": conversation_id,
+                    "thread_id": thread_id,
+                    "history_size": history_size,
+                    "source": "orchestrator.context_guard",
                 },
             }
         )
         await websocket.send_json(
             {
                 "type": "assistant_error",
-                "payload": {"content": "يرجى ذكر الكيان المقصود صراحةً (مثال: ما عاصمة الجزائر؟)."},
+                "payload": {
+                    "content": "يرجى ذكر الكيان المقصود صراحةً (مثال: ما عاصمة الجزائر؟).",
+                    "code": context_gap_reason,
+                    "source": "orchestrator.context_guard",
+                },
             }
-        )
-        logger.warning(
-            "[CONTEXT_GUARD] blocked ambiguous follow-up without anchor. conv_id=%s reason=%s",
-            conversation_id,
-            context_gap_reason,
         )
         return
     prepared_objective = _augment_ambiguous_objective(objective, safe_history)

--- a/tests/test_context_guard_contract.py
+++ b/tests/test_context_guard_contract.py
@@ -33,3 +33,11 @@ def test_france_followup_is_augmented_with_anchor() -> None:
     rewritten = _augment_ambiguous_objective("ما هي عاصمتها؟", history)
     assert "فرنسا" in rewritten
     assert "مرجع سياقي إلزامي" in rewritten
+
+
+def test_context_gap_uses_assistant_anchor_when_user_turn_missing() -> None:
+    history = [
+        {"role": "assistant", "content": "تقع فرنسا في غرب أوروبا وحدودها مع بلجيكا وألمانيا."},
+    ]
+    reason = _context_gap_reason_for_followup("ما هي عاصمتها؟", history_messages=history)
+    assert reason is None


### PR DESCRIPTION
### Motivation
- Provide the backend with a compact, normalized slice of recent client-side messages to improve disambiguation for follow-ups sent over WebSocket.
- Make the orchestrator's context-guard more robust when the explicit user anchor is missing by extracting anchors from assistant turns as a forensic fallback.
- Surface richer diagnostic information to clients and logs when ambiguous follow-ups are blocked so callers can act and operators can triage.

### Description
- Added `buildClientContextMessages` in `frontend/public/js/legacy-app.jsx` to normalize recent `user`/`assistant` messages and append the current question, and included it as `client_context_messages` in the WS payloads for both user and admin chat endpoints.
- Refactored `_extract_recent_entity_anchor` in `microservices/orchestrator_service/src/api/routes.py` by extracting text processing into `_extract_from_text`, returning candidates only when present, and adding a forensic fallback loop to scan `assistant` turns when user anchors are absent.
- Enhanced context-guard behavior to log `history_size` and `thread_id` on blocked follow-ups and to include `thread_id`, `history_size`, `source`, and `code` in the `context_missing` and `assistant_error` WebSocket payloads.
- Added a unit test `test_context_gap_uses_assistant_anchor_when_user_turn_missing` in `tests/test_context_guard_contract.py` to assert that assistant content can satisfy anchor requirements.

### Testing
- Ran the context-guard contract tests with `pytest tests/test_context_guard_contract.py` and all tests, including the new `test_context_gap_uses_assistant_anchor_when_user_turn_missing`, passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4175be144832c847951937c23c430)