### PR TITLE
Document platform-specific frontend ports and update memory architecture docs

### DIFF
--- a/.memory/context.md
+++ b/.memory/context.md
@@ -28,3 +28,9 @@
 ## Guardrails
 - Avoid claims tied to one hosting platform only.
 - Document architecture from executable code paths, not environment assumptions.
+
+
+## Platform Port Truth
+- Replit frontend runtime is expected on **5000**.
+- GitHub Codespaces frontend runtime is expected on **3000** (via `FRONTEND_PORT`).
+- Backend API remains **8000** in local/dev startup scripts unless `PORT` overrides it.

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -20,3 +20,9 @@
 ## D-005 Environment-Conditional Reachability
 **Decision**: Document microservice reachability as environment-dependent.
 **Reason**: Compose/dev/prod topologies differ.
+
+
+## D-006 Platform-Specific Frontend Port
+**Decision**: Treat frontend port as platform-specific (`5000` Replit, `3000` Codespaces) instead of a single global invariant.
+**Reason**: Devcontainer supervisor and Replit workflow encode different operational defaults.
+**Constraint**: Keep CORS and docs in sync with both to prevent runtime confusion.

--- a/.memory/progress.md
+++ b/.memory/progress.md
@@ -12,3 +12,7 @@
 ## Current State
 - `.memory` now reflects the same architectural truth documented in updated project docs.
 - Focus moved from environment-specific claims to code-backed invariants.
+
+
+## Additional update
+5. Validated port topology across environments and recorded policy: Replit frontend=5000, Codespaces frontend=3000, backend default=8000.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CogniForge — Claude Code Context
 
-> **AI tutor for Algerian students** | FastAPI 8000 + Next.js 5000 + LangGraph 1.1.10
+> **AI tutor for Algerian students** | FastAPI 8000 + Next.js (Replit:5000 / Codespaces:3000) + LangGraph 1.1.10
 > Arabic / French / Darija | BAC preparation platform
 
 ---
@@ -22,7 +22,7 @@ CogniForge is an educational AI platform for Algerian high-school students prepa
 # Backend (port 8000)
 uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
-# Frontend (port 5000)
+# Frontend (Replit:5000, Codespaces:3000 via FRONTEND_PORT)
 cd frontend && npm run dev
 
 # Health check
@@ -31,11 +31,21 @@ curl -s http://localhost:8000/health | python -m json.tool
 
 ---
 
+
+## Port Policy (Platform-Aware)
+
+- **Backend API**: `8000` in local/dev tooling unless overridden by `PORT`.
+- **Frontend in Replit**: `5000` (workflow + `.replit` webview mapping).
+- **Frontend in Codespaces**: `3000` (`FRONTEND_PORT` default in `.devcontainer/supervisor.sh`).
+- Operational rule: keep CORS/forwarded ports aligned with the active platform to avoid false "app down" signals.
+
+---
+
 ## 3. Architecture at a Glance (Evidence-Based)
 
 ```
 Browser
-  └── Next.js (port 5000)
+  └── Next.js (platform-dependent: 5000 on Replit, 3000 on Codespaces)
         └── /api/* → FastAPI kernel in app/
               └── RealityKernel (composition pipeline)
                     ├── Mount routers from registry


### PR DESCRIPTION
### Motivation
- Align repository documentation with the actual runtime topology evidenced in code and devcontainer workflows. 
- Clarify platform-specific frontend port behavior to avoid confusion when running the app in Replit versus Codespaces. 

### Description
- Added a `Platform Port Truth` section to `.memory/context.md` recording `5000` for Replit and `3000` for Codespaces and noting the backend default `8000` unless overridden by `PORT`. 
- Introduced decision `D-006` in `.memory/decisions.md` to treat the frontend port as platform-specific and to require CORS/docs alignment. 
- Updated `.memory/progress.md` to record the port-topology validation and policy. 
- Updated `CLAUDE.md` to reflect platform-aware frontend ports in the header, start commands, port policy section, and the architecture diagram line. 

### Testing
- This is a documentation-only change so no automated tests were modified or required for the update. 
- No automated test suite runs were triggered as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f25c7894832c9e96f0263b592752)