### PR TITLE
docs: Intelligent merge of observability doctrine into persistent memory

### DIFF
--- a/.memory/dashboard-inventory.md
+++ b/.memory/dashboard-inventory.md
@@ -36,6 +36,8 @@ the left-nav order. The `00-` dashboard is set as Grafana's default home.
 
 ## Required dashboard hygiene
 
+* **Instrumentation first, visualization second:** Dashboards must never outpace instrumentation.
+* **Debugging support:** Every visualization must support debugging and investigation.
 * Title MUST be human-readable; emoji prefix is encouraged for the home row.
 * Description (panel-level) MUST explain the metric's source AND interpretation.
 * `tags` MUST include `cogniforge` so the folder grouping works.

--- a/.memory/observability_truth.md
+++ b/.memory/observability_truth.md
@@ -20,6 +20,13 @@ The following component status represents strictly what is proven by import + ca
 1. **Trace Split-Brain**: The API Gateway passes W3C `traceparent` headers to Orchestrator Service, but Orchestrator and downstream LangGraph nodes ignore them. Distributed tracing is structurally broken at this boundary.
 2. **Volatile Data**: All complex logic in `observability_service` (Z-scores, trend lines) is purely in-memory and therefore volatile.
 
+## Observability Principles
+* **Diagnosis over Decoration:** Observability is for diagnosis, not decoration.
+* **Metric Evidence:** Metrics require runtime evidence to be trusted.
+* **Separation of Concerns:** Traces and metrics are separate disciplines.
+* **Cardinality Constraints:** High-cardinality labels are dangerous and strictly forbidden.
+* **Semantic Contracts:** Semantic meaning must exist before a metric is accepted.
+
 ## Rules for AI Sessions
 * **Do NOT assume traces or correlated logs exist.** Unless you manually boot the Docker Compose observability stack, Tempo/Loki are dead.
 * **Use Native Metrics.** If you need evidence, use Prometheus metrics surfaced via native Grafana on port 3001, or manual stdout logs.

--- a/.runtime/truth_table.lock.json
+++ b/.runtime/truth_table.lock.json
@@ -1,5 +1,5 @@
 {
-  "branch": "jules-17497610847561986097-4542941c",
+  "branch": "jules-16680908087727361795-78a289b6",
   "components": [
     {
       "agreed": true,
@@ -312,6 +312,6 @@
       "on_live_chain": true
     }
   ],
-  "generated_at_utc": "2026-05-07T21:06:17.422728+00:00",
+  "generated_at_utc": "2026-05-08T02:05:24.319344+00:00",
   "schema_version": 1
 }

--- a/.runtime/truth_table.lock.json
+++ b/.runtime/truth_table.lock.json
@@ -312,6 +312,6 @@
       "on_live_chain": true
     }
   ],
-  "generated_at_utc": "2026-05-08T02:05:24.319344+00:00",
+  "generated_at_utc": "2026-05-08T02:09:44.543425+00:00",
   "schema_version": 1
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1447,6 +1447,13 @@ The NAAS-Agentic-Core system is in a transitional "strangler fig" phase, meaning
 *   **GitHub Actions CI (`observability_validation.yml`):** ACTIVE but narrow. It validates structural wiring (imports, YAML syntax) and existence of checks, but it **DOES NOT** prove runtime telemetry flow.
 
 **3. Rules for AI (What you must do before assuming observability)**
+
+*   **Permanent Observability Doctrine:**
+    *   **Runtime truth over synthetic certainty.** If it isn't executing and measured, it isn't real.
+    *   **Instrumentation before visualization.** Dashboards must never outpace instrumentation.
+    *   **Unknown is better than fake certainty.** Do not present dormant systems as healthy.
+    *   **Every metric must have a semantic contract,** and must reflect real runtime evidence.
+    *   **Repository memory must remain coherent, curated, and durable.** Every future agent must inherit these rules automatically.
 *   **Do NOT assume traces or correlated logs exist.** Unless you manually boot the Docker Compose observability stack, Tempo/Loki are dead.
 *   **Use Native Metrics.** If you need evidence, use Prometheus metrics surfaced via native Grafana on port 3001, or manual stdout logs.
 *   **Do not remove structural hooks.** CI checks (like `check_tracing_gate.py`) enforce the *presence* of hooks like `open_ws_turn` or `TraceContextMiddleware`. Deleting dormant observability code will break the CI gate.


### PR DESCRIPTION
This commit intelligently merges the requested observability doctrine into the existing repository memory architecture.

Modifications:
- `CLAUDE.md`: Added top-level, permanent observability doctrine under 'Rules for AI'.
- `.memory/observability_truth.md`: Integrated specific rules on metric evidence, traces vs metrics, cardinality constraints, and semantic contracts.
- `.memory/dashboard-inventory.md`: Inserted visualization rules mandating instrumentation precedence and debugging support.

The changes were made strictly to the documentation files to reflect the requested architectural principles without altering any application logic or creating redundant files.

---
*PR created automatically by Jules for task [16680908087727361795](https://jules.google.com/task/16680908087727361795) started by @HOUSSAM16ai*