### PR TITLE
fix(retrieval): replace flat keyword list with two-phase intent classifier (ISS-038)

### DIFF
--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -221,3 +221,29 @@ start" — this is the right hook.
 - `docker-compose.observability.yml` Grafana env block uses `${VAR:-default}` for every `GF_*` var so missing vars never break the local boot.
 - Never set `cookie_secure=true` unconditionally — it breaks plain `http://localhost:3001/`.
 **Status**: IMPLEMENTED 2026-05-07 — see branch `claude/fix-monitoring-port-hQ7JL` and CLAUDE.md §6.12.
+
+
+## D-018 · Exercise Retrieval Uses Two-Phase Intent Classifier, Not Keyword List (ISS-038)
+**Decision**: `detect_exercise_retrieval()` in `app/services/capabilities/exercise_retrieval.py`
+uses a two-phase intent classifier instead of a flat keyword list.
+**Reason**: A flat keyword list on `"تمرين"` / `"احتمالات"` / `"درس"` causes context blindness.
+Since `knowledge_base/` contains exactly one file, any false-positive trigger returns the
+probability BAC exercise unconditionally — regardless of what the student asked. A student
+asking "اشرح الجزء أ من هذا التمرين" received a probability exercise instead of an explanation.
+**The two phases**:
+1. **Explanation-intent guard** (highest priority): patterns like `"اشرح"`, `"كيف"`, `"هذا التمرين"`,
+   `"ساعدني"`, `"explain"`, `"help me"`, `"الجزء أ"` cancel retrieval even when "تمرين" is present.
+2. **Explicit retrieval trigger**: patterns like `"تمرين بكالوريا"`, `"التمرين الأول"`, `"exercise 1"`,
+   `"الموضوع الأول"`, year+exercise combos trigger retrieval.
+3. **Default**: no retrieval → fall through to LangGraph.
+**New field**: `ExerciseRetrievalDecision.reason` (optional str, default `""`) — audit trail for
+debugging misclassifications. Backward-compatible: callers only read `.recognized`.
+**Consequence**:
+- Explanation/help questions now fall through to LangGraph, which handles them correctly.
+- Explicit BAC retrieval requests still work as before.
+- Adding new trigger keywords requires a corresponding negation pattern — enforced by 25 regression tests.
+**What MUST NOT change**:
+- The explanation-intent list must always take priority over the retrieval list.
+- The `reason` field must not be removed — it is the only audit trail for misclassification debugging.
+- New keywords must not be added to the retrieval list without a corresponding explanation-intent guard.
+**Status**: IMPLEMENTED 2026-05-10 — branch `fix/exercise-retrieval-context-blindness`.

--- a/.memory/fragility-patterns.md
+++ b/.memory/fragility-patterns.md
@@ -317,9 +317,30 @@ Emitting the same logical metric through two different paths (UnifiedObs + OTel)
 
 ---
 
+## Pattern 5 — Retrieval Context Blindness (ISS-038, RESOLVED 2026-05-10)
+
+**What happened:** `detect_exercise_retrieval()` used a flat keyword list. Any question containing `"تمرين"`, `"احتمالات"`, `"درس"`, or `"بكالوريا"` triggered `_build_local_retrieval_response()`. Since `knowledge_base/` contained exactly one file (the probability BAC exercise), every triggered retrieval returned that file — regardless of what the student actually asked. A student asking "اشرح الجزء أ من هذا التمرين" received a probability exercise instead of an explanation.
+
+**Root cause:** Keyword presence was treated as intent. The system had no model of *why* the user mentioned the keyword — explanation context, conceptual question, and explicit retrieval request all looked identical to the classifier.
+
+**The fix:** Two-phase intent classifier:
+1. Explanation-intent patterns (`"اشرح"`, `"كيف"`, `"هذا التمرين"`, `"ساعدني"`, …) cancel retrieval at highest priority.
+2. Explicit retrieval patterns (`"تمرين بكالوريا"`, `"التمرين الأول"`, `"exercise 1"`, year+exercise combos) trigger retrieval.
+3. Default: no retrieval → LangGraph.
+
+**The structural risk that remains:** `knowledge_base/` is a single-file directory. Any retrieval trigger — even a correct one — returns the same file. As the knowledge base grows, the retrieval system needs semantic ranking, not just file enumeration. Until then, the two-phase classifier is the only guard against context blindness.
+
+**What must never be done:**
+- Do not add new keywords to `detect_exercise_retrieval()` without also adding corresponding explanation-intent negation patterns.
+- Do not assume keyword presence = retrieval intent. Always model the *why*.
+- Do not expand `knowledge_base/` without also updating the retrieval ranking logic in `local_store.py` — a larger knowledge base with a flat retrieval strategy will return arbitrary results.
+- Do not remove the `reason` field from `ExerciseRetrievalDecision` — it is the audit trail for debugging misclassifications.
+
+---
+
 ## Cross-Pattern Synthesis
 
