### PR TITLE
Fix Context Amnesia in Chat Conversations

### DIFF
--- a/frontend/app/hooks/useAgentSocket.js
+++ b/frontend/app/hooks/useAgentSocket.js
@@ -49,8 +49,22 @@ const getWsBase = () => {
 const buildWebSocketUrlSafe = (baseUrl, endpoint, token) => {
     try {
         const wsUrl = new URL(endpoint, baseUrl);
-        // Token is passed in header/protocol by useRealtimeConnection.
-        // REMOVED query param appending to prevent "double method" drift.
+        // Use a persistent session ID for the browser session
+        let sessionId = '';
+        if (typeof sessionStorage !== 'undefined') {
+            sessionId = sessionStorage.getItem('agent_session_id');
+            if (!sessionId) {
+                sessionId = typeof crypto !== "undefined" && crypto.randomUUID
+                    ? crypto.randomUUID()
+                    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+                sessionStorage.setItem('agent_session_id', sessionId);
+            }
+        } else {
+            // Fallback for SSR/non-browser
+            sessionId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        }
+
+        wsUrl.searchParams.append("session_id", sessionId);
         return wsUrl.toString();
     } catch (error) {
         errorTracker.reportError(error, { message: 'Invalid WebSocket URL parts' });
@@ -319,10 +333,16 @@ export const useAgentSocket = (endpoint, token, onConversationUpdate) => {
         const clientRequestId = generateId();
         activeRequestIdRef.current = clientRequestId;
 
+        let sessionId = undefined;
+        if (typeof sessionStorage !== 'undefined') {
+            sessionId = sessionStorage.getItem('agent_session_id');
+        }
+
         const payload = {
             question: text,
             client_request_id: clientRequestId,
             client_context_messages: buildClientContextMessages(messages, text),
+            session_id: sessionId,
             ...metadata,
         };
         if (conversationId !== null && conversationId !== undefined) {

--- a/frontend/app/hooks/useRealtimeConnection.js
+++ b/frontend/app/hooks/useRealtimeConnection.js
@@ -48,7 +48,9 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
     try {
         const wsUrlObj = new URL(wsUrl);
         wsUrlObj.searchParams.append("token", token);
-        wsUrlObj.searchParams.append("session_id", connectionIdRef.current);
+        if (!wsUrlObj.searchParams.has("session_id")) {
+            wsUrlObj.searchParams.append("session_id", connectionIdRef.current);
+        }
         const ws = new WebSocket(wsUrlObj.toString(), ["jwt", token]);
         wsRef.current = ws;
 

--- a/microservices/api_gateway/main.py
+++ b/microservices/api_gateway/main.py
@@ -139,7 +139,11 @@ def _resolve_chat_ws_target(route_id: str, upstream_path: str, websocket: WebSoc
         ws_base = _conversation_ws_base_url()
     else:
         ws_base = _to_ws_base_url(target_base)
-    return f"{ws_base}/{upstream_path}"
+
+    target_url = f"{ws_base}/{upstream_path}"
+    if websocket.url.query:
+        target_url = f"{target_url}?{websocket.url.query}"
+    return target_url
 
 
 def _chat_route_uses_conversation() -> bool:

--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -5,7 +5,7 @@ from langchain_core.messages import AIMessage
 from microservices.orchestrator_service.src.core.ai_gateway import get_ai_client
 
 from .main import AgentState
-from .supervisor import format_conversation_history
+from .main import format_conversation_history
 
 logger = logging.getLogger("graph")
 

--- a/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/general_knowledge.py
@@ -4,8 +4,7 @@ from langchain_core.messages import AIMessage
 
 from microservices.orchestrator_service.src.core.ai_gateway import get_ai_client
 
-from .main import AgentState
-from .main import format_conversation_history
+from .main import AgentState, format_conversation_history
 
 logger = logging.getLogger("graph")
 


### PR DESCRIPTION
Fixes the 'every conversation starts from scratch' issue by explicitly passing a stable `session_id` from the Next.js frontend, forwarding it properly via the API Gateway, and maintaining context within the Orchestrator's general knowledge node.

---
*PR created automatically by Jules for task [13775929108971771940](https://jules.google.com/task/13775929108971771940) started by @HOUSSAM16ai*