### PR TITLE
Fix context amnesia across API and Overmind orchestration

### DIFF
--- a/app/api/routers/admin.py
+++ b/app/api/routers/admin.py
@@ -129,7 +129,7 @@ def _merge_history_with_client_context(
     if not client_context:
         return persisted_history
     if not persisted_history:
-        return client_context
+        return []
 
     merged_history = list(persisted_history)
     for message in client_context:

--- a/app/api/routers/customer_chat.py
+++ b/app/api/routers/customer_chat.py
@@ -150,7 +150,7 @@ def _merge_history_with_client_context(
     if not client_context:
         return persisted_history
     if not persisted_history:
-        return client_context
+        return []
 
     merged_history = list(persisted_history)
     for message in client_context:

--- a/frontend/app/hooks/useRealtimeConnection.js
+++ b/frontend/app/hooks/useRealtimeConnection.js
@@ -46,7 +46,9 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
     setState("connecting");
 
     try {
-        const ws = new WebSocket(wsUrl, ["jwt", token]);
+        const wsUrlObj = new URL(wsUrl);
+        wsUrlObj.searchParams.append("token", token);
+        const ws = new WebSocket(wsUrlObj.toString(), ["jwt", token]);
         wsRef.current = ws;
 
         ws.onopen = () => {

--- a/microservices/orchestrator_service/src/core/gateway/simple_client.py
+++ b/microservices/orchestrator_service/src/core/gateway/simple_client.py
@@ -72,8 +72,8 @@ class OpenRouterClient(LLMClient):
         """توليد بصمة ثابتة لسياق المحادثة."""
         if not messages:
             return "empty"
-        # We hash everything *except* the last message (which is the new prompt)
-        context_msgs = messages[:-1] if len(messages) > 1 else []
+        # We hash everything
+        context_msgs = messages
         context_str = json.dumps(context_msgs, sort_keys=True)
         return hashlib.sha256(context_str.encode()).hexdigest()
 

--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -26,7 +26,15 @@ class GeneralKnowledgeNode:
             query = messages[-1].content
         query = str(query or "").strip()
 
-        history = format_conversation_history(messages[:-1] if messages else [])
+        # Exclude the very last message from the HISTORY block if it's the current user query,
+        # to prevent prompt contamination. State is NOT modified.
+        prompt_messages = messages
+        if messages:
+            last_msg = messages[-1]
+            role = last_msg.get("role") or last_msg.get("type") if isinstance(last_msg, dict) else getattr(last_msg, "type", getattr(last_msg, "role", ""))
+            if role in ("human", "user"):
+                prompt_messages = messages[:-1]
+        history = format_conversation_history(prompt_messages)
 
         if not history.strip():
             print("🚨 FAILURE: EMPTY HISTORY")

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -363,7 +363,7 @@ def _extract_recent_entity_anchor(messages: list[object]) -> str | None:
         "عاصمتها",
         "عاصمته",
     }
-    for message in reversed(messages[:-1]):
+    for message in reversed(messages):
         role = get_message_role(message)
         if role != "user":
             continue
@@ -557,7 +557,7 @@ class SupervisorNode:
         print("NODE:", "SupervisorNode")
         print("QUERY:", query)
         messages = state.get("messages", [])
-        formatted_history = format_conversation_history(messages[:-1])
+        formatted_history = format_conversation_history(messages)
         resolved_q = _resolve_query_from_history(query=query, messages=messages)
         if resolved_q != query:
             print("RESOLVED QUERY:", resolved_q)
@@ -675,7 +675,7 @@ class ChatFallbackNode:
             query = messages[-1].content
         query = str(query or "").strip()
 
-        history = format_conversation_history(messages[:-1] if messages else [])
+        history = format_conversation_history(messages)
 
         if not history.strip():
             print("🚨 FAILURE: EMPTY HISTORY")
@@ -789,17 +789,21 @@ class QueryRewriterNode:
             return False
         return "User:" not in candidate and "Assistant:" not in candidate
 
-    def _extract_latest_reference_snippet(self, messages: list[object]) -> str:
+    def _extract_latest_reference_snippet(self, messages: list[object], current_query: str) -> str:
         """يستخرج آخر رسالة مرجعية غير فارغة لتثبيت الإحالة الضميرية عند الفشل."""
         if not messages:
             return ""
 
+        current_query_normalized = current_query.strip()
+
         for message in reversed(
-            messages[:-1]
-        ):  # exclude the last message which is the current query
+            messages
+        ):  # include all messages to avoid context amnesia
             role = get_message_role(message)
             content = get_message_content(message)
             if role not in {"user", "assistant"}:
+                continue
+            if isinstance(content, str) and content.strip() == current_query_normalized:
                 continue
 
             # Try extracting from structured kwargs first
@@ -835,7 +839,7 @@ class QueryRewriterNode:
 
     def _build_contextual_fallback_rewrite(self, query: str, messages: list[object]) -> str:
         """يبني إعادة صياغة حتمية عند تعذر إعادة الصياغة الذكية لمنع عمى السياق."""
-        reference = self._extract_latest_reference_snippet(messages=messages)
+        reference = self._extract_latest_reference_snippet(messages=messages, current_query=query)
         if not reference:
             return query
 

--- a/microservices/orchestrator_service/src/services/overmind/graph/search.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/search.py
@@ -97,7 +97,14 @@ class QueryAnalyzerNode:
 
         from .main import format_conversation_history
 
-        formatted_history = format_conversation_history(messages[:-1])
+        # Exclude the current user query from history ONLY for prompt formatting
+        prompt_messages = messages
+        if messages:
+            last_msg = messages[-1]
+            role = last_msg.get("role") or last_msg.get("type") if isinstance(last_msg, dict) else getattr(last_msg, "type", getattr(last_msg, "role", ""))
+            if role in ("human", "user"):
+                prompt_messages = messages[:-1]
+        formatted_history = format_conversation_history(prompt_messages)
 
         try:
 


### PR DESCRIPTION
Fixes severe context amnesia issues where each query in a conversation felt isolated (restarting from zero). Specifically, Next.js header strip bug on the websocket was patched; leaked histories in empty contexts are handled correctly; and prompt contamination where current queries overlap with historical references was fixed while ensuring the raw LangGraph state correctly maintained all elements intact.

---
*PR created automatically by Jules for task [901003300300390697](https://jules.google.com/task/901003300300390697) started by @HOUSSAM16ai*