### PR TITLE
Fix orchestrator intent routing and simplify node message returns

### DIFF
--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -82,13 +82,8 @@ class GeneralKnowledgeNode:
 
             emit_telemetry(node_name="GeneralKnowledgeNode", start_time=start_time, state=state)
             return {
-                "final_response": final_resp,
-                "messages": [
-                    AIMessage(
-                        content=response_content.strip(),
-                        additional_kwargs={"structured": final_resp},
-                    )
-                ],
+                "final_response": response_content.strip(),
+                "messages": [AIMessage(content=response_content.strip())]
             }
 
         except Exception as error:
@@ -102,10 +97,6 @@ class GeneralKnowledgeNode:
                 node_name="GeneralKnowledgeNode", start_time=start_time, state=state, error=error
             )
             return {
-                "final_response": final_resp,
-                "messages": [
-                    AIMessage(
-                        content=fallback_response, additional_kwargs={"structured": final_resp}
-                    )
-                ],
+                "final_response": fallback_response,
+                "messages": [AIMessage(content=fallback_response)]
             }

--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -75,11 +75,6 @@ class GeneralKnowledgeNode:
                 messages=formatted_msgs, temperature=0.3
             )
 
-            final_resp = {
-                "الإجابة": response_content.strip(),
-                "المصدر": "general_knowledge",
-            }
-
             emit_telemetry(node_name="GeneralKnowledgeNode", start_time=start_time, state=state)
             return {
                 "final_response": response_content.strip(),
@@ -89,10 +84,6 @@ class GeneralKnowledgeNode:
         except Exception as error:
             logger.error(f"GeneralKnowledgeNode failed: {error}", exc_info=True)
             fallback_response = "عذراً، لم أتمكن من استرجاع هذه المعلومة الآن."
-            final_resp = {
-                "الإجابة": fallback_response,
-                "المصدر": "general_knowledge_fallback",
-            }
             emit_telemetry(
                 node_name="GeneralKnowledgeNode", start_time=start_time, state=state, error=error
             )

--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -78,7 +78,7 @@ class GeneralKnowledgeNode:
             emit_telemetry(node_name="GeneralKnowledgeNode", start_time=start_time, state=state)
             return {
                 "final_response": response_content.strip(),
-                "messages": [AIMessage(content=response_content.strip())]
+                "messages": [AIMessage(content=response_content.strip())],
             }
 
         except Exception as error:
@@ -89,5 +89,5 @@ class GeneralKnowledgeNode:
             )
             return {
                 "final_response": fallback_response,
-                "messages": [AIMessage(content=fallback_response)]
+                "messages": [AIMessage(content=fallback_response)],
             }

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -537,10 +537,6 @@ class ChatFallbackNode:
             )
 
         emit_telemetry(node_name="ChatFallbackNode", start_time=start_time, state=state)
-        final_resp = {
-            "الإجابة": fallback_response,
-            "المصدر": "chat_fallback",
-        }
 
         from langchain_core.messages import AIMessage
 

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -545,13 +545,8 @@ class ChatFallbackNode:
         from langchain_core.messages import AIMessage
 
         return {
-            "final_response": final_resp,
-            # Context blindness fix: We must explicitly inject our final response into state.messages
-            # so that LangGraph's native Postgres checkpointer natively tracks it as AIMessage
-            # without manual extraction from DB for subsequent turns.
-            "messages": [
-                AIMessage(content=fallback_response, additional_kwargs={"structured": final_resp})
-            ],
+            "final_response": fallback_response,
+            "messages": [AIMessage(content=fallback_response)],
         }
 
 

--- a/microservices/orchestrator_service/src/services/overmind/graph/supervisor.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/supervisor.py
@@ -115,7 +115,7 @@ class SupervisorNode:
         history = format_conversation_history(messages)
 
         if not query:
-            return {"intent": "educational", "query": query}
+            return {"intent": "general_knowledge", "query": query}
 
         try:
             result = await asyncio.to_thread(
@@ -136,4 +136,4 @@ class SupervisorNode:
         except Exception as exc:
             logger.debug("Supervisor intent classification failed: %s", exc)
 
-        return {"intent": "educational", "query": query}
+        return {"intent": "general_knowledge", "query": query}


### PR DESCRIPTION
Applied routing and node output fixes as per constraints:
1. `supervisor.py`: Changed BOTH fallback assignments from `educational` to `general_knowledge`.
2. `GeneralKnowledgeNode`: Replaced `return` statement to output raw string `final_response` and plain `AIMessage` without `additional_kwargs`. Fixed `except` block similarly.
3. `ChatFallbackNode`: Replaced `return` statement similarly to use plain `AIMessage` and raw `fallback_response`.
All other files untouched. Validated node logic and confirmed all unit tests pass successfully.

---
*PR created automatically by Jules for task [14054516377154589468](https://jules.google.com/task/14054516377154589468) started by @HOUSSAM16ai*