### PR TITLE
fix: fix context amnesia issue by propagating query payload to state graph inputs

### DIFF
--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -1506,7 +1506,7 @@ async def _stream_chat_langgraph(
                 checkpointer_available=_checkpointer_available,
                 checkpoint_has_state=_checkpoint_has_state,
             )
-            inputs: dict[str, object] = {"messages": graph_messages}
+            inputs: dict[str, object] = {"messages": graph_messages, "query": prepared_objective}
             inputs = _merge_admin_inputs(inputs, admin_payload if chat_scope == "admin" else None)
             state_dict = inputs
             payload_messages = state_dict.get("messages", [])
@@ -1794,7 +1794,7 @@ async def _run_chat_langgraph(
         checkpointer_available=_checkpointer_available,
         checkpoint_has_state=_checkpoint_has_state,
     )
-    inputs: dict[str, object] = {"messages": graph_messages}
+    inputs: dict[str, object] = {"messages": graph_messages, "query": prepared_objective}
     inputs = _merge_admin_inputs(inputs, admin_payload)
 
     final_resp = None

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -1060,9 +1060,8 @@ def create_unified_graph(admin_app=None, checkpointer=None):
 
     from .admin import AdminAgentNode
     from .general_knowledge import GeneralKnowledgeNode
-    from .supervisor import SupervisorNode as ImportedSupervisorNode
 
-    graph.add_node("supervisor", ImportedSupervisorNode())
+    graph.add_node("supervisor", SupervisorNode())
     graph.add_node("query_rewriter", QueryRewriterNode())
     graph.add_node("query_analyzer", query_analyzer_node())
     graph.add_node("retriever", internal_retriever_node())


### PR DESCRIPTION
Fixes the issue where all chat conversations started from zero by correctly injecting the query intent into the LangGraph `inputs` state dict, enabling memory to properly persist and act on history. Also corrects the supervisor node import to use the version which includes memory retention behaviors instead of an older conflicting import.

---
*PR created automatically by Jules for task [577122763671484080](https://jules.google.com/task/577122763671484080) started by @HOUSSAM16ai*