### PR TITLE
Fix synchronous LLM call for query disambiguation

### DIFF
--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -363,12 +363,10 @@ def _augment_ambiguous_objective(
         return normalized
 
     try:
-        from microservices.orchestrator_service.src.core.config import get_settings
         from microservices.orchestrator_service.src.services.llm.client import get_ai_client
 
         ai_client = get_ai_client()
-        response = ai_client.chat.completions.create(
-            model=get_settings().LLM_MODEL,
+        response = ai_client.generate_sync(
             messages=[
                 {
                     "role": "user",

--- a/microservices/orchestrator_service/src/services/llm/client.py
+++ b/microservices/orchestrator_service/src/services/llm/client.py
@@ -21,7 +21,7 @@ class AIClient:
     """
 
     def __init__(self) -> None:
-        from openai import AsyncOpenAI, OpenAI
+        from openai import OpenAI
 
         settings = get_settings()
         if settings.OPENROUTER_API_KEY:

--- a/microservices/orchestrator_service/src/services/llm/client.py
+++ b/microservices/orchestrator_service/src/services/llm/client.py
@@ -21,14 +21,25 @@ class AIClient:
     """
 
     def __init__(self) -> None:
+        from openai import AsyncOpenAI, OpenAI
+
         settings = get_settings()
-        api_key = settings.OPENAI_API_KEY or settings.OPENROUTER_API_KEY
-        base_url = "https://openrouter.ai/api/v1" if settings.OPENROUTER_API_KEY else None
+        if settings.OPENROUTER_API_KEY:
+            api_key = settings.OPENROUTER_API_KEY
+            base_url = "https://openrouter.ai/api/v1"
+        else:
+            api_key = settings.OPENAI_API_KEY
+            base_url = None
 
         if not api_key:
             logger.warning("No API Key found for AI Client. AI features will fail.")
 
         self.client = AsyncOpenAI(
+            api_key=api_key or "dummy-key",
+            base_url=base_url,
+        )
+
+        self.sync_client = OpenAI(
             api_key=api_key or "dummy-key",
             base_url=base_url,
         )
@@ -89,6 +100,29 @@ class AIClient:
         """Helper for simple text generation."""
         response = await self.generate(prompt=prompt, **kwargs)
         return response.choices[0].message.content or ""
+
+    def generate_sync(
+        self,
+        model: str | None = None,
+        messages: list[dict[str, str]] | None = None,
+        **kwargs: object,
+    ) -> object:
+        """
+        Generate a complete response synchronously.
+        """
+        target_model = model or self.default_model
+        if not messages:
+            messages = [{"role": "user", "content": kwargs.get("prompt", "")}]
+
+        try:
+            return self.sync_client.chat.completions.create(
+                model=target_model,
+                messages=messages,
+                **kwargs,
+            )
+        except Exception as e:
+            logger.error(f"AI Sync Generation failed: {e}")
+            raise
 
 
 # Singleton instance

--- a/test_plan.py
+++ b/test_plan.py
@@ -1,4 +1,0 @@
-async def test_ensure_conversation_flow():
-    pass
-
-    # Needs db mock?


### PR DESCRIPTION
Fix synchronous `_augment_ambiguous_objective` to correctly initialize the LLM and disambiguate missing entity contexts correctly rather than returning the ambiguous string and causing AI agent context failures.

---
*PR created automatically by Jules for task [11375622979844854930](https://jules.google.com/task/11375622979844854930) started by @HOUSSAM16ai*