### PR TITLE
Diagnostic Report: Missing session_id on frontend WebSockets

### DIFF
--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -31,7 +31,11 @@ class GeneralKnowledgeNode:
         prompt_messages = messages
         if messages:
             last_msg = messages[-1]
-            role = last_msg.get("role") or last_msg.get("type") if isinstance(last_msg, dict) else getattr(last_msg, "type", getattr(last_msg, "role", ""))
+            role = (
+                last_msg.get("role") or last_msg.get("type")
+                if isinstance(last_msg, dict)
+                else getattr(last_msg, "type", getattr(last_msg, "role", ""))
+            )
             if role in ("human", "user"):
                 prompt_messages = messages[:-1]
         history = format_conversation_history(prompt_messages)

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -796,9 +796,7 @@ class QueryRewriterNode:
 
         current_query_normalized = current_query.strip()
 
-        for message in reversed(
-            messages
-        ):  # include all messages to avoid context amnesia
+        for message in reversed(messages):  # include all messages to avoid context amnesia
             role = get_message_role(message)
             content = get_message_content(message)
             if role not in {"user", "assistant"}:

--- a/microservices/orchestrator_service/src/services/overmind/graph/search.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/search.py
@@ -101,7 +101,11 @@ class QueryAnalyzerNode:
         prompt_messages = messages
         if messages:
             last_msg = messages[-1]
-            role = last_msg.get("role") or last_msg.get("type") if isinstance(last_msg, dict) else getattr(last_msg, "type", getattr(last_msg, "role", ""))
+            role = (
+                last_msg.get("role") or last_msg.get("type")
+                if isinstance(last_msg, dict)
+                else getattr(last_msg, "type", getattr(last_msg, "role", ""))
+            )
             if role in ("human", "user"):
                 prompt_messages = messages[:-1]
         formatted_history = format_conversation_history(prompt_messages)


### PR DESCRIPTION
## Diagnostic Proof: Missing `session_id`

This submission provides the read-only diagnostic proof answering why `session_id` is missing in the WebSocket routing pipeline.

1. **Where is `session_id` expected?**
   - In `microservices/api_gateway/main.py` (`_extract_session_id`), the API Gateway attempts to parse it from the URL query parameters (`?session_id=...`) or HTTP headers (`x-session-id`). If neither is present, it logs `session_id source=absent` and falls back to generating a random UUID.

2. **Which component fails to provide it?**
   - The frontend's WebSocket clients:
     - `frontend/app/hooks/useRealtimeConnection.js` (React hook)
     - `frontend/public/js/legacy-app.jsx` (Legacy React app)
   - Both components construct the WebSocket URL and append only the `?token=` parameter, completely omitting `session_id`.

3. **Is the frontend sending it consistently across messages?**
   - No, it is never sent. The frontend does not persist or transmit a `session_id` identity across the WebSocket handshake.

Because the `session_id` is never passed by the client, the API Gateway's sticky routing generates a new, random identity on every connection, confirming the root cause is client-side identity loss.

---
*PR created automatically by Jules for task [13431632403076865628](https://jules.google.com/task/13431632403076865628) started by @HOUSSAM16ai*