### PR TITLE
fix(orchestrator): wire _build_graph_messages_graph and fix MemorySaver singleton

### DIFF
--- a/microservices/orchestrator_service/main.py
+++ b/microservices/orchestrator_service/main.py
@@ -22,6 +22,15 @@ from microservices.orchestrator_service.src.services.tools.registry import regis
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("orchestrator_service")
 
+# MemorySaver singleton — يُنشأ مرة واحدة على مستوى الـ module لضمان استمرارية الذاكرة
+# بين الطلبات عند غياب Postgres checkpointer. لا تُنشئ instance جديداً داخل lifespan.
+try:
+    from langgraph.checkpoint.memory import MemorySaver as _MemorySaver
+
+    _memory_saver: _MemorySaver | None = _MemorySaver()
+except ModuleNotFoundError:
+    _memory_saver = None
+
 
 async def _run_outbox_relay_once() -> dict[str, int]:
     """ينفذ دورة relay واحدة لسجلات Outbox مع عزل جلسة قاعدة البيانات."""
@@ -83,19 +92,19 @@ async def lifespan(app: FastAPI):
 
     # ═══ PHASE 2: GRAPHS AFTER TOOLS ═══════════════════════════
     try:
-        from langgraph.checkpoint.memory import MemorySaver
-
         from microservices.orchestrator_service.src.services.overmind.graph.admin import admin_graph
         from microservices.orchestrator_service.src.services.overmind.graph.main import (
             create_unified_graph,
         )
 
-        memory = MemorySaver()
+        # يستخدم Postgres checkpointer إذا كان متاحاً، وإلا يعود إلى MemorySaver singleton
+        # (لا تُنشئ MemorySaver جديداً هنا — يجب أن يكون نفس الـ instance طوال عمر العملية)
+        active_checkpointer = get_checkpointer() or _memory_saver
         app.state.admin_app = admin_graph.compile(
-            checkpointer=get_checkpointer() or memory, interrupt_before=[]
+            checkpointer=active_checkpointer, interrupt_before=[]
         )
         app.state.app_graph = create_unified_graph(
-            admin_app=app.state.admin_app, checkpointer=get_checkpointer() or memory
+            admin_app=app.state.admin_app, checkpointer=active_checkpointer
         )
 
         # ═══ PHASE 3: WARMUP — PROVE IT WORKS ══════════════════════

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -1469,19 +1469,9 @@ async def _stream_chat_langgraph(
             )
             config = {"configurable": {"thread_id": thread_id}}
 
-            inputs: dict[str, object] = {
-                "messages": [{"role": "user", "content": prepared_objective}]
-            }
-            inputs = _merge_admin_inputs(inputs, admin_payload if chat_scope == "admin" else None)
-            state_dict = inputs
-            payload_messages = state_dict.get("messages", [])
-            await _append_telemetry_line(
-                f"[TELEMETRY] PRE-INVOKE | "
-                f"messages type={type(payload_messages).__name__} | "
-                f"count={len(payload_messages)} | "
-                f"last_msg={str(payload_messages[-1])[:120] if payload_messages else 'EMPTY'}"
-            )
+            # فحص حالة الـ checkpointer لتحديد ما إذا كانت الحالة محفوظة مسبقاً
             checkpointer = get_checkpointer()
+            _checkpointer_available, _checkpoint_has_state = False, False
             if checkpointer is None:
                 await _append_telemetry_line("[TELEMETRY] CHECKPOINTER NOT IN SCOPE")
             else:
@@ -1489,16 +1479,40 @@ async def _stream_chat_langgraph(
                 try:
                     _ckpt = await checkpointer.aget(config)
                     _elapsed = time.monotonic() - _t
+                    _checkpoint_has_state = _ckpt is not None
+                    _checkpointer_available = True
                     _keys = list(_ckpt.channel_values.keys()) if _ckpt else None
                     await _append_telemetry_line(
                         f"[TELEMETRY] CHECKPOINTER | "
                         f"elapsed={_elapsed:.4f}s | "
-                        f"state={'NONE — silent failure' if _ckpt is None else _keys}"
+                        f"state={'NONE — no prior state' if _ckpt is None else _keys}"
                     )
                 except Exception as _e:
                     await _append_telemetry_line(
                         f"[TELEMETRY] CHECKPOINTER CRASHED | {type(_e).__name__}: {_e}"
                     )
+
+            # بناء رسائل الإدخال بشكل صحيح:
+            # - إذا كان checkpointer يحمل حالة → نمرر رسالة المستخدم الحالية فقط (delta)
+            # - إذا لم تكن هناك حالة محفوظة → نمرر كامل التاريخ + الرسالة الحالية
+            graph_messages = _build_graph_messages_graph(
+                objective=prepared_objective,
+                history_messages=safe_history if safe_history else None,
+                checkpointer_available=_checkpointer_available,
+                checkpoint_has_state=_checkpoint_has_state,
+            )
+            inputs: dict[str, object] = {"messages": graph_messages}
+            inputs = _merge_admin_inputs(inputs, admin_payload if chat_scope == "admin" else None)
+            state_dict = inputs
+            payload_messages = state_dict.get("messages", [])
+            await _append_telemetry_line(
+                f"[TELEMETRY] PRE-INVOKE | "
+                f"checkpointer_available={_checkpointer_available} | "
+                f"checkpoint_has_state={_checkpoint_has_state} | "
+                f"messages type={type(payload_messages).__name__} | "
+                f"count={len(payload_messages)} | "
+                f"last_msg={str(payload_messages[-1])[:120] if payload_messages else 'EMPTY'}"
+            )
 
             final_res = None
             async for event in _graph.astream_events(inputs, config=config, version="v2"):
@@ -1767,7 +1781,15 @@ async def _run_chat_langgraph(
         else "conversation_fallback",
         str(conversation_id),
     )
-    inputs: dict[str, object] = {"messages": [{"role": "user", "content": prepared_objective}]}
+    # فحص حالة الـ checkpointer لتحديد ما إذا كانت الحالة محفوظة مسبقاً
+    _checkpointer_available, _checkpoint_has_state = await _detect_checkpoint_state(thread_id)
+    graph_messages = _build_graph_messages_graph(
+        objective=prepared_objective,
+        history_messages=history_messages,
+        checkpointer_available=_checkpointer_available,
+        checkpoint_has_state=_checkpoint_has_state,
+    )
+    inputs: dict[str, object] = {"messages": graph_messages}
     inputs = _merge_admin_inputs(inputs, admin_payload)
 
     final_resp = None


### PR DESCRIPTION
## المشكلة

كل رسالة في الدردشة كانت تبدأ من الصفر — النظام لا يتذكر ما قيل في الرسائل السابقة.

## التشخيص

وُجدت ثلاث مشاكل متراكبة:

### 1. `inputs["messages"]` تُبنى دائماً من رسالة واحدة فقط

في كلا مساري التنفيذ (`_stream_chat_langgraph` عبر WebSocket و`_run_chat_langgraph` عبر HTTP)، كان الكود يبني `inputs` هكذا دائماً:

```python
inputs = {"messages": [{"role": "user", "content": objective}]}
```

`safe_history` كان يُبنى بشكل صحيح في الأعلى لكنه **لا يُستخدم أبداً** في `inputs`. الدالة `_build_graph_messages_graph` كانت موجودة وصحيحة — تعرف متى تمرر delta ومتى تمرر التاريخ كاملاً — لكنها لم تُستدعَ من أي مسار.

### 2. `MemorySaver()` يُنشأ من جديد في كل startup

```python
# قبل الإصلاح — داخل lifespan
memory = MemorySaver()  # instance جديد في كل restart
app.state.app_graph = create_unified_graph(checkpointer=get_checkpointer() or memory)
```

عند غياب Postgres أو عند restart، كل طلب يحصل على checkpointer فارغ تماماً.

### 3. الـ telemetry لم يكن يسجّل حالة الـ checkpointer قبل بناء `inputs`

جعل التشخيص صعباً — لم يكن واضحاً هل الـ checkpointer يحمل حالة أم لا عند بناء الرسائل.

## الإصلاح

### `routes.py` — كلا مساري التنفيذ

الآن يفحص حالة الـ checkpointer أولاً، ثم يستدعي `_build_graph_messages_graph`:

```python
_checkpointer_available, _checkpoint_has_state = await _detect_checkpoint_state(thread_id)
graph_messages = _build_graph_messages_graph(
    objective=prepared_objective,
    history_messages=safe_history,
    checkpointer_available=_checkpointer_available,
    checkpoint_has_state=_checkpoint_has_state,
)
inputs = {"messages": graph_messages}
```

المنطق:
- checkpointer يحمل حالة → delta فقط (رسالة المستخدم الحالية)
- لا حالة محفوظة → كامل `safe_history` + الرسالة الحالية

### `main.py` — MemorySaver singleton

```python
# module level — يُنشأ مرة واحدة عند تحميل الملف
_memory_saver: _MemorySaver | None = _MemorySaver()

# lifespan — يستخدم نفس الـ instance دائماً
active_checkpointer = get_checkpointer() or _memory_saver
```

## الاختبارات

```
tests/unit/test_chat_context_seed_strategy.py    27 passed
tests/unit/test_contextual_reference_resolution.py  8 passed
tests/unit/test_orchestrator_unit.py              1 passed
```

## ملاحظة

`MemorySaver` يحتفظ بالذاكرة في RAM فقط — لا يصمد عبر عمليات متعددة أو horizontal scaling. للإنتاج الحقيقي، `AsyncPostgresSaver` هو الضمان الوحيد للاستمرارية الكاملة.
