### PR TITLE
docs(architecture): clarify WebSocket streaming topology and hybrid state

### DIFF
--- a/.memory/architecture.md
+++ b/.memory/architecture.md
@@ -4,6 +4,7 @@
 ## System Shape
 - Hybrid runtime: composition shell in `app/` + independently deployable services in `microservices/`.
 - Architectural control point: `app/kernel.py`.
+- Streaming edge authority (target): `microservices/api_gateway` as single WS ingress.
 
 ## Layered Decomposition
 1. Ingress/UI layer
@@ -18,6 +19,19 @@
 - Apply middleware in deterministic order.
 - Mount routers from registry.
 - Validate contract alignment.
+
+## WebSocket Streaming Topology (Current)
+- Primary ingress:
+  - `microservices/api_gateway/main.py` (`/api/chat/ws`, `/admin/api/chat/ws`)
+- Relay engine:
+  - `microservices/api_gateway/websockets.py::websocket_proxy`
+- Compatibility fallback:
+  - Legacy/compatibility WS facades still exist in monolith routes pending full purge.
+
+## Monolith vs Microservices Status
+- Current mode: **Hybrid Transitional**.
+- Not a pure monolith; not yet full microservices completion.
+- Main migration gap: eliminate split ownership for chat streaming + enforce one event envelope contract.
 
 ## Integration Contracts
 - Service-to-service communication strictly over HTTP/gRPC style APIs.

--- a/.memory/context.md
+++ b/.memory/context.md
@@ -7,6 +7,11 @@
 ## Runtime Truth
 - `app/` remains the control shell and integration boundary.
 - `microservices/` hosts independent capabilities (user/observability/reasoning/research/gateway and others per environment).
+- WebSocket chat streaming operationally prefers API Gateway ingress, while compatibility paths in monolith still indicate transitional state.
+
+## Architectural State
+- Official interpretation: **Controlled Hybrid** using strangler migration.
+- Decision pressure area: chat WebSocket ownership and event-contract unification.
 
 ## Documentation Contract
 - Any architectural change requires synchronized updates across:

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -15,3 +15,9 @@ Cross-boundary communication is API-first only; direct DB coupling is forbidden.
 
 ## D-005
 Architecture documentation must be code-evidenced and updated in the same PR.
+
+## D-006
+Chat WebSocket streaming ownership target is API Gateway as the single ingress point; monolith WS endpoints are compatibility-only during transition.
+
+## D-007
+Monolith-vs-microservices status is tracked as "Hybrid Transitional" until compatibility WebSocket facades are fully retired.

--- a/.memory/progress.md
+++ b/.memory/progress.md
@@ -2,6 +2,6 @@
 > Last updated: 2026-05-05
 
 ## Completed
-- Delivered a full architectural dissection summary in `CLAUDE.md`.
-- Synchronized `.memory` architecture/context/decisions/issues to match the updated narrative.
-- Preserved hybrid control-plane/execution-plane interpretation.
+- Delivered an updated architectural dissection in `CLAUDE.md` with a dedicated WebSocket streaming section.
+- Synchronized `.memory/architecture.md` with streaming topology and hybrid-state interpretation.
+- Synchronized `.memory/context.md` and `.memory/decisions.md` with explicit monolith-vs-microservices status and WS ownership target.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,66 @@
 
 ---
 
