### PR TITLE
Disable asyncpg prepared-statement caches; filter fallback system-alerts; return explicit missing-anchor reason

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -86,11 +86,11 @@ def create_db_engine(settings: BaseServiceSettings) -> AsyncEngine:
         connect_args["ssl"] = ctx
         logger.info(f"SSL enabled (mode: {ssl_mode})")
 
+    # Disable prepared statement caches for asyncpg to avoid pooler incompatibilities.
+    connect_args["statement_cache_size"] = 0
+    connect_args["prepared_statement_cache_size"] = 0
+
     if is_supabase:
-        # Disable prepared statement cache — required even on port 5432 because
-        # pooler.supabase.com proxies still share state across connections.
-        connect_args["statement_cache_size"] = 0
-        connect_args["prepared_statement_cache_size"] = 0
         logger.info(
             f"Supabase database (NullPool, no prepared statements, port {url_obj.port}): {settings.SERVICE_NAME}"
         )

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -466,7 +466,7 @@ class OrchestratorClient:
                 conversation_id=conversation_id,
                 history_messages=history_messages,
             )
-            if graph_response:
+            if graph_response and not str(graph_response).startswith("⚠️ System Alert"):
                 yield graph_response
                 return
 
@@ -478,7 +478,7 @@ class OrchestratorClient:
                     question,
                     history_messages=history_messages,
                 )
-                if local_general_chat_response:
+                if local_general_chat_response and not str(local_general_chat_response).startswith("⚠️ System Alert"):
                     yield local_general_chat_response
                     return
 

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -462,8 +462,8 @@ def _context_gap_reason_for_followup(
     anchor = _extract_recent_entity_anchor(history_messages)
     if anchor:
         return None
-    logger.info("[CONTEXT_GUARD] bypassed")
-    return None
+    logger.info("[CONTEXT_GUARD] missing entity anchor for ambiguous follow-up")
+    return "MISSING_ENTITY_ANCHOR"
 
 
 async def _detect_checkpoint_state(thread_id: str) -> tuple[bool, bool]:


### PR DESCRIPTION
### Motivation

- Prevent prepared-statement cache collisions when using connection poolers (e.g., PgBouncer / Supabase) by disabling asyncpg's statement caches.
- Prevent spurious system-alert strings from being surfaced to users during fallback local responses.
- Provide an explicit, machine-readable reason when an ambiguous follow-up lacks a contextual entity anchor.

### Description

- In `create_db_engine` (in `app/core/database.py`) set `connect_args["statement_cache_size"] = 0` and `connect_args["prepared_statement_cache_size"] = 0` to disable asyncpg prepared-statement caches globally and keep the Supabase special-case behavior for `NullPool`.
- In `OrchestratorClient` (in `app/infrastructure/clients/orchestrator_client.py`) skip yielding fallback `graph_response` and `local_general_chat_response` when their string representation starts with the system-alert marker `"⚠️ System Alert"` to avoid surfacing internal alerts.
- In `_context_gap_reason_for_followup` (in `microservices/orchestrator_service/src/api/routes.py`) change the behavior to log `"[CONTEXT_GUARD] missing entity anchor for ambiguous follow-up"` and return the explicit reason string `"MISSING_ENTITY_ANCHOR"` instead of silently returning `None`.

### Testing

- Ran the project's unit test suite with `pytest`, and all tests passed.
- Ran static checks and linters (`ruff`/`flake8` and `mypy`), and no new issues were reported.
- Verified that the modified fallback branches no longer yield strings starting with `"⚠️ System Alert"` in integration smoke tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7eebdbf70832c8e0d79320ed46545)