### PR TITLE
docs(truth): runtime truth audit — lock capability status against drift

### DIFF
--- a/.memory/architecture.md
+++ b/.memory/architecture.md
@@ -1,5 +1,8 @@
 # Architecture Deep-Dive
-> Last updated: 2026-05-05 (environment: GitHub Codespaces devcontainer)
+> Last updated: 2026-05-06 (environment: GitHub Codespaces devcontainer)
+> **Authoritative runtime status of every capability lives in `.memory/runtime_truth.md`.**
+> This file describes the live request flow and middleware stack only.
+> Anything documented here must be backed by import + call chain + runtime evidence (see CLAUDE.md §6.6).
 
 ---
 
@@ -92,7 +95,7 @@ FastAPI :8000
         │     only starts the `web` container; full stack at docker-compose.yml is not run)
         │     status: ERROR → continues to fallback 4
         │
-        └── [Fallback 4] LangGraph run_local_graph()  ← PRIMARY PATH
+        └── [Fallback 4] LangGraph run_local_graph()  ← DE-FACTO HANDLER (PARTIAL — fallback only)
               span: langgraph.run
               │
               ├── supervisor_node()
@@ -276,3 +279,14 @@ Test env:
 Runner: .venv/bin/pytest (Python 3.12 — NOT system pytest which is 3.11)
 Count: 1658 tests collected total
 ```
+
+---
+
+## 9. Capability Reality (one-line summary — full table in `.memory/runtime_truth.md`)
+
+- ACTIVE: FastAPI app, ObservabilityMiddleware + UnifiedObservabilityService, customer_chat / admin routers, OrchestratorClient.chat_with_agent (entrypoint), persistence layer, auth.
+- PARTIAL: `local_graph.py` (runs on every turn in default Codespaces, but only because orchestrator HTTP fails — formally a fallback).
+- DORMANT: orchestrator-service + all microservices, MCP server, DSPy, reranker microservice.
+- ZOMBIE: `app/services/chat/graph/workflow.py` and all its nodes (super_reasoner, planner, researcher, writer, procedural_auditor, reviewer), `app/services/chat/memory_engine.py`, all `app/drivers/*`, `app/core/integration_kernel/runtime.py`, `KagentMesh` consumers.
+
+If a doc here ever says a ZOMBIE/DORMANT component is "the primary handler", that doc has drifted — re-verify against `.memory/runtime_truth.md`.

--- a/.memory/context.md
+++ b/.memory/context.md
@@ -1,5 +1,6 @@
 # CogniForge — Project Context
-> Last updated: 2026-05-05 | Branch: claude/document-project-issues-CKlup
+> Last updated: 2026-05-06 | Branch: claude/runtime-truth-audit-65iVU
+> **Runtime capability status:** see `.memory/runtime_truth.md` (authoritative).
 
 ## Identity
 - **Name**: NAAS-Agentic-Core (CogniForge)
@@ -56,7 +57,7 @@ Student browser
                                 ├─ [1] File intelligence (0.1ms → SKIP if no files)
                                 ├─ [2] Exercise retrieval (0.0ms → SKIP if no BAC match)
                                 ├─ [3] HTTP → orchestrator:8006 → ConnectError (DORMANT in Codespaces)
-                                └─ [4] LangGraph local_graph.py  ← PRIMARY HANDLER
+                                └─ [4] LangGraph local_graph.py  ← DE-FACTO HANDLER (PARTIAL — fallback only; runs every turn because [3] always ConnectErrors in default Codespaces)
                                           span: langgraph.run (757ms measured)
                                           │
                                           ├─ supervisor_node  (0.0ms, intent=educational)

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -73,3 +73,25 @@ restart) is acceptable in Codespaces but documented explicitly as ISS-020.
 **Consequence**: Production deployment MUST set `LANGGRAPH_CHECKPOINTER=postgres`
 to preserve conversation continuity across restarts.
 **Status**: DECIDED — implementation pending (ISS-020 open)
+
+## D-010 · Runtime Truth Lock — Code Presence ≠ Runtime Usage
+**Decision**: A capability is treated as ACTIVE only when proven by the triple
+**import + call chain + runtime evidence**. Anything missing one is DORMANT,
+ZOMBIE, or UNKNOWN. The authoritative table lives in `.memory/runtime_truth.md`
+and is mirrored as CLAUDE.md §6.6.
+**Reason**: The codebase advertises a multi-agent stack (LangGraph workflow,
+KAgent mesh, MCP server, LlamaIndex, DSPy, reranker, integration kernel) that
+in default Codespaces is overwhelmingly ZOMBIE/DORMANT. Aspirational docs
+(ARCHITECTURE.md, LangGraph_Architectural_Blueprint.md) describe a target
+state that the runtime does not implement. Treating those docs as truth led to
+repeated drift and false claims.
+**Consequence**:
+1. No PR may promote a component to ACTIVE without the three-part proof.
+2. Any change to the chat / agent stack must update `.memory/runtime_truth.md`
+   in the same PR if it changes a component's runtime status.
+3. Aspirational docs (`docs/architecture/*`, root blueprints) may continue to
+   describe target architecture, but they are not authoritative for runtime —
+   `.memory/runtime_truth.md` is.
+4. ZOMBIE components are not deleted on sight. They are flagged. Removal
+   requires an ADR.
+**Status**: DECIDED 2026-05-06 — see branch `claude/runtime-truth-audit-65iVU`.

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -1,6 +1,7 @@
 # Open Issues & Bugs
-> Last updated: 2026-05-05 | Branch: claude/document-project-issues-CKlup
+> Last updated: 2026-05-06 | Branch: claude/runtime-truth-audit-65iVU
 > Format: [SEVERITY] ID · Title · [CONFIRMED LIVE / INFERRED / RUNTIME-ONLY / HISTORICAL]
+> **Capability runtime status (ACTIVE/PARTIAL/DORMANT/ZOMBIE) lives in `.memory/runtime_truth.md`.**
 
 ---
 
@@ -156,16 +157,20 @@
 ## 🟡 Medium — Structural / Quality Issues (NEW — Session 2026-05-05)
 
 ### ISS-021 · Zombie / Dormant Components — Dead Code Confusing Execution Topology
-- **Status**: CONFIRMED / LIKELY DORMANT
-- **Root cause**: Several components appear in the codebase but are not on any live
-  execution path:
-  - `Conversation Service` (microservices) — stub, never called
-  - `supervisor.py` (standalone, not the LangGraph supervisor) — seemingly unused
-  - Some graph factories / pipelines that may be dead code
-- **Effect**: Developer confusion about what is "real". Maintenance burden on code
-  that has no runtime effect. Risk of accidentally activating a zombie path.
-- **Fix strategy**: Audit with `grep -r "import"` to find callers. Mark dead files
-  with `# DORMANT — not on any live path` or delete after confirmation.
+- **Status**: CONFIRMED 2026-05-06 (audit branch `claude/runtime-truth-audit-65iVU`)
+- **Authoritative inventory**: `.memory/runtime_truth.md` truth table.
+- **Confirmed ZOMBIE** (no live call chain from any production entrypoint):
+  - `app/services/chat/graph/workflow.py` — only `tests/verify_graph_manual.py` imports it.
+  - `app/services/chat/graph/nodes/{super_reasoner,planner,researcher,writer,procedural_auditor,reviewer}.py` — only used by the dead workflow.
+  - `app/services/chat/memory_engine.py` (LlamaIndex VectorStoreIndex) — only invoked by dead `reviewer.py`.
+  - `app/drivers/llamaindex_driver.py`, `app/drivers/reranker_driver.py`, `app/drivers/kagent_driver.py` — `app/drivers` package has zero importers in the live path.
+  - `app/core/integration_kernel/runtime.py` (`RealityKernel`) — singleton designed but never instantiated from startup.
+  - `app/services/kagent/*` (KagentMesh, ServiceRegistry, RemoteAgentAdapter) — DI-registered (`app/core/di.py:145`) but the only consumer is the dead workflow.
+- **Confirmed DORMANT** (real code, gated behind dormant external service):
+  - `app/services/mcp/*` — only lazy-imported by side-path agents (`socratic_tutor`, `admin` agent, `collaboration/session`, `core/prompts`); none are on `/api/chat/ws`.
+  - All `microservices/*` — not started by `.devcontainer/docker-compose.host.yml`.
+- **Effect**: Developer confusion about what is "real". The codebase looks like a sophisticated multi-agent system; in default Codespaces it runs a 2-node LangGraph + 4 fallback functions.
+- **Fix strategy**: Each ZOMBIE either (a) gets wired into the live path with an ADR, or (b) gets deleted after an ADR. Do not touch silently.
 
 ---
 
@@ -194,6 +199,34 @@
   `app/api/routers/customer_chat.py` (WS event emission)
 - **Fix strategy**: Switch graph invocation to `astream_events()` and pipe each
   token as a `stream_token` WS event.
+
+---
+
+### ISS-024 · Capability Utilization Gap — ~90% of Advertised Stack is ZOMBIE/DORMANT
+- **Status**: CONFIRMED 2026-05-06 (audit `claude/runtime-truth-audit-65iVU`)
+- **Authoritative source**: `.memory/runtime_truth.md` truth table.
+- **Root cause**: The codebase advertises a sophisticated multi-agent system
+  (LangGraph multi-agent workflow, KAgent mesh, MCP server, LlamaIndex memory,
+  DSPy refinement, reranker pipeline, integration micro-kernel, full microservice
+  fleet). In default Codespaces ONLY the following actually run on chat traffic:
+  - `app/services/chat/local_graph.py` (2 nodes: supervisor + chat) — PARTIAL.
+  - `app/infrastructure/clients/orchestrator_client.py` fallback chain
+    (file-intel → exercise-retrieval → LangGraph → general-chat) — ACTIVE.
+  - `app/telemetry/unified_observability.py` via middleware — ACTIVE on every HTTP
+    request (WS frames not traced — ISS-005).
+- **Effect**:
+  - Aspirational documents (e.g. `ARCHITECTURE.md`, `LangGraph_Architectural_Blueprint.md`)
+    describe a target state that is NOT live. New contributors mistake them for runtime.
+  - Refactors keep "polishing" zombie modules (e.g. `super_reasoner.py`, `memory_engine.py`)
+    that have no production callers.
+  - Bug reports get filed against components (MCP, KAgent, reranker) that never executed.
+- **Fix strategy**:
+  1. Treat `.memory/runtime_truth.md` as the single source of truth for capability status.
+  2. Each ZOMBIE either gets wired into the live path (with ADR + status promotion) or
+     deleted (with ADR justifying removal). No silent half-life.
+  3. Each PR touching the chat/agent stack must update the truth table if status changes.
+  4. Aspirational docs must carry a "TARGET STATE — see `.memory/runtime_truth.md` for live status"
+     header to prevent drift.
 
 ---
 

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -1,0 +1,90 @@
+# Runtime Truth Lock
+> Last updated: 2026-05-06 | Branch: claude/runtime-truth-audit-65iVU
+> Authority: this file overrides any contradictory aspirational doc in `docs/` or root markdown.
+
+## Golden rule
+A capability counts as real ONLY when proven by **all three** of:
+1. **import** — the module is imported by code reachable from `app/main.py`.
+2. **call chain** — there is a live caller that flows from a router/middleware/startup hook.
+3. **runtime evidence** — the code actually executes on the production path (logs, traces, DB writes).
+
+Missing any of the three → DORMANT, ZOMBIE, or UNKNOWN. Not ACTIVE.
+
+## Status legend
+- `ACTIVE` — all three present.
+- `PARTIAL` — on a live chain but only via fallback / conditional / non-default branch.
+- `DORMANT` — code real, gated behind an external service that does not start by default.
+- `ZOMBIE` — exists with no live call chain from a production entrypoint.
+- `UNKNOWN` — insufficient evidence.
+
+---
+
+## Capability table (verified by audit, 2026-05-06)
+
+| # | Component | File(s) | Status | Proof |
+|---|---|---|---|---|
+| 1 | LangGraph local engine | `app/services/chat/local_graph.py` | PARTIAL | imported `app/kernel.py:239` (pre-warm) + `app/infrastructure/clients/orchestrator_client.py:170` (fallback tier 3); runs on every turn in default Codespaces because orchestrator URL unset. Uses `ainvoke` (ISS-023). MemorySaver only (ISS-020, D-002, D-008). |
+| 2 | LangGraph multi-agent workflow | `app/services/chat/graph/workflow.py` + `graph/nodes/*.py` | ZOMBIE | only importer is `tests/verify_graph_manual.py`. Zero references from `app/api/`, `app/main.py`, `app/kernel.py`, or `orchestrator_client.py`. |
+| 3 | LlamaIndex memory engine | `app/services/chat/memory_engine.py` | ZOMBIE | only consumed by `reviewer.py` inside the dead workflow. Not on live chat path. |
+| 4 | LlamaIndex driver | `app/drivers/llamaindex_driver.py` | ZOMBIE | no `from app.drivers` imports in live chain. |
+| 5 | Reranker driver (monolith) | `app/drivers/reranker_driver.py` | ZOMBIE | same as 4. Driver registered only via `MCPIntegrations`, which is dormant. |
+| 6 | DSPy (orchestrator side) | `microservices/orchestrator_service/.../graph/{main,search,supervisor}.py` | DORMANT | real code, gated behind orchestrator-service that doesn't start by default. |
+| 7 | DSPy query refiner | `microservices/research_agent/src/search_engine/query_refiner.py` | DORMANT | gated behind dormant `research-agent:8007`. |
+| 8 | Reranker (microservice) | `microservices/research_agent/src/search_engine/{reranker,strategies,hybrid,llama_retriever}.py` | DORMANT | gated behind dormant `research-agent:8007`. |
+| 9 | KAgent mesh | `app/services/kagent/{interface,registry,adapters}.py` | ZOMBIE | DI-registered at `app/core/di.py:145` but the only consumer (`workflow.py`) is itself ZOMBIE. |
+| 10 | KAgent driver | `app/drivers/kagent_driver.py` | ZOMBIE | not imported by any live entrypoint. |
+| 11 | MCP server / integrations | `app/services/mcp/{server,integrations,tools,resources,protocols}.py` | DORMANT | zero imports in `app/main.py`, `app/kernel.py`, `app/api/`. Lazy-imported only by side-path agents (`socratic_tutor`, `admin` agent module, `collaboration/session`, `core/prompts`) which the live chat router does not touch. |
+| 12 | Integration micro-kernel | `app/core/integration_kernel/runtime.py` | ZOMBIE | singleton designed but never instantiated from live startup. |
+| 13 | Unified Observability | `app/telemetry/unified_observability.py` | ACTIVE | `app/kernel.py:58,208` startup; `app/middleware/fastapi_observability.py` + `app/middleware/observability/observability_middleware.py` on every HTTP request. WS frames NOT traced (ISS-005). |
+| 14 | Orchestrator HTTP client | `app/infrastructure/clients/orchestrator_client.py:chat_with_agent` | ACTIVE | sole entrypoint called by `customer_chat.py:422` and `admin.py:490`. Wraps the entire fallback chain. Does not require URL to function — falls through to local engines on `ConnectError`. |
+| 15 | Orchestrator microservice (HTTP target) | `microservices/orchestrator_service` | DORMANT | requires `$ORCHESTRATOR_SERVICE_URL` set AND `docker compose -f docker-compose.yml up -d`. Default devcontainer satisfies neither. |
+| 16 | All other microservices | `microservices/{planning,memory,user,research,reasoning,auditor,conversation,api_gateway,observability}_*` | DORMANT | not started by `.devcontainer/docker-compose.host.yml`. |
+
+---
+
+## Live execution paths (only these are real)
+
+### Customer chat — `/api/chat/ws`
+1. `app/api/routers/customer_chat.py:244` — WS endpoint
+2. `customer_chat.py:340` — Monolith writes USER message (`save_message`)
+3. `customer_chat.py:422` — `OrchestratorClient.chat_with_agent()`
+4. `orchestrator_client.py:422` — HTTP attempt → ConnectError (default)
+5. fallback chain (in order, each may short-circuit and yield):
+   - file-intelligence (`orchestrator_client.py:486`)
+   - exercise-retrieval (`orchestrator_client.py:527`)
+   - **LangGraph `run_local_graph`** (`orchestrator_client.py:569` → `local_graph.py:227`)
+   - general-chat (`orchestrator_client.py:605`)
+6. `customer_chat.py:496-546` — assistant write decision (`persisted=True`? skip : fail-safe write)
+7. `customer_chat.py:_emit_terminal_frames()` — single terminal frame guarantee
+
+### Admin chat — `/admin/api/chat/ws`
+- Identical structure in `app/api/routers/admin.py` (different table: `admin_messages`).
+
+### Everything else
+- All HTTP requests pass through ObservabilityMiddleware → traces are recorded.
+- WebSocket frames are NOT traced (ISS-005 — known gap).
+
+---
+
+## Architectural verdict
+
+**Q: Does the project use the full agentic capability stack it advertises?**
+
+**A: NO.** In default runtime:
+- Only `local_graph.py` (2 nodes) + 4 simple fallback functions in `OrchestratorClient` actually serve chat traffic.
+- The advertised multi-agent graph (super_reasoner, planner, researcher, writer, procedural_auditor, reviewer) never runs in production — it's only invoked by `tests/verify_graph_manual.py`.
+- LlamaIndex, DSPy, KAgent mesh, MCP server, reranker, and the integration kernel are all unreachable from the live chat path.
+- The "control plane" described in `ARCHITECTURE.md` (orchestrator-service + api-gateway) is dormant scaffolding.
+
+**Project = ~10% live, ~90% scaffolding/dead-code in default Codespaces deployment.**
+
+The live 10%: FastAPI app + ObservabilityMiddleware + auth + customer/admin chat router + OrchestratorClient fallback chain + `local_graph.py` + database persistence layer.
+
+---
+
+## Rules for future sessions
+1. Never claim a capability is ACTIVE without proof in this table.
+2. Adding a feature that depends on a ZOMBIE/DORMANT layer requires a wiring change first — and a status update here.
+3. If you change the fallback order in `orchestrator_client.py` or pre-warm in `kernel.py`, update this file in the same PR.
+4. Do not delete a ZOMBIE on sight — first decide whether it's planned scaffolding (keep + mark DORMANT) or genuinely abandoned (delete with ADR).
+5. Truth-table updates require: file:line evidence + a 1–3 line snippet + import path + call-chain trace.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,14 @@
-# Architecture: Single Control Plane (Orchestrator Service)
+# Architecture: Single Control Plane (Orchestrator Service) — TARGET STATE
+
+> ⚠️ **TARGET STATE — NOT CURRENT RUNTIME.**
+> This document describes the *intended* architecture, not what executes today.
+> In default Codespaces deployment, the orchestrator-service is **DORMANT**
+> (not started by `.devcontainer/docker-compose.host.yml`). The Monolith is the
+> de-facto handler — see decisions D-001 / D-006 and the authoritative
+> capability table in `.memory/runtime_truth.md` (mirrored as CLAUDE.md §6.6).
+> Any contradiction between this file and `.memory/runtime_truth.md` is resolved
+> in favor of the truth table. Update this header before promoting any of the
+> below from target → live.
 
 ## Core Principle
 نقطة التحكم الواحدة للتشغيل (Control Plane) هي خدمة **`microservices/orchestrator_service`** عبر بوابة API Gateway فقط.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,66 @@ user_id = result.scalar()
 
 ---
 
+## 6.6 Architecture Truth and Runtime Rules (Truth Table)
+
+> **The golden rule:** code presence ≠ runtime usage. A capability is real ONLY when proven by **import + call chain + runtime evidence**. Anything missing one of those three is treated as DORMANT or ZOMBIE until proven otherwise.
+
+### Status legend
+- **ACTIVE** — imported, on a live call chain reachable from `app/main.py` / `app/api/routers/`, AND observed at runtime.
+- **PARTIAL** — on a live call chain but only via fallback, conditional, or non-default branch.
+- **DORMANT** — code is real and imported, but the call chain only fires when an external service (e.g., a microservice that is not started by default) is up.
+- **ZOMBIE** — defined and possibly imported, but no live call chain leads to it from a production entrypoint.
+- **UNKNOWN** — insufficient evidence; do not claim ACTIVE.
+
+### Truth table — verified 2026-05-06 (branch `claude/runtime-truth-audit-65iVU`)
+
+| Component | Status | Proof |
+|---|---|---|
+| **`app/services/chat/local_graph.py`** (`run_local_graph`, `supervisor_node`, `chat_node`, `MemorySaver`) | **PARTIAL** | Imported `app/kernel.py:239` (pre-warm) and `app/infrastructure/clients/orchestrator_client.py:170` (fallback tier 3). In default Codespaces it IS the de-facto handler because orchestrator URL is unset → ConnectError → fallback runs every turn. Uses `ainvoke` only (not `astream_events`) → ISS-023. |
+| **`app/services/chat/graph/workflow.py`** (`create_multi_agent_graph`) | **ZOMBIE** | Only importer is `tests/verify_graph_manual.py:8`. No reference from `app/main.py`, `app/kernel.py`, `app/api/`, or `orchestrator_client.py`. |
+| **Multi-agent nodes** — `super_reasoner.py`, `planner.py`, `researcher.py`, `writer.py`, `procedural_auditor.py`, `reviewer.py` | **ZOMBIE** | Only consumed by `workflow.py` (itself ZOMBIE). No production call chain. |
+| **`app/services/chat/memory_engine.py`** (LlamaIndex VectorStoreIndex) | **ZOMBIE** | Only invoked from `reviewer.py` inside the dead `workflow.py`. Zero references from routers, kernel, or `local_graph.py`. |
+| **`app/drivers/llamaindex_driver.py`** | **ZOMBIE** | No `from app.drivers` import in `app/api/`, `app/main.py`, `app/kernel.py`, `local_graph.py`, or `orchestrator_client.py`. |
+| **`app/drivers/reranker_driver.py`** | **ZOMBIE** | Same as above — drivers package has zero importers in the live chain. |
+| **`app/drivers/kagent_driver.py`** | **ZOMBIE** | Same — only registered conditionally inside `MCPIntegrations`, which itself is dormant. |
+| **`app/core/integration_kernel/runtime.py`** (`RealityKernel` micro-kernel) | **ZOMBIE** | Singleton designed but never instantiated from `app/main.py` or `app/kernel.py`. |
+| **DSPy** (`microservices/research_agent/src/search_engine/query_refiner.py`, `microservices/orchestrator_service/.../graph/{main,search,supervisor}.py`) | **DORMANT** | Real implementation, but ALL call chains live inside microservices that the default devcontainer does not start. Reachable only when `docker compose -f docker-compose.yml up -d`. |
+| **Reranker microservice** (`microservices/research_agent/src/search_engine/{reranker,strategies,hybrid,llama_retriever}.py`) | **DORMANT** | Same — gated behind dormant `research-agent:8007`. |
+| **`app/services/kagent/`** (KagentMesh, ServiceRegistry, RemoteAgentAdapter) | **ZOMBIE** | Registered as DI singleton at `app/core/di.py:145`, but `get_kagent_mesh()` is only consumed inside the dead `workflow.py` graph nodes. No live consumer. |
+| **`app/services/mcp/`** (MCPServer, MCPIntegrations, MCPToolRegistry, MCPResourceProvider) | **DORMANT** | Zero references from `app/main.py`, `app/kernel.py`, or `app/api/`. Only lazy-imported in `app/services/chat/agents/{admin.py,socratic_tutor.py}`, `app/services/collaboration/session.py`, and `app/core/prompts.py` — none of which are on the live `/api/chat/ws` path. The `socratic_tutor` and `admin` agent modules are themselves not invoked by the live chat router. |
+| **`app/telemetry/unified_observability.py`** (`UnifiedObservabilityService`) | **ACTIVE** | Wired through `app/kernel.py:58,208` at startup. Every HTTP request passes through `app/middleware/fastapi_observability.py` and `app/middleware/observability/observability_middleware.py`. WebSocket frames are NOT traced (ISS-005). |
+| **Orchestrator microservice fallback chain** in `OrchestratorClient` (file-intelligence, exercise-retrieval, LangGraph, general-chat) | **PARTIAL/ACTIVE** | `chat_with_agent` is the ONLY service called by `customer_chat.py:422` and `admin.py:490`. The HTTP attempt to `$ORCHESTRATOR_SERVICE_URL` always raises `ConnectError` in default Codespaces; the four local fallbacks then run in order. None of them set `persisted: true`. |
+| **`OrchestratorClient` HTTP path** to orchestrator-service | **DORMANT** | Requires `ORCHESTRATOR_SERVICE_URL` set AND microservice stack up. Default devcontainer satisfies neither. |
+| **All `microservices/*`** (orchestrator, planning, memory, user, research, reasoning, auditor, conversation, api_gateway, observability) | **DORMANT** | Not started by `.devcontainer/docker-compose.host.yml`. Only wake via `docker compose -f docker-compose.yml up -d`. |
+
+### What this means for daily work
+
+1. **The "agentic" stack the codebase advertises is mostly ZOMBIE/DORMANT in default Codespaces.** Only `local_graph.py` (2 nodes: supervisor + chat) and `UnifiedObservabilityService` actually run on every request.
+2. **Do NOT add a feature that depends on KAgent, MCP, LlamaIndex, DSPy, the integration kernel, or the multi-agent workflow without first wiring it into a live entrypoint** (`app/api/routers/`, `app/kernel.py`, or `local_graph.py`). Otherwise the feature joins the zombie pile.
+3. **`docs/` / blueprints describe the target architecture, not runtime.** When a doc claims "the orchestrator is the control plane" or "the multi-agent graph runs on chat", treat it as aspirational unless this truth table backs it.
+
+### First-check protocol before any change to the chat / agent stack
+
+1. Open this truth table.
+2. Ask: is the component I'm touching ACTIVE, PARTIAL, DORMANT, or ZOMBIE?
+3. If **DORMANT/ZOMBIE** → I am editing dead code unless I also wire it into a live path. Stop and decide explicitly.
+4. If **ACTIVE/PARTIAL** → confirm the call chain still holds after my change (grep importers, run the WS chat test).
+5. Updates to capability status MUST be accompanied by a fresh import + call-chain + runtime evidence triple in this table.
+
+### What MUST NOT change without runtime proof
+- Promoting any ZOMBIE/DORMANT component to ACTIVE in this table without the three-part proof.
+- Removing the `local_graph.py` pre-warm in `app/kernel.py:239` (it's how we catch import breakage at startup).
+- Removing `ObservabilityMiddleware` from the middleware stack — it's the ONLY production-path tracing today.
+- Renaming or deleting `_emit_terminal_frames` (single emitter rule, see §6.5).
+
+### Pre-merge checklist for the chat / agent stack
+1. Did I touch a ZOMBIE? → either delete it or wire it. Don't leave it half-alive.
+2. Did I add a new dependency on a microservice? → mark the new code DORMANT in this table until the stack is awake.
+3. Did I add streaming logic? → confirm `ainvoke` vs `astream_events` decision; today only `ainvoke` is used (ISS-023).
+4. Did I change the fallback chain order in `orchestrator_client.py`? → update §3 of this file and `.memory/architecture.md` in the same PR.
+
+---
+
 ## 7. Testing
 
 ```bash
@@ -348,4 +408,8 @@ To wake the full microservices stack (separate from the devcontainer): `docker c
 
 ---
 
-*Last updated: 2026-05-05 — environment corrected from Replit to GitHub Codespaces*
+*Last updated: 2026-05-06 — runtime truth audit (claude/runtime-truth-audit-65iVU) added §6.6 Truth Table.*
+
+---
+
+> **Closing rule:** *If you read this and cannot find live evidence (import + call chain + runtime) for a capability, classify it DORMANT or ZOMBIE until the contrary is proven.*

--- a/LangGraph_Architectural_Blueprint.md
+++ b/LangGraph_Architectural_Blueprint.md
@@ -1,4 +1,15 @@
-# LangGraph Architectural Blueprint
+# LangGraph Architectural Blueprint — TARGET STATE (DORMANT)
+
+> ⚠️ **DORMANT — describes the orchestrator-service multi-agent graph that does NOT run by default.**
+> This blueprint documents `microservices/orchestrator_service/src/services/overmind/graph/*`,
+> which is gated behind the orchestrator microservice. In default Codespaces
+> (`.devcontainer/docker-compose.host.yml` runs only the `web` container) this
+> graph never executes. The live chat handler is `app/services/chat/local_graph.py`
+> (2 nodes only — supervisor + chat). See `.memory/runtime_truth.md` and
+> CLAUDE.md §6.6 for the authoritative capability table.
+>
+> To wake the stack described here: `docker compose -f docker-compose.yml up -d`.
+> Until then, every component below is DORMANT.
 
 ## 1. Graph State (CRITICAL BACKBONE)
 


### PR DESCRIPTION
## Summary

Runtime-truth audit of the agentic stack. Verified each capability against the triple **import + call chain + runtime evidence** and locked the result into `CLAUDE.md` and `.memory/` so future sessions cannot drift back into aspirational claims.

**Headline finding:** in default Codespaces, ~90% of the advertised agentic stack (LangGraph multi-agent workflow, KAgent mesh, MCP server, LlamaIndex memory, DSPy, reranker, integration kernel, microservice fleet) is **ZOMBIE or DORMANT**. The live chat path is `local_graph.py` (2 nodes) + 4 fallback functions in `OrchestratorClient` + `ObservabilityMiddleware`.

## Truth table (key entries)

| Component | Status | Why |
|---|---|---|
| `app/services/chat/local_graph.py` | **PARTIAL** | pre-warm at `kernel.py:239` + fallback tier 3 at `orchestrator_client.py:170`; runs every turn because orchestrator HTTP always `ConnectError`s in default Codespaces. `ainvoke` only (ISS-023), `MemorySaver` only (ISS-020). |
| `app/services/chat/graph/workflow.py` + all nodes (super_reasoner, planner, researcher, writer, procedural_auditor, reviewer) | **ZOMBIE** | only importer is `tests/verify_graph_manual.py:8`. |
| `app/services/chat/memory_engine.py` (LlamaIndex) | **ZOMBIE** | consumed only by dead `reviewer.py`. |
| `app/drivers/{llamaindex,reranker,kagent}_driver.py` | **ZOMBIE** | zero importers in live chain. |
| `app/services/kagent/*` | **ZOMBIE** | DI singleton at `di.py:145`, but only consumer is the dead `workflow.py`. |
| `app/services/mcp/*` | **DORMANT** | lazy-imports only by side-path agents (`socratic_tutor`, `admin` agent module, `collaboration/session`, `core/prompts`); none are on `/api/chat/ws`. |
| `app/core/integration_kernel/runtime.py` (`RealityKernel`) | **ZOMBIE** | never instantiated from startup. |
| DSPy + reranker microservice | **DORMANT** | gated behind dormant `research-agent:8007` and `orchestrator-service:8006`. |
| `app/telemetry/unified_observability.py` | **ACTIVE** | `kernel.py:58,208` + middleware on every HTTP request. |
| `OrchestratorClient.chat_with_agent` (entrypoint) | **ACTIVE** | sole consumer at `customer_chat.py:422` and `admin.py:490`. |

Full table and per-component proof: `.memory/runtime_truth.md` (authoritative) and `CLAUDE.md` §6.6 (mirror).

## Changes

- `CLAUDE.md` — new §6.6 *Architecture Truth and Runtime Rules* with status legend, truth table, first-check protocol, pre-merge checklist; closing rule appended at the bottom.
- `.memory/runtime_truth.md` — new authoritative capability registry.
- `.memory/decisions.md` — D-010 *Runtime Truth Lock — Code Presence ≠ Runtime Usage*.
- `.memory/issues.md` — ISS-021 upgraded with concrete ZOMBIE inventory; new **ISS-024** *Capability Utilization Gap*.
- `.memory/architecture.md` — corrected `local_graph` label from "PRIMARY PATH" to "DE-FACTO HANDLER (PARTIAL — fallback only)"; added §9 capability summary.
- `.memory/context.md` — same correction; reference to `runtime_truth.md`.
- `ARCHITECTURE.md` — `TARGET STATE — NOT CURRENT RUNTIME` header.
- `LangGraph_Architectural_Blueprint.md` — `TARGET STATE (DORMANT)` header.

No application code changed. This is a documentation lock, not a refactor.

## Test plan

- [ ] Reviewer skims `.memory/runtime_truth.md` and confirms each row's `file:line` evidence resolves on the current branch.
- [ ] Reviewer reads `CLAUDE.md` §6.6 and confirms the status legend + first-check protocol are clear.
- [ ] Confirm no production code paths changed: `git diff --stat main..HEAD -- app/ microservices/ frontend/` returns empty.
- [ ] Optional: wake the microservice stack (`docker compose -f docker-compose.yml up -d`) and verify which DORMANT entries flip to ACTIVE — update the table in a follow-up PR if any do.

## Remaining unknowns

- WebSocket-layer runtime evidence not collected this session (ISS-005 still open).
- Hundreds of `docs/*.md` files were not individually reviewed; deletion deferred per the "if in doubt, do not delete" rule.

https://claude.ai/code/session_011i6W3by5Bz3PkFDjc8eTBW

---
_Generated by [Claude Code](https://claude.ai/code/session_011i6W3by5Bz3PkFDjc8eTBW)_