### PR TITLE
Fix build_conversation_context for Mixed Message Types

### DIFF
--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -275,12 +275,29 @@ def build_conversation_context(
 
     recent_messages: list[str] = []
     last_signature: tuple[str, str] | None = None
+
     for msg in messages[-max_turns:]:
-        content = getattr(msg, "content", None)
+        if isinstance(msg, dict):
+            content = msg.get("content")
+            role = msg.get("role") or msg.get("type") or "user"
+        else:
+            content = getattr(msg, "content", None)
+            role = getattr(msg, "type", getattr(msg, "role", "user"))
+
         if not isinstance(content, str) or not content.strip():
             continue
-        role = getattr(msg, "type", getattr(msg, "role", "user"))
-        prefix = "User: " if role in ("human", "user") else "Assistant: "
+
+        role = str(role).lower().strip()
+
+        if role in {"assistant", "ai"}:
+            prefix = "Assistant: "
+        elif role in {"human", "user"}:
+            prefix = "User: "
+        elif role == "system":
+            prefix = "System: "
+        else:
+            prefix = "User: "
+
         text = content.strip()
         if include_json_extraction and text.startswith("{") and role in ("ai", "assistant"):
             try:


### PR DESCRIPTION
Modified `build_conversation_context` in `microservices/orchestrator_service/src/services/overmind/graph/main.py` to extract `role` and `content` seamlessly regardless of whether the message is a `dict` (e.g., in REST/HTTP payloads) or a standard LangChain `BaseMessage` object instance. This prevents silent skipping of dictionary messages during context building, ensuring history correctly passes into the DSPy/LangGraph contexts. Tests were verified to ensure routing and history rewriting functions as expected.

---
*PR created automatically by Jules for task [3165876571129092819](https://jules.google.com/task/3165876571129092819) started by @HOUSSAM16ai*