### PR TITLE
docs(memory): advanced LangGraph + Tavily live audit 2026-05-09

### DIFF
--- a/.memory/architecture_truth.md
+++ b/.memory/architecture_truth.md
@@ -1,5 +1,5 @@
 # Architectural Diagnostic: NAAS-Agentic-Core
-> Last updated: **2026-05-09** | Live audit (Ona agent — full runtime investigation).
+> Last updated: **2026-05-09** | Live audit (Ona agent — third pass: advanced LangGraph + Tavily deep investigation).
 
 ## Executive Summary
 The system is in a "strangler fig" migration phase from monolith to microservices. In the default Codespaces environment (without explicitly launching `docker-compose.yml`), the system relies entirely on the FastAPI monolith and a 2-node local LangGraph fallback. The advertised "Agentic" capabilities (KAgent, MCP, DSPy, Reranker, LlamaIndex, Multi-agent workflows) are either DORMANT (gated behind microservices that aren't running) or ZOMBIE (code exists but has no live consumers).
@@ -15,6 +15,8 @@ The system is in a "strangler fig" migration phase from monolith to microservice
 | **KAgent Mesh** (`app/services/kagent/`) | **ZOMBIE** | DI-registered in `app/core/di.py:145` but only consumed by dead `workflow.py` graph nodes. No live consumer. |
 | **MCP** (`app/services/mcp/`) | **DORMANT** | Not referenced by live APIs or kernel. Lazy-imported only in dormant agents. |
 | **Reranker / LlamaIndex / DSPy** | **DORMANT** | Implemented in `microservices/research_agent` and `orchestrator_service`. Blocked by microservice boundaries that are inactive by default. |
+| **Tavily (WebSearchFallbackNode)** | **DORMANT** | `tavily-python==0.7.24` installed. `TavilyClient` importable. Live search confirmed. Only called from `orchestrator_service/graph/search.py:WebSearchFallbackNode` — DORMANT. `TAVILY_API_KEY` absent from `docker-compose.yml`. Silent skip when key missing. |
+| **Advanced orchestrator StateGraph** | **DORMANT** | 13-node graph compiles and runs in isolation with `OPENROUTER_API_KEY`. NOT on live call chain. Requires full Docker Compose stack. `cognitive_engine.memorize` bug (non-blocking). `FlagEmbeddingReranker` not installed. |
 | **Database** (`app/core/database.py`) | **ACTIVE** | Monolith directly accesses DB via `async_session_factory`. PostgreSQL 17.6 Supabase. PgBouncer transaction mode. |
 | **Cache** (`app/caching/factory.py`) | **ACTIVE (InMemoryCache)** | `REDIS_URL` not set → `get_cache()` returns `InMemoryCache`. Redis process runs on 6379 but unused. |
 | **AI Gateway** (`app/core/gateway/simple_client.py`) | **ACTIVE** | `SimpleAIClient` with OpenRouter. Primary: `nvidia/nemotron-3-super-120b-a12b:free`. 5 fallback models. |
@@ -44,6 +46,17 @@ The system is in a "strangler fig" migration phase from monolith to microservice
 ## Transformation Gap
 To move from "transitional/zombie" to "production-grade multi-service":
 1. **Wake the mesh** — `docker compose -f docker-compose.yml up -d` + set `ORCHESTRATOR_SERVICE_URL`. Prove `compatibility_facade=True` round-trip writes exactly one row per turn. No code change required.
-2. **Fix OTEL** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to a valid collector URL.
-3. **Activate Redis** — set `REDIS_URL=redis://localhost:6379/0`.
-4. **Promote ONE agentic layer** — pick exactly one of (multi-agent workflow, MCP, KAgent, LlamaIndex, reranker, DSPy) and wire it into the live router or a `local_graph` node. Add runtime trace assertion. Update `.memory/runtime_truth.md`.
+2. **Add `TAVILY_API_KEY` to `docker-compose.yml`** — add under `orchestrator-service.environment` and `research-agent.environment`. Key must start with `tvly-`. Currently absent from all env templates.
+3. **Fix OTEL** — set `OTEL_EXPORTER_OTLP_ENDPOINT` to a valid collector URL.
+4. **Activate Redis** — set `REDIS_URL=redis://localhost:6379/0`.
+5. **Fix DuckDuckGo fallback** — install `ddgs` package (`pip install ddgs`) if Tavily-less degraded mode is needed.
+6. **Promote ONE agentic layer** — pick exactly one of (multi-agent workflow, MCP, KAgent, LlamaIndex, reranker, DSPy) and wire it into the live router or a `local_graph` node. Add runtime trace assertion. Update `.memory/runtime_truth.md`.
+
+## Advanced LangGraph + Tavily Revival Checklist (verified 2026-05-09)
+- [ ] Add `TAVILY_API_KEY=${TAVILY_API_KEY:-}` to `docker-compose.yml` (orchestrator-service + research-agent)
+- [ ] `docker compose -f docker-compose.yml up -d orchestrator-service research-agent postgres-orchestrator redis-orchestrator`
+- [ ] Verify `curl http://localhost:8006/health` returns healthy
+- [ ] Verify orchestrator warmup passes (admin tool invocation in lifespan)
+- [ ] Set `ORCHESTRATOR_SERVICE_URL=http://localhost:8006` in monolith env
+- [ ] Send educational query → verify `retrieval_source="web"` in telemetry (not `"web_skipped_missing_tavily"`)
+- [ ] Update `.memory/runtime_truth.md` rows 24, 24a, 24b to ACTIVE

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -1,5 +1,5 @@
 # Architectural Decisions
-> Last updated: 2026-05-05 (environment: GitHub Codespaces)
+> Last updated: 2026-05-09 (environment: GitHub Codespaces — third pass: advanced LangGraph + Tavily investigation)
 
 ## D-001 · LangGraph as Primary Chat Handler
 **Decision**: `app/services/chat/local_graph.py` is the real handler. The orchestrator microservice is DORMANT in the default development environment.
@@ -127,6 +127,26 @@ repeated drift and false claims.
 **Reason**: Zombie metrics (ISS-029) create permanently empty panels that operators cannot distinguish from "system not running". This is worse than no dashboard — it creates false confidence.
 **Consequence**: The LangGraph dashboard (`20-langgraph.json`) has 4 zombie metric panels that must either gain emitters or be removed.
 **Status**: DECIDED 2026-05-09 — see `.memory/fragility-patterns.md` Pattern 4.
+
+## D-018 · Tavily Key Must Be Injected via Environment — Never Hardcoded
+**Decision**: `TAVILY_API_KEY` must be injected at runtime via environment variable. It must never be hardcoded in source files, committed to `.env` files, or embedded in `docker-compose.yml` as a literal value.
+**Reason**: The key is a secret. `docker-compose.yml` uses `${TAVILY_API_KEY:-}` pattern (empty default) so the service starts in degraded mode when the key is absent rather than failing.
+**Key format**: Must start with `tvly-`. MCP URL format (`https://mcp.tavily.com/mcp/?tavilyApiKey=...`) is auto-sanitized by `readiness.py` and `super_search.py` — but the raw key form is preferred.
+**Current state**: `TAVILY_API_KEY` is absent from `docker-compose.yml` (both `orchestrator-service` and `research-agent` environment sections). Must be added before the full stack can use web search.
+**Status**: DECIDED 2026-05-09 — see CLAUDE.md §6.7.
+
+## D-019 · Advanced Orchestrator Graph Uses 4-Intent Taxonomy — Do Not Conflate with Local Graph
+**Decision**: The orchestrator microservice's `SupervisorNode` uses a 4-intent taxonomy: `educational`, `general_knowledge`, `admin`, `chat`. The local `local_graph.py` uses a 3-intent taxonomy: `educational`, `general`, `chat`. These are semantically different and must not be conflated.
+**Reason**: The orchestrator's `general_knowledge` intent routes to `GeneralKnowledgeNode` (a dedicated LLM handler). The local graph's `general` intent routes to the same `chat_node` as `chat`. Merging the taxonomies without a translation layer would break routing in both graphs.
+**Consequence**: Any future work that wires the orchestrator graph into the live path must account for this taxonomy difference. The local graph's intent classification bugs (Arabic greetings → 'general') are separate from the orchestrator's DSPy-based classification.
+**Status**: DECIDED 2026-05-09 — see CLAUDE.md §6.7.
+
+## D-020 · WebSearchFallbackNode Silent Skip Is a Known Degradation — Not a Bug
+**Decision**: `WebSearchFallbackNode` silently returns `{"used_web": False, "reranked_docs": []}` when `TAVILY_API_KEY` is absent. This is intentional degraded-mode behavior, not a bug.
+**Reason**: The node must not block the graph when web search is unavailable. The `SynthesizerNode` handles empty docs by returning `"لا توجد تفاصيل متاحة."`.
+**Risk**: Silent degradation is invisible to operators without telemetry. The telemetry event `retrieval_source="web_skipped_missing_tavily"` is the only signal. Operators must monitor this event to detect key absence.
+**Consequence**: Any dashboard that shows "web search active" must verify against this telemetry event, not just the presence of the `TAVILY_API_KEY` env var.
+**Status**: DECIDED 2026-05-09 — see CLAUDE.md §6.7.
 
 ## D-017 · WS Turn Metrics Must Have a Single Emission Owner
 **Decision**: `ws.chat.turn.duration_seconds`, `ws.chat.terminal_events.total`, and `ws.chat.fallback.total` must be emitted through exactly one path. The designated owner is the OTel SDK path (`path_observer._emit_to_otel`). The redundant `obs.record_metric(...)` calls for the same metric names in `path_observer.py` must be removed to prevent double-counting (ISS-030).

--- a/.memory/progress.md
+++ b/.memory/progress.md
@@ -1,5 +1,59 @@
 # Progress — What Has Been Done
-> Last updated: 2026-05-05
+> Last updated: 2026-05-09
+
+---
+
+## ✅ Session: 2026-05-09 (third pass) — Advanced LangGraph + Tavily Deep Investigation
+
+**Branch**: `docs/advanced-langgraph-tavily-audit-2026-05-09`
+**Mode**: Live runtime investigation + documentation update. No application code changed.
+
+### What Was Investigated (Live Runtime — No Code Changes)
+
+1. **Advanced orchestrator StateGraph (13 nodes)**:
+   - `create_unified_graph()` compiles without error → `CompiledStateGraph` with 13 nodes
+   - `graph.ainvoke(state)` with `OPENROUTER_API_KEY` → valid Arabic response in ~10s (confirmed live)
+   - NOT on live call chain — `ORCHESTRATOR_SERVICE_URL=http://orchestrator-service:8006` → Docker DNS → ConnectError
+   - `cognitive_engine.memorize` bug confirmed: `AttributeError: 'NoneType' object has no attribute 'memorize'` on primary model (non-blocking, fallback models handle)
+   - `FlagEmbeddingReranker` not installed → `RerankerNode` falls back to simple score sort
+   - Postgres checkpointer absent → graph compiled without checkpointer
+   - 4-intent taxonomy: `educational`, `general_knowledge`, `admin`, `chat` (different from local graph's 3-intent)
+   - DSPy usage confirmed: `IntentClassifier`, `QueryRewriterSignature`, `AnalyzeQuery`, `EducationalSynthesizer`
+
+2. **Tavily integration**:
+   - `tavily-python==0.7.24` installed, `TavilyClient` importable
+   - Live search confirmed: `TavilyClient(api_key='tvly-dev-...').search('بكالوريا جزائر رياضيات')` → 2 results in <3s
+   - Key format validation: must start with `tvly-`. MCP URL format auto-sanitized in `readiness.py` and `super_search.py`
+   - `TAVILY_API_KEY` absent from `docker-compose.yml` (both `orchestrator-service` and `research-agent`)
+   - Silent skip confirmed: `WebSearchFallbackNode` returns `{"used_web": False, "reranked_docs": []}` with no exception when key absent
+   - Monolith does NOT use Tavily — `strategy_handlers.py:208` only checks for key as a warning, and `strategy_handlers.py` is on the PARTIAL (loaded-not-invoked) path
+
+3. **DuckDuckGo fallback broken**:
+   - `ddgs` package NOT installed → `ImportError` when `SuperSearchOrchestrator` initializes without Tavily
+   - `DuckDuckGoSearchAPIWrapper` from `langchain_community` requires `ddgs`
+
+4. **`WebSearchFallbackNode` call chain**:
+   - Calls `research_client.deep_research()` → HTTP to `research-agent:8007` → ConnectError (DORMANT)
+   - `research_client` base URL: `http://research-agent:8007` — Docker DNS, not running by default
+
+5. **`TAVILY_API_KEY` in docker-compose.yml**:
+   - Absent from `docker-compose.yml` (current version)
+   - Only present in `docker-compose.legacy.yml:61` as `TAVILY_API_KEY: ${TAVILY_API_KEY:-}`
+   - Must be added to both `orchestrator-service` and `research-agent` environment sections
+
+### Files Updated
+- `CLAUDE.md` — added §6.7 (Advanced LangGraph + Tavily doctrine), updated §6.6 truth table (rows 24, 24a, 24b), updated §10 env vars table
+- `.memory/runtime_truth.md` — rows 24, 24a, 24b added/updated, architectural verdict updated, rules 11–15 added
+- `.memory/architecture_truth.md` — component inventory updated, Transformation Gap updated, revival checklist added
+- `.memory/decisions.md` — D-018, D-019, D-020 added
+- `.memory/tasks.md` — H1–H4 tasks added (revival roadmap)
+- `.memory/progress.md` — this entry
+
+### What Was NOT Changed
+- No application source code (`app/`, `microservices/`, `frontend/`)
+- No test files
+- No CI workflows
+- No runtime behavior
 
 ---
 

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -66,8 +66,10 @@ Missing any of the three → DORMANT, ZOMBIE, or UNKNOWN. Not ACTIVE.
 | 21 | **TLM (Trustworthy LM)** | — | **NOT INSTALLED** | `cleanlab` not installed. No `tlm` package. Zero references to TLM in `app/`. Not part of this codebase. |
 | 22 | **Multi-agent workflow** | `app/services/chat/graph/workflow.py` | **ZOMBIE (compilable, KAgent-blocked)** | `create_multi_agent_graph(ai_client, tools=[])` → `CompiledStateGraph`. Nodes: `['__start__', 'planner', 'researcher', 'writer', 'super_reasoner', 'procedural_auditor', 'reviewer', 'supervisor']`. Invocation → `"⛔ Security Alert: Invalid token from planner_node"` → KAgent security blocks all nodes. Only consumer: `tests/verify_graph_manual.py`. |
 | 23 | **Multi-agent nodes** | `app/services/chat/graph/nodes/` | **ZOMBIE** | `ReviewerNode` importable. `SuperReasonerNode`, `PlannerNode`, `ResearcherNode`, `WriterNode` — class names differ from expected (import fails with wrong name). All blocked by KAgent security in practice. |
-| 24 | **Orchestrator microservice StateGraph** | `microservices/orchestrator_service/src/services/overmind/graph/main.py` | **DORMANT** | `SupervisorNode`, `AgentState`, `IntentClassifier`, `ChatFallbackNode`, `QueryRewriterNode`, `ToolExecutorNode`, `ValidatorNode` all importable. `AgentState` fields: `messages, query, intent, filters, retrieved_docs, reranked_docs, used_web, final_response`. `DecentralizedGraphOrchestrator` in `orchestrator.py`. Not running by default. |
-| 25 | **DSPy in orchestrator** | `microservices/orchestrator_service/src/services/overmind/graph/` | **DORMANT** | `QueryRewriterSignature`, `ChatFallbackSignature` use DSPy. Importable. Not running. |
+| 24 | **Orchestrator microservice StateGraph** | `microservices/orchestrator_service/src/services/overmind/graph/main.py` | **DORMANT** | 13-node graph: `supervisor, query_rewriter, query_analyzer, retriever, reranker, web_fallback, admin_agent, tool_executor, chat_fallback, general_knowledge, synthesizer, validator`. `create_unified_graph()` compiles without error. `graph.ainvoke(state)` with `OPENROUTER_API_KEY` → valid Arabic response in ~10s. NOT on live call chain. Requires `docker compose -f docker-compose.yml up -d`. `cognitive_engine.memorize` bug on primary model (non-blocking). `FlagEmbeddingReranker` not installed → simple sort fallback. Postgres checkpointer absent → compiled without checkpointer. |
+| 24a | **Tavily (WebSearchFallbackNode)** | `microservices/orchestrator_service/src/services/overmind/graph/search.py:WebSearchFallbackNode` | **DORMANT** | `tavily-python==0.7.24` installed. `TavilyClient` importable. Live search confirmed: `TavilyClient(api_key='tvly-dev-...').search('بكالوريا جزائر رياضيات')` → 2 results. Key must start with `tvly-`. MCP URL format auto-sanitized. `TAVILY_API_KEY` absent from `docker-compose.yml`. Silent skip when key missing (`used_web=False`, no exception). Calls `research_client.deep_research()` → HTTP to `research-agent:8007` → ConnectError (DORMANT). |
+| 24b | **SuperSearchOrchestrator** | `microservices/research_agent/src/search_engine/super_search.py` | **DORMANT** | Uses `TavilyClient` when `TAVILY_API_KEY` present (key format `tvly-*`). Falls back to `DuckDuckGoSearchAPIWrapper` when absent — but `ddgs` package NOT installed → `ImportError` on init. `SimpleWebScraper` (httpx + BeautifulSoup) is scraper fallback. Not running. |
+| 25 | **DSPy in orchestrator** | `microservices/orchestrator_service/src/services/overmind/graph/` | **DORMANT** | `IntentClassifier` (4-intent: educational/general_knowledge/admin/chat), `QueryRewriterSignature`, `ChatFallbackSignature`, `AnalyzeQuery`, `EducationalSynthesizer` all use DSPy. Configured via `_configure_dspy()` using `OPENROUTER_API_KEY`. Importable. Not running. |
 | 26 | **Research agent reranker** | `microservices/research_agent/src/search_engine/reranker.py` | **DORMANT** | Importable (without sys.path conflict). Uses `BAAI/bge-reranker-base` (cached). Not running. |
 | 27 | **LlamaIndex driver (app)** | `app/drivers/llamaindex_driver.py` | **ZOMBIE** | Exports `LlamaIndexDriver(RetrievalEngine)`. No `LlamaIndexRetrievalEngine` (wrong import name). No live consumer. |
 | 28 | **Reranker driver (app)** | `app/drivers/reranker_driver.py` | **ZOMBIE** | No `RerankDriver` export (import fails). No live consumer. |
@@ -111,7 +113,7 @@ Server → Client: {"type": "assistant_final",   "payload": {"content": "", "con
 | `'ما هو الذكاء الاصطناعي'` | general | general | ✓ |
 | `'حل لي هذه المسألة في الرياضيات'` | educational | educational | ✓ |
 
-## Architectural verdict (2026-05-09 — second pass)
+## Architectural verdict (2026-05-09 — third pass)
 
 **Live stack (what actually runs on every chat turn):**
 1. FastAPI `customer_chat.py` WS endpoint
@@ -123,15 +125,25 @@ Server → Client: {"type": "assistant_final",   "payload": {"content": "", "con
 7. `save_message(ASSISTANT)` → PostgreSQL (fail-safe write, `persisted=False`)
 
 **What is installed but NOT wired to live path:**
-- DSPy 3.2.1 ✓ installed, ✗ not on live path
+- DSPy 3.2.1 ✓ installed, ✗ not on live path (only in dormant orchestrator microservice)
 - LlamaIndex 0.14.13 ✓ installed, ✗ requires OpenAI key for default embeddings, ✗ not on live path
 - CrossEncoder BAAI/bge-reranker-base ✓ cached, ✗ not on live path
 - KAgent ✓ instantiable, ✗ security-blocked (invalid token), ✗ not on live path
 - MCP ✓ 8 tools callable, ✗ not on live path
-- Multi-agent graph ✓ compiles (8 nodes), ✗ KAgent security blocks all nodes, ✗ not on live path
+- Multi-agent workflow ✓ compiles (8 nodes), ✗ KAgent security blocks all nodes, ✗ not on live path
 - TLM ✗ NOT INSTALLED, ✗ not referenced in codebase
+- **Tavily** ✓ `tavily-python==0.7.24` installed, ✓ live search confirmed, ✗ only called from DORMANT `WebSearchFallbackNode`, ✗ `TAVILY_API_KEY` absent from `docker-compose.yml`
+- **Advanced orchestrator graph (13 nodes)** ✓ compiles, ✓ runs in isolation, ✗ NOT on live call chain, ✗ requires full Docker Compose stack
+- **DuckDuckGo fallback** ✗ `ddgs` package NOT installed → `ImportError` if Tavily absent and orchestrator running
 
 **Project = ~15% live, ~85% scaffolding in default Codespaces.**
+
+**Advanced stack revival requires (in order):**
+1. Add `TAVILY_API_KEY` to `docker-compose.yml` (orchestrator-service + research-agent)
+2. `docker compose -f docker-compose.yml up -d` (orchestrator-service, research-agent, postgres-orchestrator, redis-orchestrator)
+3. Set `ORCHESTRATOR_SERVICE_URL=http://localhost:8006` in monolith (or use Docker network)
+4. Verify orchestrator warmup passes (admin tool invocation in lifespan)
+5. Update this file: promote orchestrator StateGraph and Tavily to ACTIVE
 
 ---
 
@@ -140,9 +152,14 @@ Server → Client: {"type": "assistant_final",   "payload": {"content": "", "con
 2. WS auth: `subprotocols=['jwt', TOKEN]`.
 3. `OTEL_EXPORTER_OTLP_ENDPOINT=http` is invalid — OTEL is a no-op.
 4. `REDIS_URL` not set — cache is InMemoryCache.
-5. `ORCHESTRATOR_SERVICE_URL=http://orchestrator-service:8006` — Docker DNS, always ConnectError.
+5. `ORCHESTRATOR_SERVICE_URL=http://orchestrator-service:8006` — Docker DNS, always ConnectError in default Codespaces.
 6. KAgent security blocks all calls without a valid internal token — multi-agent graph cannot run.
 7. LlamaIndex requires `OPENAI_API_KEY` for default embeddings — use HuggingFace explicitly.
 8. TLM is NOT part of this codebase.
 9. Grafana is on port 3001 (not 3000).
 10. FastAPI version: `v4.1-root`.
+11. **Tavily**: `tavily-python==0.7.24` installed, `TavilyClient` importable, live search confirmed. Key must start with `tvly-`. NOT on live call chain — only in DORMANT `WebSearchFallbackNode`. `TAVILY_API_KEY` absent from `docker-compose.yml`.
+12. **Advanced orchestrator graph**: 13 nodes, compiles and runs in isolation with `OPENROUTER_API_KEY`. NOT on live call chain. `cognitive_engine.memorize` bug on primary model (non-blocking). `FlagEmbeddingReranker` not installed. Postgres checkpointer absent.
+13. **DuckDuckGo fallback broken**: `ddgs` package not installed. If Tavily absent and orchestrator running, `SuperSearchOrchestrator` raises `ImportError`.
+14. **`TAVILY_API_KEY` absent from `docker-compose.yml`**: must be added to both `orchestrator-service` and `research-agent` environment sections before the full stack can use web search.
+15. The advanced orchestrator graph uses a **4-intent taxonomy** (educational/general_knowledge/admin/chat) — different from the local `local_graph.py` 3-intent taxonomy (educational/general/chat). Do not conflate them.

--- a/.memory/tasks.md
+++ b/.memory/tasks.md
@@ -1,6 +1,42 @@
 # Tasks — What Comes Next
-> Last updated: 2026-05-09 | Branch: `claude/architecture-rescue-diagnostic-wUfbE` (third audit) + enrichment session 2026-05-09.
+> Last updated: 2026-05-09 | Branch: `docs/advanced-langgraph-tavily-audit-2026-05-09` (fourth pass: advanced LangGraph + Tavily deep investigation).
 > Priority: 🔴 Critical → 🟡 Medium → 🟢 Nice-to-have
+
+---
+
+## 🟡 Medium — Advanced LangGraph + Tavily Revival (NEW — Session 2026-05-09 third pass)
+
+### H1 — Add `TAVILY_API_KEY` to `docker-compose.yml` (ISS-032)
+**Scope**: `docker-compose.yml` only — no application code changes.
+1. Add `- TAVILY_API_KEY=${TAVILY_API_KEY:-}` under `orchestrator-service.environment`.
+2. Add `- TAVILY_API_KEY=${TAVILY_API_KEY:-}` under `research-agent.environment`.
+3. Add `TAVILY_API_KEY=` (empty) to `.env.security.example` with a comment explaining the format (`tvly-*`).
+4. Verify: `docker compose config` shows the variable in both services.
+**Why**: `TAVILY_API_KEY` is currently absent from `docker-compose.yml`. `WebSearchFallbackNode` silently skips web search when the key is missing. This is the minimum change to enable Tavily when the full stack is running.
+**ADR needed**: No — this is a configuration addition, not an architectural decision.
+
+### H2 — Fix DuckDuckGo Fallback (ISS-033)
+**Scope**: `requirements.txt` for `research-agent` microservice.
+1. Add `ddgs>=6.0` to `microservices/research_agent/requirements.txt`.
+2. Verify: `SuperSearchOrchestrator()` initializes without `ImportError` when `TAVILY_API_KEY` is absent.
+3. Add a test: `test_super_search_no_tavily.py` — assert `search_tool` is `DuckDuckGoSearchAPIWrapper` when key absent.
+**Why**: `ddgs` package not installed → `ImportError` when `SuperSearchOrchestrator` initializes without Tavily. This breaks the degraded-mode fallback.
+
+### H3 — Fix `cognitive_engine.memorize` Bug in Orchestrator Gateway (ISS-034)
+**Scope**: `microservices/orchestrator_service/src/core/gateway/simple_client.py:116`.
+**Bug**: `self.cognitive_engine.memorize(...)` raises `AttributeError: 'NoneType' object has no attribute 'memorize'` when `cognitive_engine` is `None`.
+**Fix**: Guard with `if self.cognitive_engine is not None:` before the call.
+**Impact**: Non-blocking (fallback models handle the turn), but generates noisy tracebacks in logs.
+**ADR needed**: No — defensive null check.
+
+### H4 — Verify Orchestrator Warmup After Stack Activation (ISS-035)
+**Scope**: Integration test only — no code changes.
+After running `docker compose -f docker-compose.yml up -d`:
+1. `curl http://localhost:8006/health` → must return `{"status": "ok"}`.
+2. Send WS message to monolith → verify `persisted: true` event reaches client (orchestrator persisted, monolith skipped fail-safe write).
+3. Check DB: exactly one row in `customer_messages` for the turn (no dual-write).
+4. Check telemetry: `retrieval_source` is `"internal_exact"` or `"web"` (not `"web_skipped_missing_tavily"`).
+**Why**: Validates the full revival path end-to-end before updating `.memory/runtime_truth.md` to ACTIVE.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,8 +285,10 @@ Typical latency: 6–18s (OpenRouter free tier). `persisted` event only when orc
 | **MCP server (8 tools)** | **DORMANT (instantiable, not wired)** | `MCPServer().initialize()` → OK. `get_tools_for_llm()` → 8 tools. `call_tool('get_project_metrics')` → works. Zero imports from live path. |
 | **TLM (Trustworthy LM)** | **NOT INSTALLED** | `cleanlab` not installed. Zero references in `app/`. Not part of this codebase. |
 | **Multi-agent workflow** (8 nodes) | **ZOMBIE (KAgent-blocked)** | `create_multi_agent_graph(ai_client, tools=[])` compiles. Nodes: `planner, researcher, writer, super_reasoner, procedural_auditor, reviewer, supervisor`. Invocation → `"⛔ Security Alert: Invalid token from planner_node"`. Only consumer: `tests/verify_graph_manual.py`. |
-| **Orchestrator microservice StateGraph** | **DORMANT** | `SupervisorNode`, `AgentState`, `IntentClassifier`, `ChatFallbackNode`, `QueryRewriterNode`, `ToolExecutorNode`, `ValidatorNode` importable. `AgentState` fields: `messages, query, intent, filters, retrieved_docs, reranked_docs, used_web, final_response`. Not running. |
-| **DSPy in orchestrator** | **DORMANT** | `QueryRewriterSignature`, `ChatFallbackSignature` use DSPy. Importable. Not running. |
+| **Orchestrator microservice StateGraph** | **DORMANT** | 13-node graph: `supervisor, query_rewriter, query_analyzer, retriever, reranker, web_fallback, admin_agent, tool_executor, chat_fallback, general_knowledge, synthesizer, validator`. Compiles and runs in isolation with `OPENROUTER_API_KEY`. NOT on live call chain — requires `docker compose -f docker-compose.yml up -d`. `cognitive_engine.memorize` bug on primary model (non-blocking, fallback models handle). |
+| **Tavily (WebSearchFallbackNode)** | **DORMANT** | `tavily-python==0.7.24` installed. `TavilyClient` importable. Live search confirmed (2 results for BAC query). Only called from `orchestrator_service/src/services/overmind/graph/search.py:WebSearchFallbackNode` — which is DORMANT. `TAVILY_API_KEY` absent from `docker-compose.yml`. Silent skip when key missing. |
+| **DSPy in orchestrator** | **DORMANT** | `QueryRewriterSignature`, `ChatFallbackSignature`, `IntentClassifier`, `AnalyzeQuery`, `EducationalSynthesizer` use DSPy. Importable. Not running. |
+| **Research agent / SuperSearchOrchestrator** | **DORMANT** | `super_search.py` uses `TavilyClient` when key present, `DuckDuckGoSearchAPIWrapper` otherwise. `ddgs` package NOT installed — DuckDuckGo fallback broken. Not running. |
 | **Research agent reranker** | **DORMANT** | `microservices/research_agent/src/search_engine/reranker.py` importable. Uses cached `BAAI/bge-reranker-base`. Not running. |
 | **UnifiedObservabilityService** | **ACTIVE** | Every HTTP request traced. WS frames NOT traced per-frame (ISS-005). |
 | **OTEL SDK** | **ACTIVE (no-op)** | `OTEL_EXPORTER_OTLP_ENDPOINT=http` (invalid URL) → no spans exported. |
@@ -302,6 +304,9 @@ Typical latency: 6–18s (OpenRouter free tier). `persisted` event only when orc
 5. **TLM is not part of this codebase** — do not reference it.
 6. **WS payload key is `question`** — not `content`, not `message`. Wrong key → `"Question is required."` error.
 7. **Intent classification has bugs**: Arabic greetings ('مرحبا') → 'general' (should be 'chat'). English 'hello' → 'chat' (should be 'general').
+8. **The advanced orchestrator graph (13 nodes) is DORMANT** — it compiles and runs in isolation but requires the full Docker Compose stack. See §6.7 for the complete revival roadmap.
+9. **Tavily is installed and works** — but is only called from the DORMANT `WebSearchFallbackNode` inside the orchestrator microservice. The monolith fallback chain has no web search step. `TAVILY_API_KEY` is absent from `docker-compose.yml` and must be added before the full stack can use it.
+10. **DuckDuckGo fallback is broken** — `ddgs` package not installed. If Tavily key is absent and the orchestrator is running, `SuperSearchOrchestrator` will raise `ImportError` on initialization.
 
 ### First-check protocol before any change to the chat / agent stack
 
@@ -317,6 +322,146 @@ Typical latency: 6–18s (OpenRouter free tier). `persisted` event only when orc
 
 ---
 
+## 6.7 Advanced LangGraph (Microservices) and Tavily — Verified Runtime Doctrine
+
+> **Last verified: 2026-05-09 — live runtime investigation (third pass).**
+> Authority: this section overrides any aspirational description in `docs/`, `LangGraph_Architectural_Blueprint.md`, or `ARCHITECTURE.md`.
+
+### Advanced LangGraph (Orchestrator Microservice StateGraph)
+
+**Status: DORMANT** — code is real, compilable, and partially runnable in isolation, but NOT on the live call chain in the default Codespaces environment.
+
+**What was verified live (2026-05-09):**
+
+| Fact | Evidence |
+|---|---|
+| Graph compiles without error | `create_unified_graph()` → `CompiledStateGraph` with 13 nodes |
+| Graph runs in isolation | `graph.ainvoke(state)` with `OPENROUTER_API_KEY` set → valid Arabic response in ~10s |
+| Graph is NOT on the live call chain | `ORCHESTRATOR_SERVICE_URL=http://orchestrator-service:8006` → Docker DNS → ConnectError. Monolith falls through to `local_graph.py` (2-node fallback). |
+| Orchestrator service is NOT started by default | `.devcontainer/docker-compose.host.yml` starts only the `web` container. Full stack requires `docker compose -f docker-compose.yml up -d`. |
+| `cognitive_engine.memorize` bug | `orchestrator_service/src/core/gateway/simple_client.py:116` raises `AttributeError: 'NoneType' object has no attribute 'memorize'` on primary model. Fallback models handle the turn. Non-blocking. |
+| FlagEmbeddingReranker not installed | `RerankerNode` falls back to simple score sort. `cross-encoder/ms-marco-MiniLM-L-6-v2` not cached. |
+| Postgres checkpointer absent | `get_checkpointer()` returns `None` → graph compiled without checkpointer. State continuity relies on injected history. |
+
+**13-node graph topology (orchestrator microservice):**
+```
+supervisor → [intent routing]
+  educational → query_rewriter → query_analyzer → retriever → reranker
+                  → [check_results] → synthesizer | web_fallback → synthesizer
+  admin       → admin_agent → validator
+  chat        → chat_fallback → validator
+  general_knowledge → general_knowledge → validator
+  tool        → tool_executor → validator
+validator → [check_quality] → END | supervisor (retry)
+```
+
+**DSPy usage inside the advanced graph:**
+- `SupervisorNode` uses `dspy.ChainOfThought(IntentClassifier)` — 4-intent taxonomy: `educational`, `general_knowledge`, `admin`, `chat`
+- `QueryRewriterNode` uses `dspy.ChainOfThought(QueryRewriterSignature)` — pronoun resolution
+- `QueryAnalyzerNode` uses `dspy.Predict(AnalyzeQuery)` — BAC filter extraction
+- `SynthesizerNode` uses `dspy.Predict(EducationalSynthesizer)` — response synthesis
+- All DSPy calls require `OPENROUTER_API_KEY` and are configured via `_configure_dspy()` at graph startup
+
+**`WebSearchFallbackNode` behavior (search.py):**
+- Triggered only when `reranked_docs` is empty AND intent is `educational`
+- Reads `TAVILY_API_KEY` from environment at call time (not at import time)
+- If key absent → **silent skip**: `used_web=False`, `reranked_docs=[]`, no exception raised
+- If key present → calls `research_client.deep_research()` → HTTP to `research-agent:8007` → ConnectError (DORMANT)
+- The `research_client` base URL is `http://research-agent:8007` — Docker DNS, not running by default
+
+**Revival prerequisites for the advanced LangGraph:**
+1. `docker compose -f docker-compose.yml up -d` — starts orchestrator-service (port 8006), research-agent (port 8007), postgres-orchestrator, redis-orchestrator
+2. `OPENROUTER_API_KEY` must be set in the orchestrator container environment
+3. `ORCHESTRATOR_DATABASE_URL` must point to `postgres-orchestrator:5432/orchestrator_db`
+4. `TAVILY_API_KEY` must be added to `docker-compose.yml` under `orchestrator-service` and `research-agent` environment sections (currently absent)
+5. `ORCHESTRATOR_SERVICE_URL` in the monolith must resolve to the running container (already set to `http://orchestrator-service:8006` — works when Docker network is up)
+6. Warmup check in `main.py` lifespan must pass: `admin_graph.ainvoke({"query": "كم عدد ملفات بايثون"})` must return `tool_name` in `final_response`
+
+---
+
+### Tavily Integration
+
+**Status: DORMANT** — package installed, key validated live, but NOT on the live call chain in the default environment.
+
+**What was verified live (2026-05-09):**
+
+| Fact | Evidence |
+|---|---|
+| `tavily-python==0.7.24` installed | `pip show tavily-python` confirmed |
+| `TavilyClient` importable | `from tavily import TavilyClient` → OK |
+| Live search works with provided key | `TavilyClient(api_key='tvly-dev-...').search(query='بكالوريا جزائر رياضيات')` → 2 results in <3s |
+| Key format validation | Must start with `tvly-`. MCP URL format (`https://mcp.tavily.com/mcp/?tavilyApiKey=...`) is auto-sanitized in `readiness.py` and `super_search.py` |
+| `TAVILY_API_KEY` NOT in `docker-compose.yml` | Neither `orchestrator-service` nor `research-agent` environment sections include it. Must be added manually. |
+| `TAVILY_API_KEY` NOT in `.env.docker` or `.env.security.example` | Absent from all env templates. Only referenced in `docker-compose.legacy.yml`. |
+| Monolith does NOT use Tavily | `app/` has one reference: `strategy_handlers.py:208` checks for the key as a warning only. `strategy_handlers.py` is on the `ChatOrchestrator` path which is PARTIAL (loaded-not-invoked). |
+| Silent skip when key absent | `WebSearchFallbackNode.__call__` returns `{"used_web": False, "reranked_docs": []}` with no exception when `TAVILY_API_KEY` is empty |
+| DuckDuckGo fallback broken | `SuperSearchOrchestrator` falls back to `DuckDuckGoSearchAPIWrapper` when Tavily absent, but `ddgs` package not installed → `ImportError` |
+
+**Tavily call chain (when microservices are running):**
+```
+orchestrator-service: WebSearchFallbackNode (search.py:300)
+  → os.environ.get("TAVILY_API_KEY")
+  → research_client.deep_research(query)  [HTTP to research-agent:8007]
+    → research-agent: SuperSearchOrchestrator (super_search.py)
+      → TavilyClient(api_key=key).search(query, search_depth="basic", max_results=3)
+      → parallel scraping → synthesis via LLM
+```
+
+**Tavily is NOT used in the monolith fallback chain.** The 4-tier fallback in `OrchestratorClient` (`local_graph.py`) has no web search step. Web search only exists in the orchestrator microservice's `WebSearchFallbackNode`.
+
+**Revival prerequisites for Tavily:**
+1. Advanced LangGraph (orchestrator microservice) must be running — see above
+2. `TAVILY_API_KEY=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` (or production key) must be added to `docker-compose.yml` under both `orchestrator-service` and `research-agent`
+3. `research-agent` service must be running (port 8007) — it is the actual Tavily caller
+4. `ddgs` package must be installed if DuckDuckGo fallback is needed: `pip install ddgs`
+5. `FIRECRAWL_API_KEY` is optional — `SimpleWebScraper` (httpx + BeautifulSoup) is the fallback scraper
+
+**Degradation behavior (no Tavily key):**
+- `WebSearchFallbackNode` → silent skip → `SynthesizerNode` receives empty docs → response: `"لا توجد تفاصيل متاحة."` (schema-locked JSON)
+- No exception, no log at ERROR level — only a telemetry event with `retrieval_source="web_skipped_missing_tavily"`
+- This is a **silent degradation** — operators cannot distinguish "no BAC content found" from "web search skipped" without checking telemetry
+
+---
+
+### Revival Roadmap (Documentation Only — Do Not Implement)
+
+To bring the advanced LangGraph + Tavily stack to ACTIVE status:
+
+**Step 1 — Add `TAVILY_API_KEY` to `docker-compose.yml`**
+Add under `orchestrator-service.environment` and `research-agent.environment`:
+```yaml
+- TAVILY_API_KEY=${TAVILY_API_KEY:-}
+```
+
+**Step 2 — Start the full microservices stack**
+```bash
+export OPENROUTER_API_KEY=<key>
+export TAVILY_API_KEY=<key>
+docker compose -f docker-compose.yml up -d orchestrator-service research-agent postgres-orchestrator redis-orchestrator
+```
+
+**Step 3 — Verify orchestrator health**
+```bash
+curl http://localhost:8006/health
+# Expected: {"status": "ok", "graph": "ready", "tools": [...]}
+```
+
+**Step 4 — Verify the monolith routes to orchestrator**
+Set `ORCHESTRATOR_SERVICE_URL=http://localhost:8006` in the monolith environment (or `http://orchestrator-service:8006` if on the same Docker network). The fallback chain will then reach the orchestrator before falling through to `local_graph.py`.
+
+**Step 5 — Verify Tavily is active**
+Send an educational query that has no BAC content match. Check telemetry for `retrieval_source="web"` (not `"web_skipped_missing_tavily"`).
+
+**Step 6 — Update `.memory/runtime_truth.md`**
+Add rows for `orchestrator-service StateGraph` (ACTIVE), `Tavily` (ACTIVE), `WebSearchFallbackNode` (ACTIVE). Update the architectural verdict.
+
+**Architectural boundaries that must be respected:**
+- The monolith (`app/`) must never import from `microservices/` — communication is HTTP only
+- `research_client` in the orchestrator calls `research-agent:8007` via HTTP — never direct DB access
+- `TAVILY_API_KEY` must be injected via environment, never hardcoded
+- The `persisted: true` flag protocol (D-006) applies when the orchestrator is active — the monolith must still own the persistence decision
+
+---
 
 ## 7. Testing
 
@@ -381,6 +526,7 @@ Sourced from Codespaces secrets and forwarded via `.devcontainer/devcontainer.js
 | `ENVIRONMENT` | ✅ `development` | Controls dev behavior |
 | `ORCHESTRATOR_SERVICE_URL` | ❌ Not set | Defaults to Docker DNS — always fails in Codespaces default setup |
 | `REDIS_URL` | ❌ Not set | Redis not started by devcontainer — cache falls back to memory |
+| `TAVILY_API_KEY` | ❌ Not set (monolith) | Required by `WebSearchFallbackNode` in orchestrator microservice. Absent from `docker-compose.yml`. Silent skip when missing. Key must start with `tvly-`. |
 | `OPENROUTER_SITE_URL` | ⚠️ Optional | Set this to your Codespaces URL if OpenRouter rejects with `Host not in allowlist` |
 
 ---


### PR DESCRIPTION
## What

Live runtime investigation of the orchestrator microservice StateGraph (advanced LangGraph) and Tavily integration. Documentation and memory update only — no application code changed.

## Why

The repository's `.memory/` and `CLAUDE.md` lacked verified runtime truth for two key components: the 13-node orchestrator StateGraph and Tavily web search. Previous sessions documented them as DORMANT without live evidence. This session provides that evidence and encodes a durable revival roadmap.

## Verified Findings (live runtime — 2026-05-09)

### Advanced LangGraph (Orchestrator Microservice)
- **Status: DORMANT** — compiles and runs in isolation, NOT on live call chain
- `create_unified_graph()` → `CompiledStateGraph` with 13 nodes (confirmed live)
- `graph.ainvoke(state)` with `OPENROUTER_API_KEY` → valid Arabic response in ~10s (confirmed live)
- Blocked by Docker DNS: `orchestrator-service:8006` → ConnectError in default Codespaces
- `cognitive_engine.memorize` bug on primary model (non-blocking, fallback models handle)
- `FlagEmbeddingReranker` not installed → simple sort fallback in `RerankerNode`
- Postgres checkpointer absent → compiled without checkpointer
- Uses 4-intent taxonomy: `educational`, `general_knowledge`, `admin`, `chat` (different from local graph's 3-intent)
- DSPy usage confirmed: `IntentClassifier`, `QueryRewriterSignature`, `AnalyzeQuery`, `EducationalSynthesizer`

### Tavily
- **Status: DORMANT** — package installed, live search confirmed, NOT on live call chain
- `tavily-python==0.7.24` installed, `TavilyClient` importable
- Live search confirmed: 2 results for BAC query in <3s
- `TAVILY_API_KEY` absent from `docker-compose.yml` (both `orchestrator-service` and `research-agent`)
- Silent skip when key missing: `WebSearchFallbackNode` returns `{"used_web": False}` with no exception
- Monolith does NOT use Tavily — `strategy_handlers.py` check is warning-only on a PARTIAL path
- DuckDuckGo fallback broken: `ddgs` package not installed → `ImportError`

## Files Changed

| File | Change |
|---|---|
| `CLAUDE.md` | Added §6.7 (Advanced LangGraph + Tavily doctrine), updated §6.6 truth table (rows 24/24a/24b), §10 env vars |
| `.memory/runtime_truth.md` | Rows 24/24a/24b added, architectural verdict updated, rules 11–15 added |
| `.memory/architecture_truth.md` | Component inventory updated, revival checklist added |
| `.memory/decisions.md` | D-018 (Tavily key injection), D-019 (4-intent taxonomy), D-020 (silent skip doctrine) |
| `.memory/tasks.md` | H1–H4 revival roadmap tasks |
| `.memory/progress.md` | Session record |

## Revival Roadmap (documentation only — not implemented)

1. Add `TAVILY_API_KEY=${TAVILY_API_KEY:-}` to `docker-compose.yml` (orchestrator-service + research-agent)
2. `docker compose -f docker-compose.yml up -d orchestrator-service research-agent postgres-orchestrator redis-orchestrator`
3. Verify orchestrator warmup passes
4. Set `ORCHESTRATOR_SERVICE_URL=http://localhost:8006` in monolith env
5. Verify `retrieval_source="web"` in telemetry (not `"web_skipped_missing_tavily"`)
6. Update `.memory/runtime_truth.md` rows 24/24a/24b to ACTIVE