### PR TITLE
fix: resolve offline WebSocket connection in Cloud IDEs

### DIFF
--- a/frontend/app/hooks/useAgentSocket.js
+++ b/frontend/app/hooks/useAgentSocket.js
@@ -42,6 +42,12 @@ const getWsBase = () => {
          return `${protocol}://${hostname}:8000`;
     }
 
+    // Cloud IDE fallback (e.g. GitHub Codespaces, Gitpod) where port is empty and embedded in hostname
+    if (!port && hostname.includes('-3000.')) {
+        const newHostname = hostname.replace('-3000.', '-8000.');
+        return `${protocol}://${newHostname}`;
+    }
+
     const host = window.location.host;
     return `${protocol}://${host}`;
 };


### PR DESCRIPTION
Fixed an issue where the agent frontend remained "offline" in cloud development environments (like GitHub Codespaces) because the WebSocket connection was failing to resolve correctly. Added logic to infer the backend host directly by swapping `-3000` to `-8000` in the window hostname when ports are implicitly mapped by the cloud IDE.

---
*PR created automatically by Jules for task [8096808657160159115](https://jules.google.com/task/8096808657160159115) started by @HOUSSAM16ai*