### PR TITLE
Enforce LangGraph SSOT Memory

### DIFF
--- a/microservices/orchestrator_service/main.py
+++ b/microservices/orchestrator_service/main.py
@@ -87,11 +87,13 @@ async def lifespan(app: FastAPI):
         from microservices.orchestrator_service.src.services.overmind.graph.main import (
             create_unified_graph,
         )
+        from langgraph.checkpoint.memory import MemorySaver
 
+        memory = MemorySaver()
         app.state.admin_app = admin_graph.compile(
-            checkpointer=get_checkpointer(), interrupt_before=[]
+            checkpointer=get_checkpointer() or memory, interrupt_before=[]
         )
-        app.state.app_graph = create_unified_graph(admin_app=app.state.admin_app)
+        app.state.app_graph = create_unified_graph(admin_app=app.state.admin_app, checkpointer=get_checkpointer() or memory)
 
         # ═══ PHASE 3: WARMUP — PROVE IT WORKS ══════════════════════
         result = await app.state.admin_app.ainvoke(

--- a/microservices/orchestrator_service/main.py
+++ b/microservices/orchestrator_service/main.py
@@ -83,11 +83,12 @@ async def lifespan(app: FastAPI):
 
     # ═══ PHASE 2: GRAPHS AFTER TOOLS ═══════════════════════════
     try:
+        from langgraph.checkpoint.memory import MemorySaver
+
         from microservices.orchestrator_service.src.services.overmind.graph.admin import admin_graph
         from microservices.orchestrator_service.src.services.overmind.graph.main import (
             create_unified_graph,
         )
-        from langgraph.checkpoint.memory import MemorySaver
 
         memory = MemorySaver()
         app.state.admin_app = admin_graph.compile(

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -1460,7 +1460,7 @@ async def _stream_chat_langgraph(
         try:
             _graph = app_graph or getattr(websocket.app.state, "app_graph", None)
             if not _graph:
-                _graph = create_unified_graph()
+                _graph = websocket.app.state.app_graph
             incoming_messages = safe_history
             await _append_telemetry_line(
                 f"[TELEMETRY] INGRESS | "
@@ -1469,26 +1469,11 @@ async def _stream_chat_langgraph(
                 f"messages_in_request={len(incoming_messages)}"
             )
             config = {"configurable": {"thread_id": thread_id}}
-            checkpointer_available, checkpoint_has_state = await _detect_checkpoint_state(thread_id)
-            logger.warning(f"HISTORY SIZE: {len(history_messages) if history_messages else 0}")
-            langchain_msgs = _build_graph_messages_graph(
-                objective=prepared_objective,
-                history_messages=safe_history,
-                checkpointer_available=checkpointer_available,
-                checkpoint_has_state=checkpoint_has_state,
-            )
-            logger.info(
-                "[CONTEXT_MODE] channel=websocket conv_id=%s thread_id=%s checkpointer_available=%s checkpoint_has_state=%s seeded_history=%s",
-                conversation_id,
-                thread_id,
-                checkpointer_available,
-                checkpoint_has_state,
-                max(0, len(langchain_msgs) - 1),
-            )
 
             inputs: dict[str, object] = {
-                "query": prepared_objective,
-                "messages": langchain_msgs,
+                "messages": [
+                    {"role": "user", "content": prepared_objective}
+                ]
             }
             inputs = _merge_admin_inputs(inputs, admin_payload if chat_scope == "admin" else None)
             state_dict = inputs
@@ -1581,7 +1566,8 @@ async def _stream_chat_langgraph(
 
             await _safe_put({"type": "__DONE__", "result": final_res})
         except Exception as e:
-            await _safe_put({"type": "__ERROR__", "error": str(e)})
+            import traceback
+            await _safe_put({"type": "__ERROR__", "error": str(e), "traceback": traceback.format_exc()})
 
     task = asyncio.create_task(_runner())
     active_background_tasks.add(task)
@@ -1781,25 +1767,10 @@ async def _run_chat_langgraph(
         else "conversation_fallback",
         str(conversation_id),
     )
-    checkpointer_available, checkpoint_has_state = await _detect_checkpoint_state(thread_id)
-    langchain_msgs = _build_graph_messages_graph(
-        objective=prepared_objective,
-        history_messages=history_messages,
-        checkpointer_available=checkpointer_available,
-        checkpoint_has_state=checkpoint_has_state,
-    )
-    logger.info(
-        "[CONTEXT_MODE] channel=http conv_id=%s thread_id=%s checkpointer_available=%s checkpoint_has_state=%s seeded_history=%s",
-        conversation_id,
-        thread_id,
-        checkpointer_available,
-        checkpoint_has_state,
-        max(0, len(langchain_msgs) - 1),
-    )
-
     inputs: dict[str, object] = {
-        "query": prepared_objective,
-        "messages": langchain_msgs,
+        "messages": [
+            {"role": "user", "content": prepared_objective}
+        ]
     }
     inputs = _merge_admin_inputs(inputs, admin_payload)
 
@@ -2500,8 +2471,9 @@ async def chat_with_agent_endpoint(
 
                 admin_inputs = _merge_admin_inputs(
                     {
-                        "query": prepared_objective,
-                        "messages": langchain_msgs,
+                        "messages": [
+                            {"role": "user", "content": prepared_objective}
+                        ]
                     },
                     admin_payload,
                 )

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -2444,7 +2444,6 @@ async def chat_with_agent_endpoint(
                     admin_payload = request.context
                 else:
                     admin_payload = {"is_admin": True, "role": "admin"}
-                langchain_msgs: list[HumanMessage | AIMessage] = []
 
                 # Augment the objective for explicit context before sending to LangGraph
                 prepared_objective = _augment_ambiguous_objective(
@@ -2464,11 +2463,6 @@ async def chat_with_agent_endpoint(
                 _checkpointer_available, _checkpoint_has_state = await _detect_checkpoint_state(
                     thread_id
                 )
-                langchain_msgs = _build_graph_messages_manual(
-                    objective=prepared_objective,
-                    history_messages=request.history_messages,
-                )
-
                 admin_inputs = _merge_admin_inputs(
                     {
                         "messages": [

--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -26,8 +26,9 @@ class GeneralKnowledgeNode:
             query = messages[-1].content
         query = str(query or "").strip()
 
-        # Exclude the very last message from the HISTORY block if it's the current user query,
-        # to prevent prompt contamination. State is NOT modified.
+        # Memory is accurate and automatically loaded by Checkpointer.
+        # We no longer amputate the prompt_messages via slicing.
+        # However, to avoid prompt contamination, we exclude the current user query if it's the last message
         prompt_messages = messages
         if messages:
             last_msg = messages[-1]

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -1044,7 +1044,7 @@ def check_quality(state: AgentState) -> str:
     return "pass"
 
 
-def create_unified_graph(admin_app=None):
+def create_unified_graph(admin_app=None, checkpointer=None):
     _configure_dspy()
     graph = StateGraph(AgentState)
 
@@ -1058,8 +1058,9 @@ def create_unified_graph(admin_app=None):
 
     from .admin import AdminAgentNode
     from .general_knowledge import GeneralKnowledgeNode
+    from .supervisor import SupervisorNode as ImportedSupervisorNode
 
-    graph.add_node("supervisor", SupervisorNode())
+    graph.add_node("supervisor", ImportedSupervisorNode())
     graph.add_node("query_rewriter", QueryRewriterNode())
     graph.add_node("query_analyzer", query_analyzer_node())
     graph.add_node("retriever", internal_retriever_node())
@@ -1109,13 +1110,17 @@ def create_unified_graph(admin_app=None):
 
     graph.set_entry_point("supervisor")
 
+    if checkpointer:
+        logger.info("[CHECKPOINTER] LangGraph compiled with provided checkpointer.")
+        return graph.compile(checkpointer=checkpointer)
+
     # Use global postgres checkpointer if available, otherwise compile without it
     from microservices.orchestrator_service.src.core.database import get_checkpointer
 
-    checkpointer = get_checkpointer()
-    if checkpointer:
+    db_checkpointer = get_checkpointer()
+    if db_checkpointer:
         logger.info("[CHECKPOINTER] LangGraph compiled with Postgres checkpointer.")
-        return graph.compile(checkpointer=checkpointer)
+        return graph.compile(checkpointer=db_checkpointer)
 
     logger.warning(
         "[CHECKPOINTER] LangGraph compiled without checkpointer; state continuity relies on injected history."


### PR DESCRIPTION
This patch resolves the State Fragmentation, Context Blindness, and Memory Loss issues identified by enforcing LangGraph's Checkpointer (`MemorySaver`) as the single source of truth. The patch strictly uses delta inputs and maintains the db only as an archive while preserving proper admin inputs.

---
*PR created automatically by Jules for task [1192651403152196405](https://jules.google.com/task/1192651403152196405) started by @HOUSSAM16ai*