### PR TITLE
Prevent ambiguous referential follow-ups and add contextual local fallback (backend + frontend + tests)

### DIFF
--- a/app/api/routers/customer_chat.py
+++ b/app/api/routers/customer_chat.py
@@ -6,6 +6,7 @@
 """
 
 import asyncio
+import re
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
@@ -142,6 +143,66 @@ def _extract_client_context_messages(payload: dict[str, object]) -> list[dict[st
     return sanitized
 
 
+def _is_ambiguous_followup_question(question: str) -> bool:
+    """يتحقق من كون السؤال متابعة إحالية قصيرة تتطلب مرساة كيان صريحة."""
+    normalized = question.strip().casefold()
+    if not normalized:
+        return False
+    triggers = (
+        "عاصمتها",
+        "عاصمته",
+        "عاصمتهم",
+        "موقعها",
+        "عدد سكانها",
+        "كم سكانها",
+        "what is its",
+        "where is its",
+    )
+    if any(trigger in normalized for trigger in triggers):
+        return True
+    return len(normalized.split()) <= 4 and any(token in normalized for token in ("ها", "his", "her", "its"))
+
+
+def _has_entity_anchor(messages: list[dict[str, str]]) -> bool:
+    """يفحص وجود مرساة كيان في رسائل العميل لتأمين استمرارية السياق."""
+    if not messages:
+        return False
+
+    entity_regex = re.compile(
+        r"\b(?:france|algeria|egypt|morocco|tunisia|germany|spain|niger|nigeria)\b",
+        flags=re.IGNORECASE,
+    )
+    blocked_tokens = {
+        "ما",
+        "من",
+        "هي",
+        "هو",
+        "عاصمتها",
+        "عاصمته",
+        "موقعها",
+        "عددها",
+        "كم",
+        "أين",
+    }
+
+    for message in reversed(messages[-20:]):
+        if message.get("role") != "user":
+            continue
+        content = str(message.get("content", "")).strip()
+        if not content:
+            continue
+        if entity_regex.search(content):
+            return True
+        arabic_tokens = [
+            token.strip("؟،.!:؛")
+            for token in re.findall(r"[\u0600-\u06FF]+", content)
+            if token
+        ]
+        if any(len(token) > 2 and token not in blocked_tokens for token in arabic_tokens):
+            return True
+    return False
+
+
 def _merge_history_with_client_context(
     persisted_history: list[dict[str, str]],
     client_context: list[dict[str, str]],
@@ -239,6 +300,29 @@ async def chat_stream_ws(
                 metadata["client_context_messages"] = client_context_messages
 
             original_conversation_id = payload.get("conversation_id")
+            if (
+                original_conversation_id is None
+                and _is_ambiguous_followup_question(question)
+                and not _has_entity_anchor(client_context_messages)
+            ):
+                await websocket.send_json(
+                    _bind_stream_metadata(
+                        normalize_streaming_event(
+                            {
+                                "type": "assistant_error",
+                                "payload": {
+                                    "content": (
+                                        "السؤال الحالي إحالي بدون مرجع سياقي واضح. "
+                                        "يرجى ذكر الكيان صراحةً (مثال: ما عاصمة النيجر؟)."
+                                    )
+                                },
+                            }
+                        ),
+                        None,
+                        stream_request_id,
+                    )
+                )
+                continue
             local_conversation_id: int | None = None
             history_messages: list[dict[str, str]] = []
 

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
 from ast import literal_eval
 from collections.abc import AsyncGenerator
@@ -169,6 +170,124 @@ class OrchestratorClient:
         if not clean_response:
             return None
         return clean_response
+
+    @staticmethod
+    def _build_local_history_digest(history_messages: list[dict[str, str]] | None) -> str:
+        """يبني ملخصاً موجزاً لتاريخ الحوار كي لا يعمل fallback المحلي بشكل عديم السياق."""
+        if not history_messages:
+            return ""
+
+        normalized_rows: list[str] = []
+        for item in history_messages[-12:]:
+            role = item.get("role")
+            content = str(item.get("content", "")).replace("\x00", "").strip()
+            if role not in {"user", "assistant"} or not content:
+                continue
+            label = "المستخدم" if role == "user" else "المساعد"
+            compact = " ".join(content.split())
+            if len(compact) > 240:
+                compact = f"{compact[:240]}…"
+            normalized_rows.append(f"- {label}: {compact}")
+
+        return "\n".join(normalized_rows)
+
+    @staticmethod
+    def _is_ambiguous_followup_question(question: str) -> bool:
+        """يكشف السؤال الإحالي القصير الذي يحتاج مرجعاً صريحاً."""
+        normalized = question.strip().casefold()
+        if not normalized:
+            return False
+        triggers = (
+            "عاصمتها",
+            "عاصمته",
+            "عاصمتهم",
+            "ما هي عاصمتها",
+            "ما عاصمتها",
+            "موقعها",
+            "عدد سكانها",
+            "كم سكانها",
+            "ما هي",
+            "وما هي",
+            "where is its",
+            "what is its",
+        )
+        if any(token in normalized for token in triggers):
+            return True
+        return len(normalized.split()) <= 4 and any(
+            token in normalized for token in ("ها", "his", "her", "its")
+        )
+
+    @staticmethod
+    def _history_has_entity_anchor(history_messages: list[dict[str, str]] | None) -> bool:
+        """يتحقق من وجود كيان واضح داخل سجل المستخدم الأخير لتثبيت الضمائر الإحالية."""
+        if not history_messages:
+            return False
+
+        entity_regex = re.compile(
+            r"\b(?:france|algeria|egypt|morocco|tunisia|germany|spain|niger|nigeria)\b",
+            flags=re.IGNORECASE,
+        )
+        for item in reversed(history_messages[-12:]):
+            if item.get("role") != "user":
+                continue
+            content = str(item.get("content", "")).strip()
+            if not content:
+                continue
+            if entity_regex.search(content):
+                return True
+            arabic_tokens = [
+                token.strip("؟،.!:؛")
+                for token in re.findall(r"[\u0600-\u06FF]+", content)
+                if token
+            ]
+            if any(len(token) > 2 and token not in {"ما", "من", "هي", "هو", "عاصمتها"} for token in arabic_tokens):
+                return True
+        return False
+
+    async def _build_local_general_chat_response_with_history(
+        self,
+        question: str,
+        history_messages: list[dict[str, str]] | None,
+    ) -> str | None:
+        """ينفذ fallback محلي واعٍ بالسياق ويمنع انهيار المتابعات الإحالية عند تعطل orchestrator."""
+        sanitized_question = question.replace("\x00", "").strip()
+        if not sanitized_question:
+            return None
+
+        if self._is_ambiguous_followup_question(sanitized_question) and not self._history_has_entity_anchor(
+            history_messages
+        ):
+            return (
+                "لضمان الدقة: السؤال الإحالي الحالي لا يحتوي مرجعًا كافيًا. "
+                "يرجى ذكر الكيان صراحةً (مثال: ما عاصمة النيجر؟)."
+            )
+
+        context_digest = self._build_local_history_digest(history_messages)
+        if not context_digest:
+            return await self._build_local_general_chat_response(sanitized_question)
+
+        ai_client = get_ai_client()
+        contextual_system_prompt = (
+            "أنت مساعد عربي احترافي. استخدم سجل الحوار التالي كمرجع إلزامي قبل الإجابة. "
+            "إذا كان السؤال الحالي إحاليًا (ضمائر مثل: عاصمتها/موقعها) فاستخرج مرجعه من السياق."
+        )
+        composed_user_prompt = (
+            "سجل الحوار الأخير:\n"
+            f"{context_digest}\n\n"
+            "السؤال الحالي:\n"
+            f"{sanitized_question}"
+        )
+
+        try:
+            response_text = await ai_client.send_message(contextual_system_prompt, composed_user_prompt)
+        except Exception:
+            logger.warning("local_general_chat_contextual_fallback_failed", exc_info=True)
+            return await self._build_local_general_chat_response(sanitized_question)
+
+        clean_response = response_text.replace("\x00", "").strip()
+        if clean_response:
+            return clean_response
+        return await self._build_local_general_chat_response(sanitized_question)
 
     @staticmethod
     def _sanitize_text_for_user(content: str) -> str:
@@ -412,8 +531,9 @@ class OrchestratorClient:
             is_file_intelligence = self._file_intelligence_decision(question)[0]
             is_exercise_retrieval = self._exercise_retrieval_decision(question)
             if not is_file_intelligence and not is_exercise_retrieval:
-                local_general_chat_response = await self._build_local_general_chat_response(
-                    question
+                local_general_chat_response = await self._build_local_general_chat_response_with_history(
+                    question,
+                    history_messages,
                 )
                 if local_general_chat_response:
                     yield local_general_chat_response

--- a/app/infrastructure/clients/routing_policy.py
+++ b/app/infrastructure/clients/routing_policy.py
@@ -35,7 +35,7 @@ class ChatRoutingPolicy:
 
         return cls(
             candidate_bases=deduped,
-            fallback_enabled=os.getenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1") != "0",
+            fallback_enabled=os.getenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "0") != "0",
             breakglass_multi_target=breakglass_multi_target,
             contract_version=os.getenv("CHAT_CONTRACT_VERSION", "v1"),
         )

--- a/frontend/app/hooks/useAgentSocket.js
+++ b/frontend/app/hooks/useAgentSocket.js
@@ -143,7 +143,46 @@ const buildClientContextMessages = (messages, currentQuestion) => {
         normalized.push({ role: 'user', content: questionText });
     }
 
-    return normalized.slice(-30);
+    return normalized.slice(-60);
+};
+
+const isAmbiguousFollowupQuestion = (text) => {
+    const normalized = typeof text === 'string' ? text.trim().toLowerCase() : '';
+    if (!normalized) return false;
+    const triggers = [
+        'عاصمتها',
+        'عاصمته',
+        'عاصمتهم',
+        'موقعها',
+        'عدد سكانها',
+        'كم سكانها',
+        'what is its',
+        'where is its',
+    ];
+    if (triggers.some((item) => normalized.includes(item))) return true;
+    return normalized.split(/\s+/).length <= 4 && ['ها', 'his', 'her', 'its'].some((item) => normalized.includes(item));
+};
+
+const hasEntityAnchorInMessages = (messages) => {
+    const safeMessages = Array.isArray(messages) ? messages : [];
+    const anchorRegex = /\b(?:france|algeria|egypt|morocco|tunisia|germany|spain|niger|nigeria)\b/i;
+    const blocked = new Set(['ما', 'من', 'هي', 'هو', 'عاصمتها', 'عاصمته', 'موقعها', 'كم', 'أين']);
+
+    for (let idx = safeMessages.length - 1; idx >= 0; idx -= 1) {
+        const item = safeMessages[idx];
+        if (!item || item.role !== 'user') continue;
+        const content = typeof item.content === 'string' ? item.content.trim() : '';
+        if (!content) continue;
+        if (anchorRegex.test(content)) return true;
+
+        const arabicTokens = (content.match(/[\u0600-\u06FF]+/g) || [])
+            .map((token) => token.replace(/[؟،.!:؛]/g, '').trim())
+            .filter((token) => token.length > 0);
+        if (arabicTokens.some((token) => token.length > 2 && !blocked.has(token))) {
+            return true;
+        }
+    }
+    return false;
 };
 
 export const useAgentSocket = (endpoint, token, onConversationUpdate) => {
@@ -229,6 +268,7 @@ export const useAgentSocket = (endpoint, token, onConversationUpdate) => {
 
             if (type === 'conversation_init') {
                 if (payload?.conversation_id) {
+                    activeConversationIdRef.current = payload.conversation_id;
                     setConversationId(payload.conversation_id);
                 }
                 refreshConversationHistory();
@@ -325,10 +365,26 @@ export const useAgentSocket = (endpoint, token, onConversationUpdate) => {
             client_context_messages: buildClientContextMessages(messages, text),
             ...metadata,
         };
-        if (conversationId !== null && conversationId !== undefined) {
-            const normalizedConversationId = Number.parseInt(String(conversationId), 10);
+        const effectiveConversationId =
+            activeConversationIdRef.current !== null && activeConversationIdRef.current !== undefined
+                ? activeConversationIdRef.current
+                : conversationId;
+
+        if (
+            effectiveConversationId === null
+            && isAmbiguousFollowupQuestion(text)
+            && !hasEntityAnchorInMessages(messages)
+        ) {
+            const advisory = 'السؤال الحالي إحالي بدون مرجع واضح. اذكر الكيان صراحةً (مثال: ما عاصمة النيجر؟).';
+            notifyAgentError(advisory);
+            addMessage({ id: generateId(), role: 'assistant', content: advisory, isComplete: true, isError: true });
+            activeRequestIdRef.current = null;
+            return;
+        }
+        if (effectiveConversationId !== null && effectiveConversationId !== undefined) {
+            const normalizedConversationId = Number.parseInt(String(effectiveConversationId), 10);
             payload.conversation_id = Number.isNaN(normalizedConversationId)
-                ? conversationId
+                ? effectiveConversationId
                 : normalizedConversationId;
         }
 

--- a/tests/api/test_customer_chat_context_contract.py
+++ b/tests/api/test_customer_chat_context_contract.py
@@ -1,0 +1,30 @@
+"""اختبارات عقد استمرارية السياق لمسار محادثة العميل."""
+
+from app.api.routers.customer_chat import (
+    _has_entity_anchor,
+    _is_ambiguous_followup_question,
+)
+
+
+def test_ambiguous_followup_detection_for_arabic_reference_question() -> None:
+    """يتحقق من اكتشاف الأسئلة الإحالية القصيرة (مثل: ما هي عاصمتها؟)."""
+    assert _is_ambiguous_followup_question("ما هي عاصمتها؟") is True
+    assert _is_ambiguous_followup_question("أين تقع النيجر؟") is False
+
+
+def test_anchor_detection_uses_recent_user_messages() -> None:
+    """يتحقق من قبول المتابعة الإحالية عند وجود مرساة كيان في رسائل المستخدم."""
+    messages = [
+        {"role": "user", "content": "أين تقع النيجر؟"},
+        {"role": "assistant", "content": "تقع في غرب إفريقيا."},
+    ]
+    assert _has_entity_anchor(messages) is True
+
+
+def test_anchor_detection_rejects_pronoun_only_context() -> None:
+    """يتحقق من رفض السياق الضميري الخالص بدون مرساة كيان واضحة."""
+    messages = [
+        {"role": "user", "content": "ما هي عاصمتها؟"},
+        {"role": "assistant", "content": "يرجى تحديد الدولة."},
+    ]
+    assert _has_entity_anchor(messages) is False

--- a/tests/microservices/test_orchestrator_client_resilience.py
+++ b/tests/microservices/test_orchestrator_client_resilience.py
@@ -55,6 +55,7 @@ async def test_user_facing_error_is_sanitized(monkeypatch: pytest.MonkeyPatch) -
 async def test_local_fallback_still_works_for_file_count(monkeypatch: pytest.MonkeyPatch) -> None:
     """يحافظ على مسار التدهور المحلي الحالي عندما يكون السؤال من نمط عدّ الملفات."""
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():
@@ -80,6 +81,7 @@ async def test_local_fallback_supports_generic_extension_file_count(
 ) -> None:
     """يتحقق أن مسار التدهور يدعم صيغ ملفات متعددة لخدمة عدّ الملفات الإدارية."""
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():
@@ -107,6 +109,7 @@ async def test_local_retrieval_fallback_for_exercise_request(
 ) -> None:
     """يستخدم مسار الاسترجاع المحلي عند تعطل control-plane لطلب تمرين تعليمي."""
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():
@@ -136,6 +139,7 @@ async def test_local_general_chat_fallback_when_specialized_fallbacks_miss(
 ) -> None:
     """يضمن استمرار الدردشة العامة عند تعطل orchestrator وعدم انطباق fallback المتخصص."""
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():
@@ -147,13 +151,13 @@ async def test_local_general_chat_fallback_when_specialized_fallbacks_miss(
     async def no_retrieval(_question: str):
         return None
 
-    async def local_general_chat(_question: str):
+    async def local_general_chat(_question: str, _history_messages: list[dict[str, str]] | None):
         return "مرحبًا! هذه إجابة محلية عامة لضمان استمرارية الدردشة."
 
     monkeypatch.setattr(client, "_get_client", fake_get_client)
     monkeypatch.setattr(client, "_build_local_file_count_response", no_file_count)
     monkeypatch.setattr(client, "_build_local_retrieval_response", no_retrieval)
-    monkeypatch.setattr(client, "_build_local_general_chat_response", local_general_chat)
+    monkeypatch.setattr(client, "_build_local_general_chat_response_with_history", local_general_chat)
 
     results: list[str] = []
     async for item in client.chat_with_agent(question="السلام عليكم", user_id=7):
@@ -173,13 +177,16 @@ async def test_local_fallback_can_be_disabled_with_flag(monkeypatch: pytest.Monk
     async def fake_get_client():
         return _AlwaysFailClient()
 
-    async def local_fallback(_question: str):
+    async def local_fallback(
+        _question: str,
+        _history_messages: list[dict[str, str]] | None = None,
+    ):
         return "عدد ملفات بايثون في المشروع هو: 99 ملف."
 
     monkeypatch.setattr(client, "_get_client", fake_get_client)
     monkeypatch.setattr(client, "_build_local_file_count_response", local_fallback)
     monkeypatch.setattr(client, "_build_local_retrieval_response", local_fallback)
-    monkeypatch.setattr(client, "_build_local_general_chat_response", local_fallback)
+    monkeypatch.setattr(client, "_build_local_general_chat_response_with_history", local_fallback)
 
     chunks: list[str] = []
     async for item in client.chat_with_agent(question="كم عدد ملفات بايثون؟", user_id=1):
@@ -192,11 +199,70 @@ async def test_local_fallback_can_be_disabled_with_flag(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_contextual_local_fallback_receives_history_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """يتحقق من تمرير history_messages إلى fallback المحلي لمنع عمى السياق الإحالي."""
+    monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
+    client = OrchestratorClient(base_url="http://orchestrator-service:8006")
+
+    async def fake_get_client():
+        return _AlwaysFailClient()
+
+    async def no_file_count(_question: str):
+        return None
+
+    async def no_retrieval(_question: str):
+        return None
+
+    seen: dict[str, object] = {}
+
+    async def contextual_local_chat(
+        _question: str,
+        history_messages: list[dict[str, str]] | None,
+    ) -> str:
+        seen["history_messages"] = history_messages
+        return "تمت الإجابة باستخدام fallback سياقي."
+
+    monkeypatch.setattr(client, "_get_client", fake_get_client)
+    monkeypatch.setattr(client, "_build_local_file_count_response", no_file_count)
+    monkeypatch.setattr(client, "_build_local_retrieval_response", no_retrieval)
+    monkeypatch.setattr(client, "_build_local_general_chat_response_with_history", contextual_local_chat)
+
+    history_messages = [
+        {"role": "user", "content": "أين تقع النيجر؟"},
+        {"role": "assistant", "content": "تقع في غرب إفريقيا."},
+    ]
+    results: list[str] = []
+    async for item in client.chat_with_agent(
+        question="ما هي عاصمتها؟",
+        user_id=5,
+        history_messages=history_messages,
+    ):
+        if isinstance(item, str):
+            results.append(item)
+
+    assert results == ["تمت الإجابة باستخدام fallback سياقي."]
+    assert seen["history_messages"] == history_messages
+
+
+def test_chat_routing_policy_disables_local_fallback_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """يتحقق أن fallback المحلي الافتراضي مغلق لمنع ردود عديمة السياق في الإنتاج."""
+    monkeypatch.delenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", raising=False)
+    policy = ChatRoutingPolicy.from_environment("http://orchestrator-service:8006")
+    assert policy.fallback_enabled is False
+
+
+@pytest.mark.asyncio
 async def test_local_fallback_supports_csv_and_json_file_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """يتحقق من دعم CSV/JSON كصيغ مطلوبة ضمن ذكاء الملفات الإداري."""
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():
@@ -311,6 +377,7 @@ async def test_file_intelligence_fallback_concurrency_smoke(
     import asyncio
 
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():
@@ -341,6 +408,7 @@ async def test_exercise_retrieval_fallback_concurrency_smoke(
     import asyncio
 
     monkeypatch.setenv("ORCHESTRATOR_SERVICE_URL", "http://orchestrator-service:8006")
+    monkeypatch.setenv("ORCHESTRATOR_LOCAL_FALLBACK_ENABLED", "1")
     client = OrchestratorClient(base_url="http://orchestrator-service:8006")
 
     async def fake_get_client():

--- a/tests/test_context_resurrection.py
+++ b/tests/test_context_resurrection.py
@@ -16,7 +16,12 @@ def test_safe_conversation_id_parses_string_and_int() -> None:
 def test_frontend_no_longer_forces_string_conversation_id() -> None:
     source = Path("frontend/app/hooks/useAgentSocket.js").read_text(encoding="utf-8")
     assert "payload.conversation_id = String(conversationId)" not in source
-    assert "Number.parseInt(String(conversationId), 10)" in source
+    assert "Number.parseInt(String(effectiveConversationId), 10)" in source
+    assert "const effectiveConversationId =" in source
+    assert "activeConversationIdRef.current = payload.conversation_id;" in source
+    assert "return normalized.slice(-60);" in source
+    assert "isAmbiguousFollowupQuestion(text)" in source
+    assert "hasEntityAnchorInMessages(messages)" in source
 
 
 def test_gateway_has_explicit_admin_conversation_routes_before_admin_catch_all() -> None:


### PR DESCRIPTION
### Motivation
- Prevent short referential follow-up questions (e.g. "ما هي عاصمتها؟") from producing misleading answers when there is no explicit entity anchor in context. 
- Make the local fallback for the orchestrator context-aware so degraded responses can use recent history to resolve pronoun references. 
- Tighten production behavior by disabling the local fallback by default and add a defensive client-side check to surface advisory messages earlier. 

### Description
- Added referential-ambiguity detection and entity-anchor checks with `_is_ambiguous_followup_question` and `_has_entity_anchor` to `app/api/routers/customer_chat.py` and gate WebSocket requests to return an advisory error when a follow-up is ambiguous and lacks anchors. 
- Implemented context-aware local fallback helpers in `OrchestratorClient`: `_build_local_history_digest`, `_is_ambiguous_followup_question`, `_history_has_entity_anchor`, and `_build_local_general_chat_response_with_history`, and wired the chat fallback to call the contextual fallback when appropriate. 
- Changed `ChatRoutingPolicy.from_environment` default so `ORCHESTRATOR_LOCAL_FALLBACK_ENABLED` is off by default (treats missing env as disabled). 
- Frontend `useAgentSocket.js` changes: increased `client_context_messages` slice to `-60`, added `isAmbiguousFollowupQuestion` and `hasEntityAnchorInMessages` checks, introduced `effectiveConversationId` to prefer the active conversation from the socket, and surface an advisory assistant error early when the follow-up is ambiguous without anchors. 
- Added and updated tests: `tests/api/test_customer_chat_context_contract.py`, `tests/microservices/test_orchestrator_client_resilience.py`, and `tests/test_context_resurrection.py` to cover ambiguity detection, contextual fallback wiring, fallback flag behavior, and frontend source expectations. 

### Testing
- Ran new unit tests in `tests/api/test_customer_chat_context_contract.py` and they succeeded. 
- Ran updated microservice tests in `tests/microservices/test_orchestrator_client_resilience.py` and they succeeded, including concurrency/fallback scenarios and the new contextual fallback contract. 
- Ran repository-level checks in `tests/test_context_resurrection.py` to validate frontend string changes and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4298c378c832c871c723c88b2db9f)