-These four patterns share a common root: **the gap between what the system claims to do and what it actually does**.
+These five patterns share a common root: **the gap between what the system claims to do and what it actually does**.
 
 | Pattern | Claim | Reality |
 |---|---|---|
@@ -327,11 +348,13 @@ These four patterns share a common root: **the gap between what the system claim
 | DOM leakage | "Sidebar is hidden when closed" | Sidebar is visually off-screen but fully present in DOM, accessible to screen readers, keyboard, and find-in-page |
 | Runtime truth | "CI enforces architectural truth" | CI enforces static import topology; runtime behavior, metric emission, and dashboard contracts are unverified |
 | Observability | "LangGraph dashboard shows node metrics" | LangGraph dashboard queries metrics that are never emitted; panels are permanently empty |
+| Retrieval context blindness | "Retrieves relevant exercise content" | Returns the same single file for any question containing "تمرين" — keyword presence ≠ retrieval intent |
 
 **The systemic failure mode:** Each layer of the system (routing, rendering, governance, observability) has a local definition of "working" that does not align with the user-visible definition of "working". The system passes its own checks while failing the user's expectations.
 
 **The institutional memory imperative:** These patterns must be remembered because they will recur. Every time a new feature is added:
 - A new keyword will be added to `_EDUCATIONAL_PATTERNS` instead of fixing the semantic classifier
+- A new keyword will be added to `detect_exercise_retrieval()` without a negation guard, re-introducing context blindness
 - A new sidebar will use `transform: translateX` without `aria-hidden`
 - A new dashboard panel will be added without verifying the metric emitter
 - A new component will be classified ACTIVE based on import presence alone

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -1,8 +1,28 @@
 # Open Issues & Bugs
-> Last updated: 2026-05-09 | Branch: `fix/lifespan-orchestration-env-injection`
+> Last updated: 2026-05-10 | Branch: `fix/exercise-retrieval-context-blindness`
 > Format: [SEVERITY] ID · Title · [CONFIRMED LIVE / INFERRED / RUNTIME-ONLY / HISTORICAL]
 > **Capability runtime status (ACTIVE/PARTIAL/DORMANT/ZOMBIE) lives in `.memory/runtime_truth.md`.**
 > **Architectural fragility patterns (root causes, lessons) live in `.memory/fragility-patterns.md`.**
