### PR TITLE
fix(supervisor+frontend): all ports dead after commit 3fd7824 — ISS-037 + ISS-036

### DIFF
--- a/.devcontainer/secrets.env.example
+++ b/.devcontainer/secrets.env.example
@@ -1,0 +1,21 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# secrets.env.example — Codespaces local secrets fallback
+#
+# Copy this file to .devcontainer/secrets.env and fill in real values.
+# secrets.env is git-ignored and never committed.
+#
+# When to use this file:
+#   - You are running in GitHub Codespaces but have NOT configured Codespaces
+#     Secrets in your GitHub account settings.
+#   - supervisor.sh reads this file BEFORE falling back to SQLite.
+#
+# Preferred alternative: configure Codespaces Secrets at
+#   https://github.com/settings/codespaces
+#   and add: APP_DATABASE_URL, OPENROUTER_API_KEY, SECRET_KEY
+# ─────────────────────────────────────────────────────────────────────────────
+
+APP_DATABASE_URL=postgresql://user:password@host:6543/dbname?sslmode=require
+DATABASE_URL=postgresql://user:password@host:6543/dbname?sslmode=require
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+SECRET_KEY=your-secret-key-min-32-chars-here
+ENVIRONMENT=development

--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -79,17 +79,37 @@ fi
 # ── ENV INJECTION ─────────────────────────────────────────────────────────────
 # Priority order (highest → lowest):
 #   1. Process environment (injected by devcontainer.json remoteEnv / Gitpod secrets)
-#   2. Existing .env file values (preserved if already set)
-#   3. Safe development defaults (sqlite only in TESTING=1 mode)
+#   2. .devcontainer/secrets.env  ← local fallback, git-ignored, never committed
+#   3. Existing .env file values (preserved if already set)
+#   4. Safe development defaults (sqlite only in TESTING=1 mode)
 #
 # CRITICAL: DATABASE_URL=sqlite in ENVIRONMENT=development causes AppSettings to
 # raise a ValidationError and crash uvicorn on import. We must inject the real
 # DATABASE_URL from the process environment before uvicorn starts.
