### PR TITLE
fix(ci): resolve Ruff lint and formatting failures

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -32,9 +32,7 @@ def _is_supabase_url(host: str | None, port: int | None) -> bool:
     """Return True for any Supabase connection."""
     if host and "supabase.com" in host:
         return True
-    if port == 6543:
-        return True
-    return False
+    return port == 6543
 
 
 def create_db_engine(settings: BaseServiceSettings) -> AsyncEngine:
@@ -65,7 +63,7 @@ def create_db_engine(settings: BaseServiceSettings) -> AsyncEngine:
 
     is_supabase = _is_supabase_url(url_obj.host, url_obj.port)
 
-    if is_supabase:
+    if is_supabase and url_obj.port == 6543:
         # Rewrite port 6543 (PgBouncer transaction mode) → 5432 (session mode).
         # Port 6543 uses PgBouncer which keeps prepared statement names in its
         # own cache across logical connections. This causes asyncpg to hit
@@ -73,9 +71,8 @@ def create_db_engine(settings: BaseServiceSettings) -> AsyncEngine:
         # because the collision happens at the PgBouncer protocol layer.
         # Port 5432 connects directly to the Postgres session pool on Supabase,
         # which correctly handles statement_cache_size=0.
-        if url_obj.port == 6543:
-            url_obj = url_obj.set(port=5432)
-            logger.info("Rewrote Supabase port 6543 → 5432 (session mode)")
+        url_obj = url_obj.set(port=5432)
+        logger.info("Rewrote Supabase port 6543 → 5432 (session mode)")
 
     url_obj = url_obj.set(query=qs)
     db_url = url_obj.render_as_string(hide_password=False)
@@ -94,7 +91,9 @@ def create_db_engine(settings: BaseServiceSettings) -> AsyncEngine:
         # pooler.supabase.com proxies still share state across connections.
         connect_args["statement_cache_size"] = 0
         connect_args["prepared_statement_cache_size"] = 0
-        logger.info(f"Supabase database (NullPool, no prepared statements, port {url_obj.port}): {settings.SERVICE_NAME}")
+        logger.info(
+            f"Supabase database (NullPool, no prepared statements, port {url_obj.port}): {settings.SERVICE_NAME}"
+        )
         return create_async_engine(
             db_url,
             echo=settings.DEBUG,

--- a/app/core/settings/base.py
+++ b/app/core/settings/base.py
@@ -74,6 +74,7 @@ class BaseServiceSettings(BaseSettings):
     def prefer_app_database_url(cls, values: dict) -> dict:
         """Use APP_DATABASE_URL when set, falling back to DATABASE_URL."""
         import os
+
         app_db = values.get("APP_DATABASE_URL") or os.environ.get("APP_DATABASE_URL")
         if app_db:
             values["DATABASE_URL"] = app_db

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -205,9 +205,7 @@ class OrchestratorClient:
             if history_messages:
                 history_text = self._format_history_for_prompt(history_messages)
                 if history_text:
-                    user_message = (
-                        f"سياق المحادثة السابقة:\n{history_text}\n\nالسؤال الحالي: {sanitized_question}"
-                    )
+                    user_message = f"سياق المحادثة السابقة:\n{history_text}\n\nالسؤال الحالي: {sanitized_question}"
                 else:
                     user_message = sanitized_question
             else:

--- a/app/kernel.py
+++ b/app/kernel.py
@@ -237,6 +237,7 @@ class RealityKernel:
         # Pre-warm LangGraph local engine (catches import errors at startup)
         try:
             from app.services.chat.local_graph import get_local_graph
+
             get_local_graph()
             logger.info("✅ LangGraph local engine initialized")
         except Exception:

--- a/app/services/chat/local_graph.py
+++ b/app/services/chat/local_graph.py
@@ -16,7 +16,6 @@ import logging
 import re
 from typing import TypedDict
 
-from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
 
@@ -51,10 +50,7 @@ _SYSTEM_PROMPTS = {
         "عند وجود ضمائر أو إشارات مرجعية. "
         "لا تُشر إلى تفاصيل داخلية أو بنية النظام."
     ),
-    "chat": (
-        "أنت مساعد ودود للطلاب الجزائريين. "
-        "رد بشكل طبيعي ومختصر باللغة العربية."
-    ),
+    "chat": ("أنت مساعد ودود للطلاب الجزائريين. رد بشكل طبيعي ومختصر باللغة العربية."),
 }
 
 
@@ -119,9 +115,7 @@ async def _chat_node(state: LocalChatState) -> dict:
 
     history_text = _format_history(history)
     if history_text:
-        user_message = (
-            f"سياق المحادثة السابقة:\n{history_text}\n\nالسؤال الحالي: {question}"
-        )
+        user_message = f"سياق المحادثة السابقة:\n{history_text}\n\nالسؤال الحالي: {question}"
     else:
         user_message = question
 


### PR DESCRIPTION
### Motivation
- Fix Ruff lint and formatting failures that caused the CI `lint` job to fail and blocked required checks.
- Remove small code issues (unused imports and redundant branching) that produced Ruff diagnostics and noise in CI.

### Description
- Simplified `_is_supabase_url` return logic and collapsed a nested port check into a single condition in `app/core/database.py` to address `SIM103`/`SIM102` suggestions.
- Removed unused `AIMessage` and `HumanMessage` imports and normalized a multi-line system prompt and user message construction in `app/services/chat/local_graph.py` to resolve `F401` and formatting issues.
- Applied `ruff format` to files flagged by the formatter, including `app/core/settings/base.py`, `app/infrastructure/clients/orchestrator_client.py`, and `app/kernel.py`, plus the two functional changes above.

### Testing
- Ran `ruff check .` and `ruff format --check .`, and both passed locally.
- Ran provider contract verification with `python scripts/fitness/check_gateway_provider_contracts.py` and `python -m pytest -q tests/contracts/test_gateway_provider_contracts.py`, and both passed.
- Ran architecture guardrails `python scripts/ci_guardrails.py` and related fitness checks (`check_no_app_imports_in_microservices.py --strict`, `check_route_registry_parity.py`, `check_tracing_gate.py`), and they all passed.
- Ran `mypy app/ microservices/`, which reported numerous preexisting type errors not introduced by these targeted lint/format fixes and therefore remains a separate ongoing effort.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b6eba148832c90517149db6a67a4)