### PR TITLE
docs: persist observability doctrine into memory architecture

### DIFF
--- a/.memory/observability_truth.md
+++ b/.memory/observability_truth.md
@@ -21,11 +21,14 @@ The following component status represents strictly what is proven by import + ca
 2. **Volatile Data**: All complex logic in `observability_service` (Z-scores, trend lines) is purely in-memory and therefore volatile.
 
 ## Observability Principles
-* **Diagnosis over Decoration:** Observability is for diagnosis, not decoration.
-* **Metric Evidence:** Metrics require runtime evidence to be trusted.
-* **Separation of Concerns:** Traces and metrics are separate disciplines.
-* **Cardinality Constraints:** High-cardinality labels are dangerous and strictly forbidden.
-* **Semantic Contracts:** Semantic meaning must exist before a metric is accepted.
+* **Runtime Truth over Synthetic Dashboards:** Always prioritize actual runtime evidence over what a synthetic or aspirational dashboard claims.
+* **Instrumentation First, Visualization Second:** Never build dashboards that outpace actual code instrumentation. The underlying data source must be solid first.
+* **Diagnosis over Decoration:** Observability is for debugging and investigation, not just for show. Every dashboard must support active debugging.
+* **Unknown is Better than Fake Certainty:** Do not present dormant systems as healthy. If a system is not actively emitting data, it should be marked as unknown or dormant.
+* **Metric Evidence:** Metrics require real runtime evidence to be trusted. Do not hallucinate or mock metric data in production.
+* **Separation of Concerns:** Traces and metrics are different disciplines. Treat them independently when instrumenting and debugging.
+* **Cardinality Constraints:** High-cardinality labels are dangerous and strictly forbidden as they can crash the metrics backend.
+* **Semantic Contracts:** Semantic meaning must exist before a metric is accepted. You must know what a metric means before emitting it.
 
 ## Rules for AI Sessions
 * **Do NOT assume traces or correlated logs exist.** Unless you manually boot the Docker Compose observability stack, Tempo/Loki are dead.

--- a/.memory/runtime-rules.md
+++ b/.memory/runtime-rules.md
@@ -8,3 +8,5 @@
 - Classify each component: ACTIVE / PARTIAL / DORMANT / ZOMBIE / UNKNOWN.
 - Treat OTel stack as PARTIAL by default unless OTLP endpoint + collector + backend signals are observed.
 - Before merge: verify workflows `ci.yml`, `observability_validation.yml`, `runtime_truth.yml` are green and relevant telemetry fields still emitted.
+- **Reasoning about Truth:** Future agents must inherit the discipline of verifying capabilities via the truth table (`.runtime/truth_table.lock.json`) rather than assuming aspirational architecture docs are real.
+- **Uncertainty vs Evidence:** When there is uncertainty, do not synthesize or assume positive state. Default to UNKNOWN or DORMANT until explicit runtime evidence (logs, DB writes, metrics) proves otherwise. Always favor runtime evidence over documented claims.

--- a/.runtime/truth_table.lock.json
+++ b/.runtime/truth_table.lock.json
@@ -1,5 +1,5 @@
 {
-  "branch": "jules-16680908087727361795-78a289b6",
+  "branch": "jules-5513332666705839536-7e7df21b",
   "components": [
     {
       "agreed": true,
@@ -312,6 +312,6 @@
       "on_live_chain": true
     }
   ],
-  "generated_at_utc": "2026-05-08T02:09:44.543425+00:00",
+  "generated_at_utc": "2026-05-08T08:17:11.451596+00:00",
   "schema_version": 1
 }

--- a/.runtime/truth_table.lock.json
+++ b/.runtime/truth_table.lock.json
@@ -312,6 +312,6 @@
       "on_live_chain": true
     }
   ],
-  "generated_at_utc": "2026-05-08T08:17:11.451596+00:00",
+  "generated_at_utc": "2026-05-08T09:54:43.624200+00:00",
   "schema_version": 1
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 0. Core System Doctrine
+
+**Single writer. Single terminal frame. No silent failure.** These are operational laws, not aspirations.
+
+The system must preserve the following principles permanently. Every future agent must inherit and obey these rules automatically:
+
+- **Runtime truth over synthetic certainty**: Code presence ≠ runtime usage. A capability is real ONLY when proven by import + call chain + runtime evidence. Anything missing one of those three is treated as DORMANT or ZOMBIE until proven otherwise.
+- **Instrumentation before visualization**: Dashboards must never outpace instrumentation.
+- **Observability is for diagnosis, not decoration**: Every visualization must support debugging.
+- **Unknown is better than fake certainty**: Dormant systems must not be presented as healthy.
+- **Metrics require runtime evidence**: Every metric must have a semantic contract.
+- **Traces and metrics are separate disciplines**: Treat them as such in architecture and implementation.
+- **Forbidden anti-patterns**: High-cardinality labels are dangerous and strictly forbidden. Dual-writes to the database are forbidden.
+- **CI truth-gate philosophy**: The project enforces architectural capability truths via static analysis in CI (`scripts/runtime_truth.py --check`), which strictly validates the codebase against `.runtime/truth_table.lock.json`. Do not bypass or break this gate.
+- **Repository memory coherence**: Repository memory (`.memory/` and `CLAUDE.md`) must remain coherent, curated, and durable over time. It must reflect the actual runtime reality, not aspirational architecture.
+
+---
+
 ## 1. What This Project Does
 
 CogniForge is an educational AI platform for Algerian high-school students preparing for the Baccalaureate exam. Students chat in Arabic, French, or Darija and receive tutoring in math, physics, and sciences. The backend is a FastAPI monolith.


### PR DESCRIPTION
This change permanently encodes the observability and system architecture doctrine into the repository's long-term memory. It establishes the "Single writer. Single terminal frame. No silent failure." principle as an operational law in `CLAUDE.md` and explicitly outlines how future agents should reason about runtime capabilities based on the `import + call chain + runtime evidence` rule. Detailed observability rules (instrumentation before visualization, avoiding high-cardinality labels, and prioritizing diagnosis over decoration) are mapped into `.memory/observability_truth.md` and `.memory/runtime-rules.md`.

---
*PR created automatically by Jules for task [5513332666705839536](https://jules.google.com/task/5513332666705839536) started by @HOUSSAM16ai*