### PR TITLE
Add end-to-end WebSocket identity diagnostics for session/thread tracing

### DIFF
--- a/microservices/api_gateway/main.py
+++ b/microservices/api_gateway/main.py
@@ -80,6 +80,25 @@ def _extract_session_id(websocket: WebSocket) -> str | None:
     return None
 
 
+def _emit_gateway_identity_log(route_name: str, websocket: WebSocket) -> None:
+    """يسجل تشخيص الهوية في البوابة لربط session_id مع مسار WS ومضيف التنفيذ."""
+    session_id = _extract_session_id(websocket)
+    thread_id = websocket.query_params.get("thread_id") or websocket.headers.get("x-thread-id")
+    conversation_id = (
+        websocket.query_params.get("conversation_id") or websocket.headers.get("x-conversation-id")
+    )
+    hostname = os.getenv("HOSTNAME", "").strip() or "unknown"
+    logger.info(
+        "[GATEWAY_IDENTITY_DIAGNOSTIC] route=%s conversation_id=%s thread_id=%s session_id=%s "
+        "hostname=%s",
+        route_name,
+        conversation_id or "missing",
+        thread_id or "missing",
+        session_id or "missing",
+        hostname,
+    )
+
+
 def _build_routing_identity(route_id: str, upstream_path: str, session_id: str | None) -> str:
     """Builds a routing identity prioritizing session_id to maintain sticky routing."""
     if session_id:
@@ -277,6 +296,7 @@ async def chat_ws_proxy(websocket: WebSocket):
         logger.info(
             f"Chat WebSocket route_id={route_id} legacy_flag=false traceparent={headers.get('traceparent', 'unknown')}"
         )
+        _emit_gateway_identity_log("gateway_ws_customer", websocket)
         session_id = _extract_session_id(websocket)
         logger.info(
             f"session_id presence: {'present' if session_id else 'absent'} in chat_ws_proxy"
@@ -312,6 +332,7 @@ async def admin_chat_ws_proxy(websocket: WebSocket):
         logger.info(
             f"Chat WebSocket route_id={route_id} legacy_flag=false traceparent={headers.get('traceparent', 'unknown')}"
         )
+        _emit_gateway_identity_log("gateway_ws_admin", websocket)
         session_id = _extract_session_id(websocket)
         logger.info(
             f"session_id presence: {'present' if session_id else 'absent'} in admin_chat_ws_proxy"

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -98,6 +98,44 @@ class StreamFrame(BaseModel):
     payload: dict[str, object] = Field(default_factory=dict)
 
 
+def _resolve_session_id_from_incoming(incoming: dict[str, object]) -> str | None:
+    """يستخرج session_id بشكل صريح من الحمولة أو من context لدعم تشخيص ثبات الهوية."""
+    direct_session = incoming.get("session_id")
+    if isinstance(direct_session, str) and direct_session.strip():
+        return direct_session.strip()
+
+    context_payload = incoming.get("context")
+    if isinstance(context_payload, dict):
+        context_session = context_payload.get("session_id")
+        if isinstance(context_session, str) and context_session.strip():
+            return context_session.strip()
+    return None
+
+
+def _emit_identity_diagnostic_log(
+    *,
+    route_name: str,
+    conversation_id: int | str,
+    thread_id: str | None,
+    session_id: str | None,
+) -> None:
+    """يسجل بصمة الهوية لكل رسالة مع معلومات الحاوية لتأكيد تغيّر المسار أو ثباته."""
+    orchestrator_instance_id = os.getenv("ORCHESTRATOR_INSTANCE_ID", "").strip() or "unset"
+    hostname = os.getenv("HOSTNAME", "").strip() or "unknown"
+    container_id = hostname
+    logger.info(
+        "[IDENTITY_DIAGNOSTIC] route=%s conversation_id=%s thread_id=%s session_id=%s "
+        "orchestrator_instance_id=%s hostname=%s container_id=%s",
+        route_name,
+        conversation_id,
+        thread_id or "missing",
+        session_id or "missing",
+        orchestrator_instance_id,
+        hostname,
+        container_id,
+    )
+
+
 def _compress_text_for_context(content: str) -> str:
     """يضغط النص للسياق عبر إزالة الضوضاء وتوحيد المسافات وتقليص الطول."""
     collapsed = " ".join(content.replace("\x00", "").split())
@@ -2177,6 +2215,12 @@ async def chat_ws_stategraph(websocket: WebSocket) -> None:
             context["user_id"] = user_id
             if sticky_thread_id:
                 context["thread_id"] = sticky_thread_id
+            _emit_identity_diagnostic_log(
+                route_name="orchestrator_ws_customer",
+                conversation_id=conversation_id,
+                thread_id=sticky_thread_id,
+                session_id=_resolve_session_id_from_incoming(incoming),
+            )
 
             try:
                 client_context = _extract_client_context_messages(incoming)
@@ -2326,6 +2370,12 @@ async def admin_chat_ws_stategraph(websocket: WebSocket) -> None:
             context["user_id"] = user_id
             if sticky_thread_id:
                 context["thread_id"] = sticky_thread_id
+            _emit_identity_diagnostic_log(
+                route_name="orchestrator_ws_admin",
+                conversation_id=conversation_id,
+                thread_id=sticky_thread_id,
+                session_id=_resolve_session_id_from_incoming(incoming),
+            )
 
             try:
                 client_context = _extract_client_context_messages(incoming)


### PR DESCRIPTION
### Motivation
- Provide deterministic logs to verify whether context loss is caused by unstable `session_id`/`thread_id` or by requests being routed to different orchestrator instances (server hopping).

### Description
- Added gateway-side diagnostic helper `_emit_gateway_identity_log` and invoked it in the customer/admin WebSocket entry points to emit `route`, `conversation_id`, `thread_id`, `session_id`, and `hostname`.
- Added orchestrator-side helpers `_resolve_session_id_from_incoming` and `_emit_identity_diagnostic_log` and wired them into both customer and admin WebSocket message loops to emit `conversation_id`, `thread_id`, `session_id`, `orchestrator_instance_id`, `hostname`, and `container_id` per incoming message.
- The diagnostics are lightweight info logs and are intended to support the 3-step verification plan (trace identity per message, detect changing orchestrator instance, and validate frontend WS payload) without changing runtime behavior.

### Testing
- Ran `ruff check .` and it passed successfully.
- Ran `python -m py_compile microservices/api_gateway/main.py microservices/orchestrator_service/src/api/routes.py` and it passed for the modified files.
- Ran `mypy app/ microservices/` which failed due to many pre-existing repository type-check issues unrelated to this change (no new mypy errors introduced by these edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5812b0bc832cbcd68184f000888c)