### PR TITLE
Fix IntentClassifier coreference resolution for Arabic follow-ups

### DIFF
--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -401,20 +401,23 @@ def _configure_dspy() -> None:
 class IntentClassifier(dspy.Signature):
     """Classify if conversation needs admin system metrics, general chat/greetings, general knowledge, or educational search.
     educational: ONLY BAC exercises, school curriculum, exams.
-    general_knowledge: ALL real-world questions (geography, capitals,
-    history, science) even if follow-ups.
+    general_knowledge: Includes ALL factual questions including follow-ups that depend on history (e.g., pronouns like 'عاصمتها').
+    admin: system metrics, service counts, operational information.
+    chat: Only greetings and small talk. NEVER factual questions.
     Classify by DOMAIN, not by whether it is a follow-up.
     """
 
     history: str = dspy.InputField(
         desc="Previous conversation context to resolve pronouns and context"
     )
-    question: str = dspy.InputField()
-    intent: str = dspy.OutputField(desc="One of: educational, general_knowledge, admin, chat")
-    confidence: float = dspy.OutputField()
+    question: str = dspy.InputField(
+        desc="If the question contains pronouns or implicit entities, you MUST resolve them using history BEFORE classification."
+    )
     resolved_question: str = dspy.OutputField(
         desc="The question rewritten with pronouns resolved using history"
     )
+    intent: str = dspy.OutputField(desc="One of: educational, general_knowledge, admin, chat")
+    confidence: float = dspy.OutputField()
 
 
 class SupervisorNode:

--- a/microservices/orchestrator_service/src/services/overmind/graph/supervisor.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/supervisor.py
@@ -88,18 +88,20 @@ class IntentClassifier(dspy.Signature):
     """Classify the user's intent into one of four mutually exclusive classes.
 
     - educational: BAC exercises, lessons, subjects, branches, school-years.
-    - general_knowledge: general facts outside BAC content (geography, history, science, language).
+    - general_knowledge: Includes ALL factual questions including follow-ups that depend on history (e.g., pronouns like 'عاصمتها').
     - admin: system metrics, service counts, operational information.
-    - chat: greetings, thanks, small talk, no real question.
+    - chat: Only greetings and small talk. NEVER factual questions.
     """
 
     history: str = dspy.InputField(desc="Previous conversation context to resolve pronouns.")
-    question: str = dspy.InputField(desc="Current user question.")
-    intent: str = dspy.OutputField(desc="One of: educational | general_knowledge | admin | chat")
-    confidence: float = dspy.OutputField(desc="Confidence score from 0.0 to 1.0")
+    question: str = dspy.InputField(
+        desc="If the question contains pronouns or implicit entities, you MUST resolve them using history BEFORE classification."
+    )
     resolved_question: str = dspy.OutputField(
         desc="Question rewritten with explicit entities resolved from history."
     )
+    intent: str = dspy.OutputField(desc="One of: educational | general_knowledge | admin | chat")
+    confidence: float = dspy.OutputField(desc="Confidence score from 0.0 to 1.0")
 
 
 class SupervisorNode:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
Fix IntentClassifier coreference resolution for Arabic follow-ups

- Reordered `resolved_question` before `intent` in output fields to force Chain-of-Thought reasoning.
- Updated `general_knowledge` and `chat` docstrings for clearer domain constraints on factual follow-ups.
- Added strict explicit instructions to the `question` input field to always resolve pronouns using history before classifying.

---
*PR created automatically by Jules for task [4408894481120466598](https://jules.google.com/task/4408894481120466598) started by @HOUSSAM16ai*