-## 2) خريطة التنفيذ (Execution Topology)
+## 2) تشريح WebSocket Streaming (الحالة التشغيلية الحالية)
+
+### A. نقاط الدخول المعتمدة للدردشة اللحظية
+1. **المسار الحديث (Modern Entry Point):**
+   - `microservices/api_gateway/main.py` عبر:
+     - `/api/chat/ws`
+     - `/admin/api/chat/ws`
+   - البوابة تنفّذ:
+     - تحديد identity للجلسة (`route_id + upstream_path + session scope`) لأغراض stickiness.
+     - تمرير الاتصال إلى `websocket_proxy` داخل `microservices/api_gateway/websockets.py`.
+2. **المسار التوافقي (Compatibility Facade):**
+   - مسارات WebSocket داخل `app/api/routers/customer_chat.py` و`app/api/routers/admin.py` ما تزال موجودة كصمام توافق/rollback في بعض السيناريوهات.
+
+### B. خط الأنابيب الفعلي للـ streaming
+```text
+Client
+  -> API Gateway WS Route (/api/chat/ws | /admin/api/chat/ws)
+    -> Target resolution (_resolve_chat_ws_target)
+      -> websocket_proxy (bidirectional relay)
+        -> Upstream chat engine (orchestrator/conversation بحسب التوجيه)
+          -> event normalization contract
+            -> Client render loop
+```
+
+### C. المخاطر البنيوية في WebSocket Streaming
+- **Split-Brain ownership:** وجود مسار حديث في البوابة + مسارات توافقية بالمونوليث يخلق ازدواجية قرار التوجيه.
+- **Contract Drift:** اختلاف envelope بين بعض المنتجين (`delta` مقابل `assistant_delta` تاريخيًا) يسبب أخطاء parsing صامتة.
+- **Session Affinity Fragility:** أي تعديل في خوارزمية routing identity قد يزعزع ثبات تموضع الجلسات أثناء reconnect.
+
+### D. الحواجز التشغيلية المطلوبة (Guardrails)
+- البوابة هي **نقطة الدخول الوحيدة** للإنتاج متى ما اكتمل purge.
+- كل حدث stream يجب أن يمر بعقد موحّد قبل العميل.
+- أي rollback يجب أن يكون عبر feature flags ونافذة زمنية مضبوطة، لا عبر bypass عشوائي.
+
+---
+
+## 3) حالة Monolith vs Microservices (2026-05-05)
+
+### A. الواقع الحالي
+- المنظومة **ليست monolith خالصًا** وليست **microservices pure** بالكامل.
+- الحالة الصحيحة: **Hybrid Transitional Architecture**:
+  - `app/` ما يزال يملك وظائف تكامل وتوافق تاريخي.
+  - `microservices/` يملك مسارات تنفيذ حديثة مستقلة لعدة قدرات.
+
+### B. أين ما زال المونوليث حاضرًا؟
+- في بعض واجهات الدردشة/التوافق ومسارات orchestration التاريخية.
+- في طبقة composition العامة (Reality Kernel) التي ما تزال تدير جزءًا من control-plane.
+
+### C. أين أصبحت microservices ناضجة؟
+- وجود `api_gateway` كنقطة edge routing مستقلة.
+- وجود خدمات domain مخصصة (user/observability/reasoning/research...) بحدود نشر وتشغيل مستقلة.
+
+### D. التقييم التنفيذي المختصر
+- **Target State:** API-First Microservices بنسبة تشغيلية كاملة.
+- **Current State:** Hybrid with controlled strangler pattern.
+- **Gap:** إزالة آخر facades التوافقية للمحادثة وتثبيت ownership أحادي لمسار WS + عقود events موحّدة.
+
+---
+
+## 4) خريطة التنفيذ (Execution Topology)
 
 ```text
 Client/UI
@@ -60,7 +119,7 @@ Client/UI
 
 ---
 
-## 3) مناطق المسؤولية (Boundaries)
+## 5) مناطق المسؤولية (Boundaries)
 
 1. `app/*` = بوابة التركيب والتنسيق العام (Control Plane).
 2. `microservices/*` = وحدات أعمال مستقلة (Execution Plane).
@@ -69,16 +128,7 @@ Client/UI
 
 ---
 
-## 4) مخاطر معمارية حالية
-
-1. **Drift بين الوثائق والكود** عند تطور الخدمات بسرعة.
-2. **Coupling خفي** إذا تم تمرير نماذج داخلية بين خدمات بدل عقود API صريحة.
-3. **اختلاط أدوار app shell** إذا زاد منطق الأعمال داخل route handlers.
-4. **تباين جاهزية الخدمات** بين local/dev/prod بدون health contracts موحدة.
-
----
-
-## 5) قواعد تشغيلية إلزامية عند التعديل
+## 6) قواعد تشغيلية إلزامية عند التعديل
 
 - قبل أي تعديل معماري: راجع `docs/architecture/MICROSERVICES_CONSTITUTION.md`.
 - أي تغيير في طوبولوجيا النظام يستلزم تحديثًا متزامنًا لـ:
@@ -91,7 +141,7 @@ Client/UI
 
 ---
 
-## 6) أوامر التحقق السريع
+## 7) أوامر التحقق السريع
 
 ```bash
 ruff check .
@@ -99,3 +149,4 @@ mypy app/ microservices/
 pytest
 ```
 
+---


### PR DESCRIPTION
### Motivation
- Reduce documentation drift by making the current WebSocket streaming topology and ownership explicit across the canonical architecture artifacts. 
- Declare the operational target for chat WebSocket ingress (API Gateway) and capture the repository's current runtime posture as a Hybrid Transitional Architecture. 
- Ensure the repository's memory artifacts remain synchronized per the architecture documentation contract.

### Description
- Updated `CLAUDE.md` to add a dedicated "WebSocket Streaming" section describing modern gateway ingress, compatibility facades, streaming pipeline, risks (split-brain, contract drift, session affinity) and guardrails. 
- Synchronized `.memory` files by updating `.memory/architecture.md`, `.memory/context.md`, `.memory/decisions.md`, and `.memory/progress.md` to reflect the streaming topology and hybrid state. 
- Added decision entries `D-006` and `D-007` to `.memory/decisions.md` to record the WS ownership target (API Gateway) and the official "Hybrid Transitional" status. 
- This is documentation-only; no runtime code paths or behavior were modified.

### Testing
- No automated tests were executed for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa35bab6c0832ca9cfbcf3b6d27dcf)