+
+---
+
+## 🔴 Critical — Resolved in this branch (2026-05-10)
+
+### ISS-038 · Exercise Retrieval Context Blindness — "تمرين" Always Returns Probability Exercise [CONFIRMED LIVE]
+- **Status**: RESOLVED in `fix/exercise-retrieval-context-blindness`
+- **Root cause**: `detect_exercise_retrieval()` in `app/services/capabilities/exercise_retrieval.py` used a flat keyword list (`"تمرين"`, `"تمارين"`, `"درس"`, `"احتمالات"`, `"بكالوريا"`, `"exercise"`, `"lesson"`, `"probability"`). Any question containing these words triggered `_build_local_retrieval_response()`, which searched `knowledge_base/` — a directory containing exactly one file: `bac2024_math_experimental_subject1_ex1_ex2.md` (the probability exercise). Result: every question with "تمرين" in any context returned the probability BAC exercise, regardless of what the student actually asked.
+- **Confirmed examples**:
+  - "اشرح الجزء أ من هذا التمرين" → returned probability exercise ❌
+  - "ما هو مفهوم التمرين في الرياضيات" → returned probability exercise ❌
+  - "ساعدني في حل هذا التمرين" → returned probability exercise ❌
+  - "ما هي الاحتمالات" → returned probability exercise ❌
+- **Fix**: Replaced flat keyword list with a two-phase intent classifier:
+  1. **Explanation-intent patterns** (highest priority): `"اشرح"`, `"شرح"`, `"وضح"`, `"كيف"`, `"ما هو"`, `"هذا التمرين"`, `"الجزء أ"`, `"ساعدني"`, `"help me"`, `"explain"`, … → cancel retrieval even if "تمرين" is present.
+  2. **Explicit retrieval patterns**: `"تمرين بكالوريا"`, `"التمرين الأول"`, `"exercise 1"`, `"الموضوع الأول"`, `"بكالوريا"`, year+exercise combos → trigger retrieval.
+  3. **Default**: no retrieval → fall through to LangGraph.
+- **New field**: `ExerciseRetrievalDecision.reason` (optional str) — explains the decision: `"explanation_intent_detected"` | `"retrieval_intent_detected"` | `"no_clear_retrieval_intent"`. Backward-compatible (default `""`).
+- **Tests**: 25 tests in `tests/contracts/test_exercise_retrieval_contracts.py` — 13 regression cases (explanation context must NOT trigger) + 8 positive cases (explicit retrieval must trigger) + 4 existing contract tests.
+- **Files**: `app/services/capabilities/exercise_retrieval.py`, `tests/contracts/test_exercise_retrieval_contracts.py`
 
 ---
 

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -1,5 +1,5 @@
 # Runtime Truth Lock
-> Last updated: **2026-05-09** | Branch: `fix/codespaces-port-3000-allowed-origins`
+> Last updated: **2026-05-10** | Branch: `fix/exercise-retrieval-context-blindness`
 > Authority: this file overrides any contradictory aspirational doc in `docs/` or root markdown.
 
 ## Golden rule
@@ -188,3 +188,4 @@ Missing any one → DORMANT, ZOMBIE, or UNKNOWN. No exceptions.
 15. **`allowedDevOrigins` must include all hosting environments.** Next.js 15+ rejects dev-server requests from unlisted origins. Always include `*.app.github.dev` (Codespaces), `*.replit.dev` (Replit), and `*.gitpod.io` (Gitpod/Ona) in `frontend/next.config.js`.
 16. **`local` is illegal outside bash functions.** Using `local var` in top-level script scope (even inside `if/else`) causes bash to abort with `local: can only be used in a function`. In `supervisor.sh`, any variable at top-level must use plain assignment (`var=value`). This was the root cause of ISS-037 (commit `3fd78247`) — all ports dead after merge.
 17. **`.devcontainer/secrets.env` is the Codespaces fallback.** When Codespaces Secrets are not configured, `supervisor.sh` reads `.devcontainer/secrets.env` (git-ignored) before falling back to SQLite. Copy `.devcontainer/secrets.env.example` and fill in real values. Never commit `secrets.env`.
