### PR TITLE
Fix Supervisor Routing Fallback

### DIFF
--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -490,7 +490,7 @@ class SupervisorNode:
             emit_telemetry(node_name="SupervisorNode", start_time=start_time, state=state)
             return {"intent": "chat", "query": query}
 
-        intent = "educational"
+        intent = "general_knowledge"
         emit_telemetry(node_name="SupervisorNode", start_time=start_time, state=state)
         return {"intent": intent, "query": query}
 


### PR DESCRIPTION
The system was returning a structured JSON response saying "لا توجد تفاصيل متاحة." for follow up factual questions like "ما هي عاصمتها؟" because it was dropping them to an `"educational"` fallback intent. The intent routing has been corrected to route unclassified short factual queries safely to the `GeneralKnowledgeNode` free-response pipeline instead.

---
*PR created automatically by Jules for task [10726173449126706592](https://jules.google.com/task/10726173449126706592) started by @HOUSSAM16ai*