### PR TITLE
docs(architecture): clarify educational vs general chat paths

### DIFF
--- a/.memory/context.md
+++ b/.memory/context.md
@@ -141,3 +141,10 @@ Three quality issues: ISS-021 (zombies), ISS-022 (pipeline split), ISS-023 (stre
 - الملخص التنفيذي/السياسات: `CLAUDE.md`
 - تم حذف الأرشيفات القديمة في `docs/archive/` لتجنب تضارب المعرفة.
 
+
+
+## Educational vs General Chat (Operational Contract)
+- **Educational Path**: objective-driven tutoring flow (diagnose -> explain -> verify -> next-step), should prefer retrieval + evaluation signals and explicit learner-state updates.
+- **General Chat Path**: open conversation flow, optimized for latency and usability; retrieval is optional.
+- **Routing Principle**: the supervisor/router should classify intent early and choose state schema + tool budget accordingly.
+- **API-first impact**: each capability (auth, retrieval, orchestration, analytics) should remain independently deployable behind explicit HTTP/gRPC/event contracts.

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -88,3 +88,8 @@ The live 10%: FastAPI app + ObservabilityMiddleware + auth + customer/admin chat
 3. If you change the fallback order in `orchestrator_client.py` or pre-warm in `kernel.py`, update this file in the same PR.
 4. Do not delete a ZOMBIE on sight — first decide whether it's planned scaffolding (keep + mark DORMANT) or genuinely abandoned (delete with ADR).
 5. Truth-table updates require: file:line evidence + a 1–3 line snippet + import path + call-chain trace.
+
+
+## Strategic note — learning path vs general chat
+- Current runtime can classify intent in the local graph supervisor, but the advanced educational stack (multi-agent + deep retrieval/reranking orchestration) remains mostly ZOMBIE/DORMANT by default environment.
+- Therefore, educational-path quality currently depends heavily on the fallback local graph and available external model quality, not on the full intended microservice mesh.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,3 +431,42 @@ To wake the full microservices stack (separate from the devcontainer): `docker c
   - `README.md` و `CHANGELOG.md` و `SECURITY.md`
 - قبل إضافة أي ملف Markdown جديد: إذا كانت المعلومة تشغيلية قصيرة، توضع في `.memory/*.md` بدل إنشاء تقرير طويل جديد.
 
+
+
+## 15) المسار التعليمي vs الدردشة العامة + خريطة التكنولوجيا
+
+### التعريف التشغيلي
+- **المسار التعليمي**: مسار موجّه لتحقيق هدف تعلمي (نواتج تعلم + تقييم + تتبع تقدم + استرجاع سياق أكاديمي).
+- **الدردشة العامة**: مسار محادثة حرّة (أسئلة عامة، نقاش مفتوح، بدون التزام بناتج تعليمي أو Rubric تقييم).
+
+### الفرق المعماري (Monolith + Microservices + Agent Graph)
+1. **التحكم (Control Plane)**
+   - المسار التعليمي يحتاج Policy/Guardrails أقوى + Rubric + ذاكرة متخصصة.
+   - الدردشة العامة تعتمد سياسة أخف، وتكفيها استجابة سريعة مع سياق جلسة محدود.
+2. **البيانات (State + Memory)**
+   - التعليمي: `StateGraph` يمرر حالة صريحة (intent, grade, mastery, misconceptions, evidence).
+   - العام: حالة أخف (history, tone, user prefs).
+3. **الاسترجاع (RAG/Reranking)**
+   - التعليمي: Retriever + Reranker إلزامي تقريبًا لتحسين الدقة وتقليل الهلوسة.
+   - العام: يمكن الاستغناء عن RAG في كثير من الحالات.
+4. **الزمن الحقيقي (Streaming/WebSocket)**
+   - كلاهما يستفيد من WS/streaming؛ التعليمي يحتاج كذلك progressive hints وخطوات حل تدريجية.
+
+### علاقة المفاهيم المطلوبة ببعضها (Concept Map)
+- **Monolith**: نقطة دخول واحدة سريعة لبناء MVP.
+- **Microservices (API-first)**: فصل قدرات مستقلة (auth, orchestrator, retrieval, analytics) مع عقود API.
+- **StateGraph / LangGraph**: تنظيم منطق الوكلاء كعُقد وحواف وحالة مشتركة.
+- **Reasoning / Multi-agent**: تقسيم التفكير إلى أدوار (planner/researcher/reviewer...) بدل prompt واحد ضخم.
+- **LlamaIndex**: طبقة ingestion + indexing + retrieval فوق بياناتك.
+- **DSPy**: تحسين منهجي للبرامج اللغوية (prompts/strategies) بمقاييس.
+- **Reranker**: إعادة ترتيب نتائج الاسترجاع لرفع precision@k قبل التوليد.
+- **KAgent**: شبكة/طبقة تنسيق وكلاء عبر حدود الخدمة.
+- **MCP**: بروتوكول موحّد لربط النموذج بالأدوات/الموارد (JSON-RPC session).
+- **TLM**: طبقة إدارة نموذج/توجيه مهام (Model routing/governance) حسب الكلفة/الجودة/الزمن.
+- **FastAPI + Python**: Backend API + WS.
+- **Next.js**: واجهة المستخدم + streaming UI + app routing.
+- **Supabase/PostgreSQL**: المصدر الدائم للبيانات (auth + relational core).
+- **Redis cache**: تقليل زمن الوصول (sessions, hot keys, rate-limits, short-lived context).
+
+### مبدأ التفعيل الواقعي
+وجود الكود لا يعني أنه يعمل فعليًا. الاعتماد النهائي يكون على: **import + call-chain + runtime evidence** كما هو موثق في `.memory/runtime_truth.md`.


### PR DESCRIPTION
### Motivation
- Provide an explicit operational distinction between the Educational Path and General Chat so routing, tooling budget, and state requirements are unambiguous.
- Map core technologies to those two paths (Monolith, microservices, LangGraph/StateGraph, retrieval/reranking, multi-agent layers, MCP/TLM/KAgent, DSPy, LlamaIndex, FastAPI/Next.js, Supabase/Postgres, Redis) to reduce architectural ambiguity.
- Ensure runtime documentation (`.memory/*`) reflects the real activation state of components (ACTIVE / PARTIAL / DORMANT / ZOMBIE) rather than aspirational diagrams. 

### Description
- Add a new section `15) المسار التعليمي vs الدردشة العامة + خريطة التكنولوجيا` to `CLAUDE.md` that defines operational differences and presents a concise concept map linking relevant technologies and patterns. 
- Update `.memory/context.md` with an `Educational vs General Chat (Operational Contract)` entry describing routing principles and intent-based supervisor decisions. 
- Update `.memory/runtime_truth.md` with a `Strategic note` clarifying that the advanced educational orchestration (multi-agent + deep retrieval/reranking) is mostly DORMANT/ZOMBIE in the default development environment and that current quality depends on the local fallback graph and available model providers. 
- This PR is documentation-only and does not change runtime code or behavior. 

### Testing
- Ran lint checks with `ruff check .` which reported many pre-existing lint violations unrelated to these doc-only changes and therefore failed. 
- Ran static type checks with `mypy app/ microservices/` which reported extensive pre-existing typing errors in the repository baseline and therefore failed. 
- No unit/integration tests were modified or added for this PR and no production code behavior was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2d4deb64832ca0e13999da73cf4f)