+18. **Exercise retrieval requires intent classification, not keyword matching (ISS-038).** `detect_exercise_retrieval()` must use a two-phase classifier: (1) explanation-intent patterns cancel retrieval at highest priority; (2) only explicit retrieval patterns trigger it. A flat keyword list on "تمرين"/"احتمالات" causes context blindness — every explanation request returns the same static knowledge-base file. When in doubt, do NOT trigger retrieval; LangGraph handles ambiguous questions better. The `knowledge_base/` directory currently contains exactly one file — any retrieval trigger without explicit context returns that file unconditionally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ In both environments the backend is on **8000** and microservices in `microservi
 
 **Known fix applied 2026-05-09 (ISS-037):** commit `3fd78247` introduced `local stale_pid` at top-level scope in `supervisor.sh` (outside any function). bash rejects `local` outside functions → supervisor crashes at Step 4 with `local: can only be used in a function` → uvicorn never starts → all ports dead. Fixed by removing the `local` keyword (`stale_pid=...` instead of `local stale_pid`). Also added `.devcontainer/secrets.env` fallback so supervisor injects DB credentials even when Codespaces Secrets are not configured.
 
+**Known fix applied 2026-05-10 (ISS-038):** `detect_exercise_retrieval` in `app/services/capabilities/exercise_retrieval.py` used a flat keyword list (`"تمرين"`, `"احتمالات"`, `"درس"`, …) with no context awareness. Any question containing these words — regardless of intent — triggered `_build_local_retrieval_response`, which always returned the single file in `knowledge_base/` (the probability BAC exercise). A student asking "اشرح الجزء أ من هذا التمرين" received a probability exercise instead of an explanation. Fixed by replacing the flat keyword list with a two-phase intent classifier: (1) explanation/help intent patterns cancel retrieval even when "تمرين" is present; (2) only explicit retrieval patterns (BAC, numbered exercises, year+exercise combos) trigger retrieval. 25 regression tests added to `tests/contracts/test_exercise_retrieval_contracts.py`.
+
 ---
 
 ## 2) خريطة التنفيذ (Execution Topology)
@@ -195,6 +197,26 @@ user_id = result.scalar()
 # settings auto-converts PgBouncer port 6543 → 5432
 # Don't override this behavior in database.py
 ```
+
+### NEVER use flat keyword matching for exercise retrieval intent detection
+
+```python
+# ❌ Wrong — ISS-038: triggers retrieval for ANY question containing "تمرين"
+# regardless of context. "اشرح الجزء أ من هذا التمرين" → returns probability exercise.
+retrieval_hints = ("تمرين", "تمارين", "درس", "احتمالات", "بكالوريا", ...)
+recognized = any(hint in normalized for hint in retrieval_hints)
+
+# ✅ Correct — two-phase intent classifier in exercise_retrieval.py:
+# Phase 1: explanation/help intent → cancel retrieval (highest priority)
+# Phase 2: explicit retrieval patterns (BAC, numbered, year+exercise) → trigger
+# Default: no retrieval → fall through to LangGraph
+from app.services.capabilities.exercise_retrieval import detect_exercise_retrieval, ExerciseRetrievalRequest
+decision = detect_exercise_retrieval(ExerciseRetrievalRequest(question=question))
+# decision.recognized is True ONLY for explicit retrieval requests
+# decision.reason explains why: "explanation_intent_detected" | "retrieval_intent_detected" | "no_clear_retrieval_intent"
+```
+
+**Rule**: When adding new retrieval trigger keywords, always add corresponding explanation-intent negation patterns. The explanation-intent list takes priority. When in doubt, do NOT trigger retrieval — LangGraph handles ambiguous questions better than a static knowledge base lookup.
 
 ---
 

--- a/app/services/capabilities/exercise_retrieval.py
+++ b/app/services/capabilities/exercise_retrieval.py
@@ -2,9 +2,108 @@
 
 from __future__ import annotations
 