+#
+# HOW TO USE secrets.env (Codespaces without Secrets configured):
+#   cp .devcontainer/secrets.env.example .devcontainer/secrets.env
+#   # fill in real values — this file is git-ignored
 # ──────────────────────────────────────────────────────────────────────────────
 
 _inject_env_secrets() {
     local env_file=".env"
     local changed=0
+
+    # ── Load .devcontainer/secrets.env as fallback when Codespaces Secrets absent ──
+    # This file is git-ignored. It lets developers run without configuring
+    # Codespaces Secrets — just copy secrets.env.example and fill in values.
+    local secrets_file="$SCRIPT_DIR/secrets.env"
+    if [ -f "$secrets_file" ]; then
+        lifecycle_info "Loading fallback secrets from .devcontainer/secrets.env..."
+        while IFS='=' read -r key val; do
+            [[ "$key" =~ ^#.*$ || -z "$key" ]] && continue
+            if [ -z "${!key:-}" ]; then
+                export "$key=$val"
+                lifecycle_info "  secrets.env -> $key injected"
+            fi
+        done < "$secrets_file"
+    fi
 
     # Resolve the real DATABASE_URL: prefer APP_DATABASE_URL, then DATABASE_URL
     local real_db_url="${APP_DATABASE_URL:-${DATABASE_URL:-}}"
@@ -333,7 +353,6 @@ if _uvicorn_healthy; then
     lifecycle_release_lock "uvicorn_launch"
 else
     # Kill any stale uvicorn process that is alive but not serving
-    local stale_pid
     stale_pid=$(lifecycle_get_state "uvicorn_pid" 2>/dev/null || true)
     if [ -n "$stale_pid" ] && kill -0 "$stale_pid" 2>/dev/null; then
         lifecycle_warn "Killing stale uvicorn (PID $stale_pid — alive but not serving)"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # 1. Environment & Secrets
 # Never commit secrets, keys, passwords, or local environment settings!
 .env
+.devcontainer/secrets.env
 .venv
 venv/
 ENV/

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -96,6 +96,29 @@ Missing any one → DORMANT, ZOMBIE, or UNKNOWN. No exceptions.
 
 ---
 
+## Supervisor crash — `local` outside function (ISS-037 — RESOLVED 2026-05-09)
+
+**Symptom**: After merging commit `3fd78247`, ALL ports dead (3000, 8000, 3001, 9090). Supervisor log shows:
+```
+/app/.devcontainer/supervisor.sh: line 336: local: can only be used in a function
+[ERROR] Supervisor failed at line 336
+```
+
+**Root cause**: commit `3fd78247` added `local stale_pid` at top-level scope in `supervisor.sh` (inside an `if/else` block but outside any `function`). bash rejects `local` outside functions → supervisor exits at Step 4 → uvicorn never starts → all ports dead.
+
+**Fix applied** (`.devcontainer/supervisor.sh`):
+- `local stale_pid` → `stale_pid` (removed `local` keyword — variable is already in a subshell context)
+
+**Additional fix**: Added `.devcontainer/secrets.env` fallback read at the top of `_inject_env_secrets()`. When Codespaces Secrets are not configured, supervisor now reads credentials from this git-ignored file instead of falling back to SQLite. Template at `.devcontainer/secrets.env.example`.
+
+**Verified live** (2026-05-09):
+- Supervisor runs to completion: `✅ Backend is healthy and ready!`
+- `GET /health → {"application":"ok","database":"ok","version":"v4.1-root"}`
+- `GET http://localhost:3000/ → HTTP 200`
+- No `local: can only be used in a function` error
+
+---
+
 ## Codespaces Next.js proxy fix (ISS-036 — RESOLVED 2026-05-09)
 
 **Symptom**: Port 3000 in GitHub Codespaces returns `ERR_HTTP_RESPONSE_CODE_FAILURE` even when Next.js is running and responding 200 on localhost.
@@ -163,3 +186,5 @@ Missing any one → DORMANT, ZOMBIE, or UNKNOWN. No exceptions.
 13. **LangGraph metrics now ACTIVE for local graph.** `cogniforge_langgraph_intent_total`, `cogniforge_langgraph_node_count_total`, `cogniforge_langgraph_node_duration_seconds_bucket` emitted per WS turn.
 14. **Lock file staleness is a finding.** Always check `generated_at_utc` in `.runtime/truth_table.lock.json` before trusting it.
 15. **`allowedDevOrigins` must include all hosting environments.** Next.js 15+ rejects dev-server requests from unlisted origins. Always include `*.app.github.dev` (Codespaces), `*.replit.dev` (Replit), and `*.gitpod.io` (Gitpod/Ona) in `frontend/next.config.js`.
+16. **`local` is illegal outside bash functions.** Using `local var` in top-level script scope (even inside `if/else`) causes bash to abort with `local: can only be used in a function`. In `supervisor.sh`, any variable at top-level must use plain assignment (`var=value`). This was the root cause of ISS-037 (commit `3fd78247`) — all ports dead after merge.
+17. **`.devcontainer/secrets.env` is the Codespaces fallback.** When Codespaces Secrets are not configured, `supervisor.sh` reads `.devcontainer/secrets.env` (git-ignored) before falling back to SQLite. Copy `.devcontainer/secrets.env.example` and fill in real values. Never commit `secrets.env`.

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -1,5 +1,5 @@
 # Runtime Truth Lock
-> Last updated: **2026-05-09** | Branch: `fix/lifespan-orchestration-env-injection`
+> Last updated: **2026-05-09** | Branch: `fix/codespaces-port-3000-allowed-origins`
 > Authority: this file overrides any contradictory aspirational doc in `docs/` or root markdown.
 
 ## Golden rule
@@ -22,11 +22,11 @@ Missing any one → DORMANT, ZOMBIE, or UNKNOWN. No exceptions.
 
 ---
 
-## Infrastructure truth (verified live 2026-05-09 — fifth pass)
+## Infrastructure truth (verified live 2026-05-09 — sixth pass)
 
 | Service | Port | Status | Evidence |
 |---------|------|--------|---------|
-| **Next.js** | **3000** | **ACTIVE** | supervisor.sh `--port 3000` overrides package.json `--port 5000`. HTML confirmed. |
+| **Next.js** | **3000** | **ACTIVE** | supervisor.sh `--port 3000` overrides package.json `--port 5000`. HTML 200 confirmed. `allowedDevOrigins` now includes `*.app.github.dev` — Codespaces proxy returns 200 (was ERR_HTTP_RESPONSE_CODE_FAILURE before ISS-036 fix). |
 | **FastAPI** | **8000** | **ACTIVE** | `GET /health → {"application":"ok","database":"ok"}`. Requires DATABASE_URL in **process env** (not just .env). |
 | **Grafana** | **3001** | **ACTIVE** | `GET /api/health → {"database":"ok"}`. 5 dashboards. Prometheus datasource UP. |
 | **Prometheus** | **9090** | **ACTIVE** | `GET /-/healthy → Healthy`. 3 targets UP: fastapi, grafana, prometheus. |
@@ -96,7 +96,24 @@ Missing any one → DORMANT, ZOMBIE, or UNKNOWN. No exceptions.
 
 ---
 
-## Full capability truth table (2026-05-09 — fifth pass)
+## Codespaces Next.js proxy fix (ISS-036 — RESOLVED 2026-05-09)
+
+**Symptom**: Port 3000 in GitHub Codespaces returns `ERR_HTTP_RESPONSE_CODE_FAILURE` even when Next.js is running and responding 200 on localhost.
+
+**Root cause**: `frontend/next.config.js` `allowedDevOrigins` listed only Replit domains. Next.js 15+ enforces origin validation on the dev server — requests proxied through `*.app.github.dev` (Codespaces tunnel) were rejected at the framework level before reaching any route handler.
+
+**Fix applied** (`frontend/next.config.js`):
+- Added `*.app.github.dev` and `*.preview.app.github.dev` to `allowedDevOrigins`.
+- Added `*.gitpod.io` and `*.ws-eu*.gitpod.io` for Gitpod/Ona environments.
+
+**Verified live**:
+- `curl -s http://localhost:3000/ → HTTP 200`
+- `curl -H "Origin: https://didactic-giggle-7vwwj76p66vfrjg4-3000.app.github.dev" http://localhost:3000/ → HTTP 200`
+- FastAPI: `GET /health → {"application":"ok","database":"ok","version":"v4.1-root"}`
+
+---
+
+## Full capability truth table (2026-05-09 — sixth pass)
 
 | # | Component | File | Status | Evidence |
 |---|-----------|------|--------|---------|
@@ -145,3 +162,4 @@ Missing any one → DORMANT, ZOMBIE, or UNKNOWN. No exceptions.
 12. **thread_id namespaces incompatible.** Local graph: `str(conversation_id)`. Orchestrator: `f"u{user_id}:c{conversation_id}"`. Never mix.
 13. **LangGraph metrics now ACTIVE for local graph.** `cogniforge_langgraph_intent_total`, `cogniforge_langgraph_node_count_total`, `cogniforge_langgraph_node_duration_seconds_bucket` emitted per WS turn.
 14. **Lock file staleness is a finding.** Always check `generated_at_utc` in `.runtime/truth_table.lock.json` before trusting it.
+15. **`allowedDevOrigins` must include all hosting environments.** Next.js 15+ rejects dev-server requests from unlisted origins. Always include `*.app.github.dev` (Codespaces), `*.replit.dev` (Replit), and `*.gitpod.io` (Gitpod/Ona) in `frontend/next.config.js`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ In both environments the backend is on **8000** and microservices in `microservi
 - Prometheus: port **9090** (`GET /-/healthy → "Prometheus Server is Healthy."`)
 - Redis: port **6379** (process running but app uses `InMemoryCache` — `REDIS_URL` not set)
 
+**Known fix applied 2026-05-09 (ISS-036):** `frontend/next.config.js` `allowedDevOrigins` was missing `*.app.github.dev` — Next.js 15+ rejects Codespaces proxy requests with `ERR_HTTP_RESPONSE_CODE_FAILURE` without it. Fixed by adding `*.app.github.dev` and `*.preview.app.github.dev` to the list.
+
 ---
 
 ## 2) خريطة التنفيذ (Execution Topology)
@@ -146,6 +148,19 @@ user = db.query(User).filter_by(email=email).first()
 from sqlalchemy import select
 result = await db.execute(select(User).where(User.email == email))
 user = result.scalar_one_or_none()
+```
+
+### NEVER omit Codespaces origins from `allowedDevOrigins`
+```javascript
+// ❌ Wrong — Next.js 15+ blocks Codespaces proxy with ERR_HTTP_RESPONSE_CODE_FAILURE
+allowedDevOrigins: ['*.replit.dev']
+
+// ✅ Correct — include all hosting environments
+allowedDevOrigins: [
+    '*.replit.dev', '*.replit.app',
+    '*.app.github.dev', '*.preview.app.github.dev',  // GitHub Codespaces
+    '*.gitpod.io',                                    // Gitpod / Ona
+]
 ```
 
 ### NEVER assume microservices are reachable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ In both environments the backend is on **8000** and microservices in `microservi
 
 **Known fix applied 2026-05-09 (ISS-036):** `frontend/next.config.js` `allowedDevOrigins` was missing `*.app.github.dev` — Next.js 15+ rejects Codespaces proxy requests with `ERR_HTTP_RESPONSE_CODE_FAILURE` without it. Fixed by adding `*.app.github.dev` and `*.preview.app.github.dev` to the list.
 
+**Known fix applied 2026-05-09 (ISS-037):** commit `3fd78247` introduced `local stale_pid` at top-level scope in `supervisor.sh` (outside any function). bash rejects `local` outside functions → supervisor crashes at Step 4 with `local: can only be used in a function` → uvicorn never starts → all ports dead. Fixed by removing the `local` keyword (`stale_pid=...` instead of `local stale_pid`). Also added `.devcontainer/secrets.env` fallback so supervisor injects DB credentials even when Codespaces Secrets are not configured.
+
 ---
 
 ## 2) خريطة التنفيذ (Execution Topology)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -23,7 +23,21 @@ const nextConfig = {
         }
       ]
     },
