### PR TITLE
Fix WebSocket session persistence by passing `session_id` in URL

### DIFF
--- a/frontend/app/hooks/useRealtimeConnection.js
+++ b/frontend/app/hooks/useRealtimeConnection.js
@@ -48,6 +48,7 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
     try {
         const wsUrlObj = new URL(wsUrl);
         wsUrlObj.searchParams.append("token", token);
+        wsUrlObj.searchParams.append("session_id", connectionIdRef.current);
         const ws = new WebSocket(wsUrlObj.toString(), ["jwt", token]);
         wsRef.current = ws;
 


### PR DESCRIPTION
The chat application was dropping context on every new WebSocket connection because it lacked a stable identifier. This patch ensures the `session_id` is explicitly passed in the URL parameters so the gateway properly pins the user to their active orchestrator session.

---
*PR created automatically by Jules for task [12781979414137004311](https://jules.google.com/task/12781979414137004311) started by @HOUSSAM16ai*