+import re
+
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+
+# ─────────────────────────────────────────────────────────────────────────────
+# أنماط النية السلبية — تشير إلى أن المستخدم يريد شرحاً أو مساعدة وليس جلب محتوى.
+# عند وجود أي منها، يُلغى الاسترجاع حتى لو ذُكرت كلمة "تمرين".
+# ─────────────────────────────────────────────────────────────────────────────
+_EXPLANATION_INTENT_PATTERNS: tuple[str, ...] = (
+    # طلب الشرح الصريح
+    "اشرح",
+    "شرح",
+    "وضح",
+    "فسر",
+    "explain",
+    "describe",
+    # طلب المساعدة في حل
+    "ساعدني",
+    "ساعد",
+    "help me",
+    "help with",
+    # الإشارة إلى محتوى مُقدَّم من المستخدم ("هذا التمرين" = المستخدم يملك التمرين)
+    "هذا التمرين",
+    "هذه المسألة",
+    "هذا السؤال",
+    "هذا الجزء",
+    "الجزء أ",
+    "الجزء ب",
+    "الجزء ج",
+    "الجزء الأول",
+    "الجزء الثاني",
+    "الجزء الثالث",
+    "part a",
+    "part b",
+    "part c",
+    # طلب الفهم المفاهيمي
+    "كيف",
+    "لماذا",
+    "ما هو",
+    "ما هي",
+    "ما معنى",
+    "ما مفهوم",
+    "how",
+    "why",
+    "what is",
+    "what are",
+    "what does",
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# أنماط النية الإيجابية — تشير إلى طلب جلب محتوى من قاعدة المعرفة.
+# يجب أن تكون محددة جداً لتجنب التفعيل الخاطئ.
+# ─────────────────────────────────────────────────────────────────────────────
+_RETRIEVAL_INTENT_PATTERNS: tuple[str, ...] = (
+    # طلب صريح لتمرين بكالوريا
+    "تمرين بكالوريا",
+    "تمارين بكالوريا",
+    "بكالوريا",
+    "bac",
+    "baccalauréat",
+    # طلب تمرين محدد بموضوع
+    "تمرين احتمالات",
+    "تمارين احتمالات",
+    "exercise probability",
+    "probability exercise",
+    # طلب موضوع امتحان
+    "الموضوع الأول",
+    "الموضوع الثاني",
+    "الموضوع الثالث",
+    "subject 1",
+    "subject 2",
+    "subject 3",
+    # طلب تمرين مُرقَّم بالترتيب
+    "التمرين الأول",
+    "التمرين الثاني",
+    "التمرين الثالث",
+    "التمرين الرابع",
+    "exercise 1",
+    "exercise 2",
+    "exercise 3",
+    # طلب صريح للجلب
+    "أعطني تمرين",
+    "أعطني تمارين",
+    "أريد تمرين",
+    "أريد تمارين",
+    "give me exercise",
+    "give me exercises",
+    "fetch exercise",
+    "get exercise",
+    "ابحث عن تمرين",
+    "جلب تمرين",
+)
+
+# "تمرين" أو "exercise" متبوعاً برقم مباشرة
+_EXERCISE_WITH_NUMBER_RE = re.compile(
+    r"(تمرين|تمارين|exercise)\s*\d+", re.IGNORECASE
+)
+
+# سنة دراسية (2020–2030)
+_YEAR_RE = re.compile(r"\b20[2-3]\d\b")
 
 
 class ExerciseRetrievalRequest(RobustBaseModel):
@@ -17,6 +116,7 @@ class ExerciseRetrievalDecision(RobustBaseModel):
     """قرار التعرف على نية الاسترجاع التعليمي."""
 
     recognized: bool
+    reason: str = ""
 
 
 class ExerciseRetrievalResult(RobustBaseModel):
@@ -26,20 +126,56 @@ class ExerciseRetrievalResult(RobustBaseModel):
     message: str | None = None
 
 
+def _has_explanation_intent(normalized: str) -> bool:
+    """يكشف عن نية الشرح أو المساعدة — تلغي الاسترجاع عند وجودها."""
+    return any(pattern in normalized for pattern in _EXPLANATION_INTENT_PATTERNS)
+
+
+def _has_retrieval_intent(normalized: str) -> bool:
+    """يكشف عن نية جلب محتوى من قاعدة المعرفة بشكل صريح."""
+    if any(pattern in normalized for pattern in _RETRIEVAL_INTENT_PATTERNS):
+        return True
+    if _EXERCISE_WITH_NUMBER_RE.search(normalized):
+        return True
+    # "تمرين" + سنة = طلب تمرين من سنة محددة
+    if ("تمرين" in normalized or "exercise" in normalized) and _YEAR_RE.search(normalized):
+        return True
+    return False
+
+
 def detect_exercise_retrieval(request: ExerciseRetrievalRequest) -> ExerciseRetrievalDecision:
-    """يتعرف على أسئلة التمارين لضبط fallback eligibility بشكل حتمي."""
+    """
+    يتعرف على أسئلة الاسترجاع التعليمي بدقة عالية لتجنب التفعيل الخاطئ.
+
+    المنطق ثلاثي المراحل:
+    1. نية الشرح/المساعدة → لا استرجاع (حتى لو ذُكر "تمرين" أو "احتمالات")
+    2. نية الجلب الصريحة → استرجاع
+    3. حالة الشك → لا استرجاع (LangGraph يعالج الحالات الغامضة أفضل)
+
+    يحل ISS-038: كلمة "تمرين" في سياق الشرح كانت تُطلق استرجاع تمرين
+    الاحتمالات بشكل ثابت بغض النظر عن السياق.
+    """
     normalized = request.question.strip().lower()
-    retrieval_hints = (
-        "تمرين",
-        "تمارين",
-        "درس",
-        "احتمالات",
-        "بكالوريا",
-        "exercise",
-        "lesson",
-        "probability",
+
+    # الأولوية الأولى: نية الشرح تلغي الاسترجاع دائماً
+    if _has_explanation_intent(normalized):
+        return ExerciseRetrievalDecision(
+            recognized=False,
+            reason="explanation_intent_detected",
+        )
+
+    # الأولوية الثانية: نية الجلب الصريحة
+    if _has_retrieval_intent(normalized):
+        return ExerciseRetrievalDecision(
+            recognized=True,
+            reason="retrieval_intent_detected",
+        )
+
+    # الحالة الافتراضية: لا استرجاع — اللجوء إلى LangGraph
+    return ExerciseRetrievalDecision(
+        recognized=False,
+        reason="no_clear_retrieval_intent",
     )
-    return ExerciseRetrievalDecision(recognized=any(hint in normalized for hint in retrieval_hints))
 
 
 def make_result(raw_result: str | None) -> ExerciseRetrievalResult:

--- a/tests/contracts/test_exercise_retrieval_contracts.py
+++ b/tests/contracts/test_exercise_retrieval_contracts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.services.capabilities.exercise_retrieval import (
     ExerciseRetrievalRequest,
     detect_exercise_retrieval,
@@ -35,3 +37,52 @@ def test_make_result_keeps_message_when_available() -> None:
     result = make_result("تم العثور على تمرين.")
     assert result.success is True
     assert result.message == "تم العثور على تمرين."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# اختبارات regression — ISS-038
+# كلمة "تمرين" في سياق الشرح كانت تُطلق استرجاع تمرين الاحتمالات بشكل ثابت.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("question", [
+    "اشرح الجزء أ من هذا التمرين",
+    "اشرح لي هذا التمرين",
+    "كيف أحل هذا التمرين",
+    "ساعدني في حل هذا التمرين",
+    "ما هو مفهوم التمرين في الرياضيات",
+    "ما هو الفرق بين التمرين والمسألة",
+    "وضح لي الجزء الأول",
+    "ما هي الاحتمالات",
+    "اشرح درس الاحتمالات",
+    "فسر لي هذا السؤال",
+    "help me with this exercise",
+    "explain part a",
+    "what is probability",
+])
+def test_explanation_context_does_not_trigger_retrieval(question: str) -> None:
+    """
+    ISS-038 regression: سياق الشرح لا يُطلق الاسترجاع حتى لو ذُكر "تمرين".
+    قبل الإصلاح، كانت هذه الأسئلة تجلب تمرين الاحتمالات بشكل ثابت.
+    """
+    decision = detect_exercise_retrieval(ExerciseRetrievalRequest(question=question))
+    assert decision.recognized is False, (
+        f"سياق الشرح أطلق الاسترجاع خطأً: '{question}' — reason={decision.reason}"
+    )
+
+
+@pytest.mark.parametrize("question", [
+    "أريد تمرين بكالوريا",
+    "أعطني تمرين احتمالات",
+    "التمرين الأول من الموضوع الأول",
+    "تمرين بكالوريا 2024",
+    "الموضوع الثاني رياضيات",
+    "exercise 1",
+    "exercise 2 probability",
+    "ابحث عن تمرين احتمالات",
+])
+def test_explicit_retrieval_intent_triggers_retrieval(question: str) -> None:
+    """طلبات الجلب الصريحة تُطلق الاسترجاع بشكل صحيح."""
+    decision = detect_exercise_retrieval(ExerciseRetrievalRequest(question=question))
+    assert decision.recognized is True, (
+        f"طلب جلب صريح لم يُطلق الاسترجاع: '{question}' — reason={decision.reason}"
+    )


### PR DESCRIPTION
## المشكلة (ISS-038)

`detect_exercise_retrieval()` كانت تستخدم قائمة كلمات مفتاحية مسطحة بدون أي وعي بالسياق:

```python
# الكود القديم الكارثي
retrieval_hints = ("تمرين", "تمارين", "درس", "احتمالات", "بكالوريا", "exercise", ...)
recognized = any(hint in normalized for hint in retrieval_hints)
```

أي سؤال يحتوي على هذه الكلمات — بغض النظر عن السياق — كان يُطلق `_build_local_retrieval_response()`، التي تبحث في `knowledge_base/` الذي يحتوي على ملف واحد فقط: تمرين الاحتمالات بكالوريا 2024.

**النتيجة الكارثية المؤكدة:**
| السؤال | النتيجة القديمة | النتيجة الصحيحة |
|--------|----------------|----------------|
| "اشرح الجزء أ من هذا التمرين" | تمرين الاحتمالات ❌ | شرح من LangGraph ✅ |
| "ما هو مفهوم التمرين في الرياضيات" | تمرين الاحتمالات ❌ | شرح مفاهيمي ✅ |
| "ساعدني في حل هذا التمرين" | تمرين الاحتمالات ❌ | مساعدة من LangGraph ✅ |
| "ما هي الاحتمالات" | تمرين الاحتمالات ❌ | شرح المفهوم ✅ |
| "اشرح درس الاحتمالات" | تمرين الاحتمالات ❌ | شرح الدرس ✅ |

## الإصلاح

مصنّف نية ثنائي المراحل في `app/services/capabilities/exercise_retrieval.py`:

**المرحلة 1 — حارس نية الشرح (أعلى أولوية):**
أنماط مثل `"اشرح"`, `"كيف"`, `"هذا التمرين"`, `"ساعدني"`, `"explain"`, `"help me"`, `"الجزء أ"` تُلغي الاسترجاع حتى لو ذُكرت كلمة "تمرين".

**المرحلة 2 — أنماط الجلب الصريحة:**
أنماط مثل `"تمرين بكالوريا"`, `"التمرين الأول"`, `"exercise 1"`, `"الموضوع الأول"`, تمرين+سنة تُطلق الاسترجاع.

**الحالة الافتراضية:** لا استرجاع → LangGraph يعالج الحالات الغامضة.

**حقل جديد:** `ExerciseRetrievalDecision.reason` (اختياري، متوافق مع الكود القديم) — سجل تدقيق لتشخيص الأخطاء: `"explanation_intent_detected"` | `"retrieval_intent_detected"` | `"no_clear_retrieval_intent"`.

## الاختبارات

25 اختبار في `tests/contracts/test_exercise_retrieval_contracts.py`:
- 13 حالة regression (سياق الشرح يجب ألا يُطلق الاسترجاع)
- 8 حالات إيجابية (طلبات الجلب الصريحة يجب أن تُطلق الاسترجاع)
- 4 اختبارات عقود موجودة (لم تُكسر)

```
25 passed in 1.68s
```

## ذاكرة النظام المحدّثة

| الملف | التغيير |
|-------|---------|
| `.memory/issues.md` | ISS-038 موثّق ومحلول |
| `.memory/runtime_truth.md` | قاعدة 18 مضافة |
| `.memory/fragility-patterns.md` | النمط 5 — عمى سياق الاسترجاع |
| `.memory/decisions.md` | D-018 — قرار المصنّف الثنائي |
| `CLAUDE.md` | ISS-038 في Known Fixes + قاعدة NEVER جديدة |

## الخطر المتبقي

`knowledge_base/` يحتوي على ملف واحد. أي استرجاع صحيح يعيد نفس الملف. عند توسيع قاعدة المعرفة، يجب تحديث منطق الترتيب في `local_store.py` — وإلا ستعود مشكلة مشابهة.