-    allowedDevOrigins: ['*.replit.dev', '*.janeway.replit.dev', '*.replit.app'],
+    // Allow dev-mode requests from all supported hosting environments.
+    // GitHub Codespaces proxies the dev server through *.app.github.dev —
+    // without this, Next.js 15+ rejects those requests with ERR_HTTP_RESPONSE_CODE_FAILURE.
+    allowedDevOrigins: [
+        // Replit
+        '*.replit.dev',
+        '*.janeway.replit.dev',
+        '*.replit.app',
+        // GitHub Codespaces
+        '*.app.github.dev',
+        '*.preview.app.github.dev',
+        // Gitpod / Ona
+        '*.gitpod.io',
+        '*.ws-eu*.gitpod.io',
+    ],
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## المشكلة / Problem

بعد دمج commit `3fd78247`، توقفت جميع المنافذ (3000, 8000, 3001, 9090) مع خطأ:
```
net::ERR_HTTP_RESPONSE_CODE_FAILURE
```

After merging commit `3fd78247`, all ports stopped responding.

---

## السبب الجذري / Root Causes

### ISS-037 — السبب الرئيسي (الأكثر خطورة)

commit `3fd78247` أضاف `local stale_pid` في المستوى الأعلى من `supervisor.sh` (داخل `if/else` لكن خارج أي دالة). bash يرفض `local` خارج الدوال:

```
/app/.devcontainer/supervisor.sh: line 336: local: can only be used in a function
[ERROR] Supervisor failed at line 336
```

النتيجة: supervisor يتوقف في Step 4 → uvicorn لا يبدأ → كل المنافذ ميتة.

commit `3fd78247` added `local stale_pid` at top-level scope (inside `if/else` but outside any function). bash rejects `local` outside functions → supervisor crashes at Step 4 → uvicorn never starts → all ports dead.

### ISS-036 — مشكلة ثانوية

`frontend/next.config.js` كان `allowedDevOrigins` يحتوي فقط على نطاقات Replit. Next.js 15+ يرفض طلبات Codespaces proxy (`*.app.github.dev`) بـ `ERR_HTTP_RESPONSE_CODE_FAILURE`.

---

## الإصلاحات / Fixes

### ISS-037 — `supervisor.sh`
```bash
# ❌ قبل — يكسر bash
local stale_pid
stale_pid=$(lifecycle_get_state "uvicorn_pid" ...)

# ✅ بعد — صحيح
stale_pid=$(lifecycle_get_state "uvicorn_pid" ...)
```

### ISS-036 — `frontend/next.config.js`
```js
allowedDevOrigins: [
    '*.replit.dev', '*.janeway.replit.dev', '*.replit.app',
    '*.app.github.dev', '*.preview.app.github.dev',  // ← جديد
    '*.gitpod.io', '*.ws-eu*.gitpod.io',              // ← جديد
],
```

### إضافات / Additions
- `.devcontainer/secrets.env` (git-ignored): fallback لحقن DB credentials عند غياب Codespaces Secrets — يمنع السقوط الصامت إلى SQLite الذي يكسر FastAPI.
- `.devcontainer/secrets.env.example`: قالب للمطورين.
- `.gitignore`: استثناء `secrets.env` من version control.

---

## التحقق الحي / Live Verification

```bash
# Supervisor يكمل كل الخطوات بدون أخطاء
✅ Backend is healthy and ready!

# FastAPI
curl http://localhost:8000/health
# → {"application":"ok","database":"ok","version":"v4.1-root"}

# Next.js
curl -o /dev/null -w "%{http_code}" http://localhost:3000/
# → 200

# Codespaces Origin
curl -H "Origin: https://...-3000.app.github.dev" http://localhost:3000/
# → 200
```

---

## الملفات المعدّلة / Files Changed

| File | Change |
|------|--------|
| `.devcontainer/supervisor.sh` | Remove `local stale_pid` (ISS-037) + add `secrets.env` fallback reader |
| `.devcontainer/secrets.env.example` | New — template for local secrets fallback |
| `frontend/next.config.js` | Add `*.app.github.dev` to `allowedDevOrigins` (ISS-036) |
| `.gitignore` | Exclude `.devcontainer/secrets.env` |
| `CLAUDE.md` | Document ISS-037 + ISS-036 in §1 and §6 |
| `.memory/runtime_truth.md` | Add ISS-037 resolution + rules 16 & 17 |

---

⚠️ لا تدمج — بانتظار مراجعتك أنت.
Do **not** merge — owner review required.