### PR TITLE
fix(retrieval+ai): ISS-051 — indexed exam-card display + streaming + ring-2.6-1t primary

### DIFF
--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -631,3 +631,66 @@ debugging misclassifications. Backward-compatible: callers only read `.recognize
 - API contract findings يجب أن تبقى موثقة حتى يتم إصلاحها.
 - حالة `pipeline_mode=fallback` يجب أن تُعرض كـ PARTIAL وليس ACTIVE في truth table.
 **Status**: DOCUMENTED 2026-05-11 — branch `feat/live-runtime-audit-d043`.
+
+## D-048 · Indexed Knowledge Retrieval + Streaming Exercise Display (2026-05-13)
+**Decision**: استرجاع التمارين التعليمية يجب أن يكون **مُفهرَساً وذرياً وبثياً**:
+1. **Indexed**: استخدام `matched_entry` من `knowledge_index.py` لجلب ملف واحد بالضبط، لا wide-net search على كل `knowledge_base/*.md`.
+2. **Atomic**: تنسيق العرض يحذف YAML frontmatter + قسم الحل + الوسوم — يبقى فقط نص التمرين (بطاقة + 3 أجزاء).
+3. **Streaming**: المحتوى يُبَث كلمة بكلمة عبر `assistant_delta` متتابعة (typing-effect) بدل dump واحد كبير.
+
+**Reason**: قبل هذا القرار، استرجاع تمرين 2016 الدوال العددية كان يُرجِع:
+- ملفي 2016 + 2024 معاً (wide-net leakage)
+- YAML metadata غريب يظهر للطالب
+- الحل النموذجي يُكشف قبل أن يحل الطالب
+- النص كله يصل دفعة واحدة (لا typing-effect)
+
+**Architecture**:
+```
+detect_exercise_retrieval(question)
+  → ExerciseRetrievalDecision(recognized, matched_entry, reason)
+  → if matched_entry:
+      load_exercise_content(entry)
+      → format_exercise_for_display(entry, raw_content)
+        → strip YAML frontmatter
+        → trim at first solution/tags marker
+        → return clean Q-only text
+  → if NOT matched_entry: legacy wide-net fallback (rare)
+  → _stream_local_retrieval_response:
+      → split on \n boundaries → preserve LaTeX markers
+      → for line > 80 chars: split on spaces
+      → yield with asyncio.sleep(0.012) for typing-effect
+```
+
+**New artifacts**:
+- `app/services/capabilities/exercise_retrieval.py`:
+  - `_strip_frontmatter(content) -> str`
+  - `_trim_at_solution(content) -> str`
+  - `format_exercise_for_display(entry, raw_content) -> str`
+  - `_SOLUTION_SECTION_MARKERS` tuple — list of section starts that end the exercise text.
+- `app/infrastructure/clients/orchestrator_client.py`:
+  - `_exercise_retrieval_full_decision(question) -> ExerciseRetrievalDecision`
+  - `_stream_local_retrieval_response(question) -> AsyncGenerator[str, None]`
+
+**What MUST NOT change without an ADR**:
+- The indexed-first path inside `_build_local_retrieval_response()` — wide-net is fallback only.
+- `_SOLUTION_SECTION_MARKERS` must cover ALL solution headers in `knowledge_base/`. New KB files require auditing this list.
+- The streaming fallback path #2 in `chat_with_agent()` must call `_stream_local_retrieval_response()` not the non-streaming variant — otherwise typing-effect contract (D-047) breaks for retrieval queries.
+- `ExerciseRetrievalDecision.matched_entry` is the single source of truth for which file to read. Re-introducing wide-net code paths without first checking `matched_entry is None` re-introduces ISS-051.
+
+**Streaming chunk size invariants**:
+- ≤80 chars: emit line verbatim (preserves `$$...$$` and `\\(...\\)` markers atomically).
+- >80 chars: split on spaces, never inside a token (no risk of breaking `e^{-x}` mid-token).
+
+**Status**: IMPLEMENTED 2026-05-13 — branch `claude/fix-exercise-display-eaIQC`.
+
+## D-049 · Primary Model Switch to google/gemma-4-31b-it:free (2026-05-13)
+**Decision**: النموذج الأساسي تحوّل من `liquid/lfm-2.5-1.2b-instruct:free` إلى `google/gemma-4-31b-it:free` بطلب المستخدم.
+**Reason**: المستخدم يعتقد أن جودة عربية أعلى مطلوبة لتمارين البكالوريا والشرح التعليمي. النموذج الأصغر (1.2B) كان يُعطي إجابات سطحية أحياناً، خاصة في الرياضيات المتقدمة.
+**Risk**: `google/gemma-4-31b-it:free` قد لا يكون متاحاً على OpenRouter حساب المستخدم (Gemma 4 31B unverified availability كما في 2026-05-13). الـ fallback chain الخمسية تحمي الاستمرارية (Gemini 2 Flash → Qwen Coder → KAT → Phi 3 → Llama 3.2 Vision).
+**Override**: المستخدم يمكنه تبديل سريع عبر `export OPENROUTER_PRIMARY_MODEL=<other>` بدون إعادة بناء.
+**Streaming guarantee**: إذا كان النموذج لا يدعم token-level streaming حقيقي، الـ fallback إلى نموذج آخر سيُعيد البث الكلمة-بالكلمة (D-047 + D-048 ضمانة معمارية، ليست خاصية نموذج معين).
+**What MUST NOT change without ADR**:
+- إذا أراد فريق العمليات تغيير الافتراضي، يجب توثيق السبب هنا (D-050+).
+- لا تَحذف `_resolve_primary_model()` — هي بوابة الـ env override.
+- لا تُعدِّل ترتيب الـ fallback chain إلا بعد تجربة كل نموذج على streaming حقيقي.
+**Status**: IMPLEMENTED 2026-05-13 — branch `claude/fix-exercise-display-eaIQC`.

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -683,12 +683,16 @@ detect_exercise_retrieval(question)
 
 **Status**: IMPLEMENTED 2026-05-13 — branch `claude/fix-exercise-display-eaIQC`.
 
-## D-049 · Primary Model Switch to google/gemma-4-31b-it:free (2026-05-13)
-**Decision**: النموذج الأساسي تحوّل من `liquid/lfm-2.5-1.2b-instruct:free` إلى `google/gemma-4-31b-it:free` بطلب المستخدم.
-**Reason**: المستخدم يعتقد أن جودة عربية أعلى مطلوبة لتمارين البكالوريا والشرح التعليمي. النموذج الأصغر (1.2B) كان يُعطي إجابات سطحية أحياناً، خاصة في الرياضيات المتقدمة.
-**Risk**: `google/gemma-4-31b-it:free` قد لا يكون متاحاً على OpenRouter حساب المستخدم (Gemma 4 31B unverified availability كما في 2026-05-13). الـ fallback chain الخمسية تحمي الاستمرارية (Gemini 2 Flash → Qwen Coder → KAT → Phi 3 → Llama 3.2 Vision).
-**Override**: المستخدم يمكنه تبديل سريع عبر `export OPENROUTER_PRIMARY_MODEL=<other>` بدون إعادة بناء.
-**Streaming guarantee**: إذا كان النموذج لا يدعم token-level streaming حقيقي، الـ fallback إلى نموذج آخر سيُعيد البث الكلمة-بالكلمة (D-047 + D-048 ضمانة معمارية، ليست خاصية نموذج معين).
+## D-049 · Primary Model Switch to inclusionai/ring-2.6-1t:free (2026-05-13, superseded gemma-4-31b)
+**Decision**: النموذج الأساسي = `inclusionai/ring-2.6-1t:free` (Inclusion AI Ring 2.6, 1T params MoE).
+**History (نفس اليوم)**:
+1. كان `liquid/lfm-2.5-1.2b-instruct:free` — نموذج صغير، إجابات سطحية في الرياضيات.
+2. تجربة `google/gemma-4-31b-it:free` — تم التراجع عنها بنفس اليوم.
+3. الاختيار النهائي `inclusionai/ring-2.6-1t:free` — بطلب المستخدم.
+**Reason**: نموذج 1T params (mixture of experts) يُعطي جودة عالية للشرح التعليمي العربي والرياضيات المتقدمة، مع إتاحته مجاناً على OpenRouter.
+**Risk**: توفّر النموذج لم يُتحقَّق منه حياً من السandbox (لا اتصال خارجي). الـ fallback chain الخمسية تحمي الاستمرارية إذا 404'd: Gemini 2 Flash → Qwen Coder → KAT → Phi 3 → Llama 3.2 Vision.
+**Override**: تبديل سريع عبر `export OPENROUTER_PRIMARY_MODEL=<other>` بدون إعادة بناء.
+**Streaming guarantee**: إذا كان النموذج لا يدعم token-level streaming حقيقي، الـ fallback chain ينتقل لنموذج يدعمه (D-047 + D-048 ضمانة معمارية، ليست خاصية نموذج معين).
 **What MUST NOT change without ADR**:
 - إذا أراد فريق العمليات تغيير الافتراضي، يجب توثيق السبب هنا (D-050+).
 - لا تَحذف `_resolve_primary_model()` — هي بوابة الـ env override.

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -827,7 +827,7 @@
     - أُضيف `_stream_local_retrieval_response()` يُقسِّم على حدود الأسطر/الكلمات (~80 char) مع `asyncio.sleep(0.012)` بين كل قطعة.
     - `chat_with_agent()` المسار رقم 2 (exercise_retrieval) أصبح streaming كامل بدل dump واحد.
   - `app/core/ai_config.py`:
-    - `PRIMARY = "google/gemma-4-31b-it:free"` — جودة عربية أعلى بطلب المستخدم. fallback chain يحمي الاستمرارية.
+    - `PRIMARY = "inclusionai/ring-2.6-1t:free"` — Inclusion AI Ring 2.6 (1T params MoE) بطلب المستخدم. fallback chain يحمي الاستمرارية. (تم التراجع عن gemma-4-31b التجريبي بنفس اليوم — D-049 history.)
 - **Verified**:
   - Smoke test على ملف 2016: `10884 → 2913 char` (73% noise removed) ✅
   - YAML stripped, solution stripped, tags stripped, all 3 parts (I/II/III) intact ✅

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -801,3 +801,39 @@
 - **Path**: `User WS → Monolith:8000/api/chat/ws → OrchestratorClient.chat_with_agent() → http://localhost:8006/api/chat/messages → StateGraph 13-node → Planning:8002 + Research:8007 + Reasoning:8008 → composed answer`.
 - **Pipeline**: `POST /compose → pipeline_mode="full" | skills_active=["planning","research","reasoning"] | duration=28.5s`.
 - **Status**: VERIFIED LIVE. Microservices answer users end-to-end.
+
+### [FIXED] ISS-051 · Wide-net knowledge retrieval leaks multiple unrelated exercises + non-streaming dump · FIXED (2026-05-13)
+- **User-visible catastrophe**: عند طلب «تمرين 2016 الدورة الأولى الموضوع الثاني التمرين الرابع» يظهر:
+  1. التمرين المطلوب (الدوال العددية 2016) — صحيح.
+  2. **بالإضافة إلى** تمرين 2024 (احتمالات) — مُلوِّث، لم يُطلب.
+  3. YAML metadata غريب (`---`, `metadata:`, `render:`...) يظهر للطالب.
+  4. عناصر الإجابة النموذجية تُكشف قبل أن يحل الطالب.
+  5. النص يصل دفعة واحدة كبيرة → لا typing-effect → الطالب ينتظر طويلاً ثم يرى كل شيء فجأة.
+  6. زمن الاستجابة كبير لأن wide-net يقرأ كل ملفات `knowledge_base/`.
+- **Root causes (5 جذرية)**:
+  1. **Wasted matched_entry**: `detect_exercise_retrieval()` يُحدِّد بدقة الملف المطابق (`bac2016_s1_math_exp_subject2_ex4_numerical_functions.md`) عبر `knowledge_index.py`، لكن `_exercise_retrieval_decision()` كان يرمي `matched_entry` ويحتفظ فقط بـ `recognized: bool`.
+  2. **Wide-net fallback**: `_build_local_retrieval_response()` كان يستدعي `search_educational_content(query=question)` بدون فلاتر — يدخل في `local_store.search_local_knowledge_base()` الذي يقرأ كل ملفات `.md` ويُرجِع كل ما يحتوي على `تمرين`/`بكالوريا` → كلا ملفي 2016 و 2024 يُحقَنان.
+  3. **No YAML stripping**: المُرجَع هو المحتوى الخام للملف بما فيه `---\nmetadata:\n...---` → يظهر للطالب كرموز ميتا غير مفيدة.
+  4. **No solution gating**: «عناصر الإجابة النموذجية» تُرسَل مع نص التمرين → الطالب يرى الحل قبل أن يحاول.
+  5. **No streaming**: المسار في `chat_with_agent` كان `yield assistant_delta { content: HUGE_STRING }` ثم `assistant_final { content: "" }` — لا typing-effect مهما كان حجم النص.
+- **Fix (D-048 — Indexed Knowledge Retrieval + Streaming Display)**:
+  - `app/services/capabilities/exercise_retrieval.py`:
+    - أُضيف `_strip_frontmatter()`, `_trim_at_solution()`, `format_exercise_for_display()`.
+    - تحذف YAML frontmatter وكل قسم يبدأ بـ `## عناصر الإجابة`/`## الحل`/`## وسوم البحث`/`### الجزء I/II/III`.
+    - النتيجة: ملف 10884 char → 2913 char (~73% noise removed).
+  - `app/infrastructure/clients/orchestrator_client.py`:
+    - أُضيف `_exercise_retrieval_full_decision()` يُرجِع `ExerciseRetrievalDecision` كاملاً مع `matched_entry`.
+    - أُعيد كتابة `_build_local_retrieval_response()` ليُفضِّل المسار المُفهرَس (`load_exercise_content(matched_entry)` + `format_exercise_for_display`) — wide-net فقط كمسار بديل.
+    - أُضيف `_stream_local_retrieval_response()` يُقسِّم على حدود الأسطر/الكلمات (~80 char) مع `asyncio.sleep(0.012)` بين كل قطعة.
+    - `chat_with_agent()` المسار رقم 2 (exercise_retrieval) أصبح streaming كامل بدل dump واحد.
+  - `app/core/ai_config.py`:
+    - `PRIMARY = "google/gemma-4-31b-it:free"` — جودة عربية أعلى بطلب المستخدم. fallback chain يحمي الاستمرارية.
+- **Verified**:
+  - Smoke test على ملف 2016: `10884 → 2913 char` (73% noise removed) ✅
+  - YAML stripped, solution stripped, tags stripped, all 3 parts (I/II/III) intact ✅
+  - 6/6 intent classifier scenarios pass (catastrophe query, explanation, greeting, concept, probability request) ✅
+- **What MUST NOT regress**:
+  - `_exercise_retrieval_full_decision()` must always be called inside `_build_local_retrieval_response()` — bypassing it re-introduces wide-net leakage.
+  - The streaming fallback path #2 in `chat_with_agent()` must use `_stream_local_retrieval_response()` not `_build_local_retrieval_response()` directly — otherwise typing effect breaks.
+  - `_SOLUTION_SECTION_MARKERS` must include every section start that precedes solutions (`### الجزء I`, `## عناصر الإجابة`, etc.). Adding new KB files requires extending this list if their solution headers differ.
+- **Status**: FIXED 2026-05-13 — branch `claude/fix-exercise-display-eaIQC`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2805,8 +2805,9 @@ useAgentSocket.mergeAssistantContent
 
 ### النموذج الأساسي (D-049)
 
-`PRIMARY = "google/gemma-4-31b-it:free"` بناءً على طلب المستخدم 2026-05-13. متطلبات الاستمرارية:
+`PRIMARY = "inclusionai/ring-2.6-1t:free"` بناءً على طلب المستخدم 2026-05-13 (التحديد النهائي بعد التراجع عن `google/gemma-4-31b-it:free` التجريبي بنفس اليوم — راجع D-049 history في `.memory/decisions.md`). متطلبات الاستمرارية:
 
+- نموذج Inclusion AI Ring 2.6 = 1T params (mixture of experts) — جودة عالية للشرح التعليمي العربي والرياضيات المتقدمة.
 - إذا كان النموذج غير متاح في OpenRouter حساب المُستخدم → الـ fallback chain (Gemini 2 Flash → Qwen Coder → KAT → Phi 3 → Llama 3.2 Vision) يحمي التشغيل.
 - التبديل السريع بدون إعادة build: `export OPENROUTER_PRIMARY_MODEL=<other>`.
 - streaming كلمة بكلمة مضمون معمارياً (D-047/D-048) بغض النظر عن قدرات النموذج المحدَّد — إذا كان النموذج يُعطي chunk واحد، الـ fallback chain سينتقل لنموذج آخر يدعم streaming حقيقي.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2715,3 +2715,128 @@ curl http://localhost:8006/metrics | grep 'cogniforge_pipeline_invocations_total
 
 **زمن أول-كلمة المتوقع**: ~800ms (بدل 25–40s burst).
 
+---
+
+## 6.29 Indexed Knowledge Retrieval + Exam-Card Display Doctrine (2026-05-13, ISS-051 / D-048 / D-049)
+
+> هذا القسم يحكم استرجاع التمارين التعليمية من `knowledge_base/`. أي تعديل على
+> مسار الاسترجاع يجب أن يحترم القواعد الخمس أدناه — وإلا فالكارثة تعود.
+
+### الكارثة المُشخَّصة (قبل الإصلاح)
+
+عندما يكتب الطالب: «اعطني تمرين دوال عددية شعبة علوم تجريبية الموضوع الثاني التمرين الرابع لسنة 2016 الدورة الأولى»
+
+كان يحصل على:
+
+| الأعراض | السبب الجذري |
+|---|---|
+| ملف 2016 (الدوال) + ملف 2024 (الاحتمالات) كلاهما يظهران | wide-net `local_store.search_local_knowledge_base()` يقرأ كل `.md` في `knowledge_base/` |
+| YAML metadata غريب (`---`, `metadata:`, `topics:`...) يظهر للطالب | لا يوجد frontmatter stripping |
+| عناصر الإجابة النموذجية مكشوفة قبل المحاولة | لا يوجد solution gating |
+| النص كامل يصل دفعة واحدة (~30s انتظار ثم burst) | `chat_with_agent` يُرسِل `assistant_delta { content: HUGE_STRING }` واحد |
+| LaTeX يبدو مكرراً في الواجهة | KaTeX يرسم الـ visible + accessibility span → نسخ يُعطي تكرار |
+| الرد بطيء جداً | wide-net يقرأ كل ملفات `.md` + يُمرِّر النص الكامل للـ AI |
+
+### المسار المُصحَّح (D-048)
+
+```
+المستخدم يسأل عن تمرين بكالوريا محدد
+  │
+  ▼
+detect_exercise_retrieval(question)        ← knowledge_index.py
+  │ يستخرج: year, session, subject, exercise_number, topics
+  │ يُطابق على KNOWLEDGE_INDEX
+  ▼
+ExerciseRetrievalDecision(
+    recognized=True,
+    matched_entry=ExerciseEntry(file_path="bac2016_s1_math_exp_subject2_ex4_numerical_functions.md", ...)
+)
+  │
+  ▼
+_build_local_retrieval_response()  ← الجديد
+  │ if matched_entry:
+  │     raw = load_exercise_content(entry)             ← ملف واحد فقط
+  │     formatted = format_exercise_for_display(...)   ← يحذف YAML + الحل + الوسوم
+  │     return formatted                                ← 73% noise removed
+  │ else:
+  │     legacy wide-net (نادر)
+  ▼
+_stream_local_retrieval_response()  ← الجديد
+  │ يُقسِّم على حدود الأسطر/الكلمات (≤80 char)
+  │ yield chunk + asyncio.sleep(0.012)
+  ▼
+chat_with_agent() fallback path #2
+  │ يُصدِر assistant_delta واحد لكل قطعة
+  │ ثم assistant_final { content: "" }                  ← duplicate-suppression contract
+  ▼
+useAgentSocket.mergeAssistantContent
+  │ يجمع الـ deltas
+  │ يتجاهل assistant_final.content (لأنه فارغ)
+  ▼
+الواجهة ترسم الرد كلمة بكلمة (typing-effect)
+```
+
+### القواعد الخمس الدائمة (لا تُكسر بدون ADR)
+
+**(1) Indexed-first retrieval**: `_build_local_retrieval_response()` يجب أن يُفضِّل `matched_entry` من knowledge_index قبل اللجوء إلى wide-net search. أي تعديل يبدأ بـ wide-net مباشرة يُعيد ISS-051 فوراً.
+
+**(2) Atomic file load**: عند توفر `matched_entry`، يجب تحميل ملف واحد بالضبط (`load_exercise_content(entry)`)، لا scan على `knowledge_base/`. هذا يلغي leakage من الملفات الأخرى.
+
+**(3) Display formatting**: `format_exercise_for_display()` يجب أن يحذف:
+- YAML frontmatter (`---\n...\n---`)
+- كل قسم يبدأ بـ `## عناصر الإجابة`, `## الإجابة النموذجية`, `## الحل`, `## Solution`, `## وسوم البحث`, `## Tags`, `### الجزء I`, `### الجزء II`, `### الجزء III`
+- المُخرَج النظيف: بطاقة الامتحان + نص التمرين فقط (3 أجزاء I/II/III من الأسئلة)
+
+**(4) Streaming chunk boundaries**: التقسيم يجب أن يحافظ على سلامة LaTeX markers:
+- سطر ≤80 char: emit verbatim (يحافظ على `$$...$$` و `\\(...\\)` كاملة)
+- سطر >80 char: قطع عند الفراغات فقط (لا يكسر `e^{-x}` في منتصف token)
+- `asyncio.sleep(0.012)` بين كل قطعة لإنتاج typing-effect قابل للملاحظة بصرياً
+
+**(5) Duplicate-suppression contract** (D-047): إذا بُثَّت أي `assistant_delta`، يجب أن يكون `assistant_final.payload.content = ""`. مسار الاسترجاع الجديد يحترم هذا — لا تُرسِل `assistant_final` بمحتوى مكرر.
+
+### إضافة ملف تمرين جديد إلى `knowledge_base/`
+
+عند إضافة ملف `.md` جديد:
+
+1. أضف entry في `app/services/capabilities/knowledge_index.py:KNOWLEDGE_INDEX` مع كل الحقول (year, session, subject_number, exercise_number, branch, topics, tags).
+2. تأكد أن الملف يحوي قسم `## عناصر الإجابة` أو `### الجزء I` لتفصل بين الأسئلة والحل — وإلا `_trim_at_solution()` سيُرجِع الملف كاملاً.
+3. إذا استخدمت headers أخرى للحل (مثل `## Solutions` بالإنجليزية)، أضفها إلى `_SOLUTION_SECTION_MARKERS` في `exercise_retrieval.py`.
+4. أضف keywords للموضوع في `_TOPIC_KEYWORDS` إذا لم تكن موجودة.
+
+### النموذج الأساسي (D-049)
+
+`PRIMARY = "google/gemma-4-31b-it:free"` بناءً على طلب المستخدم 2026-05-13. متطلبات الاستمرارية:
+
+- إذا كان النموذج غير متاح في OpenRouter حساب المُستخدم → الـ fallback chain (Gemini 2 Flash → Qwen Coder → KAT → Phi 3 → Llama 3.2 Vision) يحمي التشغيل.
+- التبديل السريع بدون إعادة build: `export OPENROUTER_PRIMARY_MODEL=<other>`.
+- streaming كلمة بكلمة مضمون معمارياً (D-047/D-048) بغض النظر عن قدرات النموذج المحدَّد — إذا كان النموذج يُعطي chunk واحد، الـ fallback chain سينتقل لنموذج آخر يدعم streaming حقيقي.
+
+### قياس النجاح حياً
+
+```bash
+# 1. مطابقة دقيقة لملف واحد فقط — لا leakage
+python3 -c "
+from app.services.capabilities.exercise_retrieval import detect_exercise_retrieval, ExerciseRetrievalRequest
+d = detect_exercise_retrieval(ExerciseRetrievalRequest(question='تمرين 2016 الدورة الأولى الموضوع الثاني التمرين الرابع دوال عددية'))
+print('matched:', d.matched_entry.file_path)
+"
+# المتوقع: knowledge_base/bac2016_s1_math_exp_subject2_ex4_numerical_functions.md
+
+# 2. حجم المُخرَج النظيف
+python3 -c "
+from app.services.capabilities.exercise_retrieval import format_exercise_for_display, load_exercise_content, detect_exercise_retrieval, ExerciseRetrievalRequest
+d = detect_exercise_retrieval(ExerciseRetrievalRequest(question='تمرين 2016 الدورة الأولى التمرين الرابع'))
+raw = load_exercise_content(d.matched_entry)
+out = format_exercise_for_display(d.matched_entry, raw)
+print(f'raw={len(raw)} formatted={len(out)} reduction={100-len(out)*100//len(raw)}%')
+"
+# المتوقع: raw=10884 formatted=~2913 reduction=73%
+
+# 3. streaming chunks (يجب 30-50 chunks لتمرين عادي)
+curl -N -X POST http://localhost:8000/api/chat/ws \
+  -H "Authorization: Bearer $JWT" \
+  -d '{"question":"تمرين 2016 الدورة الأولى الموضوع الثاني التمرين الرابع دوال عددية"}' \
+  | grep -c assistant_delta
+# المتوقع: > 30
+```
+

--- a/app/core/ai_config.py
+++ b/app/core/ai_config.py
@@ -110,10 +110,12 @@ class ActiveModels:
     # nemotron-3-super-120b-a12b:free كان يُعيد chunk واحد فقط → لا typing effect
     # ISS-STREAM-003: liquid/lfm-2.5-1.2b-instruct:free — النموذج الوحيد المتاح حالياً
     # الذي يدعم streaming حقيقي (كلمة وراء كلمة) عبر OpenRouter (2026-05-13).
-    # ISS-051 (2026-05-13): النموذج الأساسي تم تبديله إلى google/gemma-4-31b-it:free
-    # بطلب المستخدم — جودة عربية أعلى لتمارين البكالوريا. fallback chain يحمي
-    # الاستمرارية إن لم يكن متاحاً في OpenRouter (يمكن تبديل سريع عبر env).
-    PRIMARY = _resolve_primary_model("google/gemma-4-31b-it:free")
+    # ISS-051 (2026-05-13, superseded by ISS-051-B): تجربة google/gemma-4-31b-it:free
+    # تم التراجع عنها بنفس اليوم لصالح inclusionai/ring-2.6-1t:free (انظر التالي).
+    # ISS-051-B (2026-05-13): النموذج الأساسي النهائي = inclusionai/ring-2.6-1t:free
+    # بطلب المستخدم (تراجع عن gemma-4-31b التجريبي). نموذج 1T params من Inclusion AI.
+    # fallback chain يحمي إن لم يكن متاحاً (تبديل سريع عبر OPENROUTER_PRIMARY_MODEL).
+    PRIMARY = _resolve_primary_model("inclusionai/ring-2.6-1t:free")
     LOW_COST = PRIMARY
     GATEWAY_PRIMARY = PRIMARY
     GATEWAY_FALLBACK_1 = AvailableModels.GEMINI_2_FLASH_EXP_FREE

--- a/app/core/ai_config.py
+++ b/app/core/ai_config.py
@@ -110,7 +110,10 @@ class ActiveModels:
     # nemotron-3-super-120b-a12b:free كان يُعيد chunk واحد فقط → لا typing effect
     # ISS-STREAM-003: liquid/lfm-2.5-1.2b-instruct:free — النموذج الوحيد المتاح حالياً
     # الذي يدعم streaming حقيقي (كلمة وراء كلمة) عبر OpenRouter (2026-05-13).
-    PRIMARY = _resolve_primary_model("liquid/lfm-2.5-1.2b-instruct:free")
+    # ISS-051 (2026-05-13): النموذج الأساسي تم تبديله إلى google/gemma-4-31b-it:free
+    # بطلب المستخدم — جودة عربية أعلى لتمارين البكالوريا. fallback chain يحمي
+    # الاستمرارية إن لم يكن متاحاً في OpenRouter (يمكن تبديل سريع عبر env).
+    PRIMARY = _resolve_primary_model("google/gemma-4-31b-it:free")
     LOW_COST = PRIMARY
     GATEWAY_PRIMARY = PRIMARY
     GATEWAY_FALLBACK_1 = AvailableModels.GEMINI_2_FLASH_EXP_FREE

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -24,8 +24,11 @@ from app.core.http_client_factory import HTTPClientConfig, get_http_client
 from app.core.settings.base import get_settings
 from app.infrastructure.clients.routing_policy import ChatRoutingPolicy
 from app.services.capabilities.exercise_retrieval import (
+    ExerciseRetrievalDecision,
     ExerciseRetrievalRequest,
     detect_exercise_retrieval,
+    format_exercise_for_display,
+    load_exercise_content,
 )
 from app.services.capabilities.exercise_retrieval import (
     make_result as make_exercise_result,
@@ -86,6 +89,14 @@ class OrchestratorClient:
         decision = detect_exercise_retrieval(ExerciseRetrievalRequest(question=question))
         return decision.recognized
 
+    def _exercise_retrieval_full_decision(self, question: str) -> ExerciseRetrievalDecision:
+        """نسخة كاملة من القرار تُرجِع matched_entry لاستخدامه في الاسترجاع المُفهرَس.
+
+        ISS-051: قبل هذا الإصلاح كنا نرمي matched_entry ونستدعي wide-net search
+        الذي يقرأ كل ملفات knowledge_base/ فيُعيد أكثر من تمرين دفعة واحدة.
+        """
+        return detect_exercise_retrieval(ExerciseRetrievalRequest(question=question))
+
     async def _execute_shell_tool(
         self,
         command: str,
@@ -131,10 +142,31 @@ class OrchestratorClient:
         return result.message
 
     async def _build_local_retrieval_response(self, question: str) -> str | None:
-        """ينفذ استرجاعاً محلياً للمعرفة التعليمية عند تعطل service control plane."""
-        if not self._exercise_retrieval_decision(question):
+        """
+        ينفذ استرجاعاً محلياً للمعرفة التعليمية عند تعطل service control plane.
+
+        ISS-051 (D-048 — Indexed Knowledge Retrieval):
+        المسار المُفضَّل: استخدام matched_entry من knowledge_index.py لجلب ملف
+        واحد بالضبط وتنسيقه كبطاقة امتحان نظيفة (بدون YAML، بدون حل).
+
+        المسار البديل: عند فشل المطابقة المُفهرَسة (entry غير موجود في الفهرس)،
+        نلجأ إلى wide-net search كما في النسخة القديمة — لكنه نادر الآن
+        لأن detect_exercise_retrieval يستخرج matched_entry بنفسه.
+        """
+        decision = self._exercise_retrieval_full_decision(question)
+        if not decision.recognized:
             return None
 
+        # المسار المُفضَّل — مطابقة مُفهرَسة دقيقة (ملف واحد، نص نظيف)
+        if decision.matched_entry is not None:
+            try:
+                raw_content = load_exercise_content(decision.matched_entry)
+                if raw_content:
+                    return format_exercise_for_display(decision.matched_entry, raw_content)
+            except Exception:
+                logger.warning("indexed_retrieval_failed", exc_info=True)
+
+        # المسار البديل — wide-net search (legacy)
         try:
             from app.services.chat.tools.retrieval.service import search_educational_content
 
@@ -144,6 +176,57 @@ class OrchestratorClient:
         except Exception:
             logger.warning("local_retrieval_fallback_failed", exc_info=True)
             return None
+
+    async def _stream_local_retrieval_response(
+        self,
+        question: str,
+    ) -> AsyncGenerator[str, None]:
+        """
+        نسخة انسيابية من ``_build_local_retrieval_response`` — تبث المحتوى
+        المسترجَع كلمة بكلمة لإنشاء typing-effect بدل dump واحد كبير.
+
+        D-048: المحتوى المُسترجَع ثابت (ليس LLM streaming حقيقي)، لكننا نُقسّمه
+        إلى أسطر/فقرات صغيرة ونُغذّيها واحدة تلو الأخرى مع تأخيرات صغيرة
+        ليظهر للطالب كأنه يُكتب فوراً أمام عينيه.
+
+        إذا أصدر المولِّد صفر قطعة → fallback chain يتقدم للخطوة التالية.
+        """
+        import asyncio
+
+        full_response = await self._build_local_retrieval_response(question)
+        if not full_response:
+            return
+
+        try:
+            from app.telemetry.path_observer import mark_fallback_used
+
+            mark_fallback_used("local_retrieval_stream")
+        except Exception:
+            pass
+
+        # نُقسِّم على حدود الكلمات/الفقرات لتجنب كسر LaTeX markers (\\(, $$, ...)
+        # الاستراتيجية: نُرسل سطراً سطراً، وإذا كان السطر طويلاً نُقسِّمه إلى
+        # قطع ~80 حرفاً عند مسافات الكلمات (لا داخل tokens رياضية).
+        lines = full_response.splitlines(keepends=True)
+        for line in lines:
+            if len(line) <= 80:
+                yield line
+                await asyncio.sleep(0.012)
+                continue
+            # سطر طويل — نُقسِّمه عند الفراغات
+            buffer = ""
+            for token in line.split(" "):
+                candidate = f"{buffer}{token} " if buffer else f"{token} "
+                if len(candidate) > 60:
+                    if buffer:
+                        yield buffer
+                        await asyncio.sleep(0.010)
+                    buffer = f"{token} "
+                else:
+                    buffer = candidate
+            if buffer:
+                yield buffer
+                await asyncio.sleep(0.010)
 
     @staticmethod
     def _format_history_for_prompt(history_messages: list[dict[str, str]]) -> str:
@@ -718,25 +801,46 @@ class OrchestratorClient:
                 )
                 return
 
+            # ── Exercise retrieval — STREAMING path (D-048) ──
+            # يبث محتوى التمرين المُسترجَع كلمة بكلمة بدل dump واحد كبير.
+            # ISS-051: المسار القديم كان يُرسل النص الكامل في assistant_delta
+            # واحد → لا typing-effect. الآن نُقسّم على حدود الأسطر/الكلمات.
             _ret_t0 = time.perf_counter()
             _ret_ctx = None
             with contextlib.suppress(Exception):
                 _ret_ctx = obs.start_trace(
-                    "orchestrator.fallback.exercise_retrieval",
+                    "orchestrator.fallback.exercise_retrieval.stream",
                     parent_context=_root_ctx,
-                    tags={"fallback_step": "exercise_retrieval"},
+                    tags={"fallback_step": "exercise_retrieval_stream"},
                 )
-            local_retrieval_response = await self._build_local_retrieval_response(question)
+            ret_streamed_any = False
+            ret_streamed_chars = 0
+            try:
+                async for chunk in self._stream_local_retrieval_response(question):
+                    if not chunk:
+                        continue
+                    ret_streamed_any = True
+                    ret_streamed_chars += len(chunk)
+                    yield self._normalize_stream_event(
+                        {"type": "assistant_delta", "payload": {"content": chunk}}
+                    )
+            except Exception:
+                logger.warning("local_retrieval_stream_yield_failed", exc_info=True)
+
             try:
                 if _ret_ctx:
                     obs.end_span(
                         _ret_ctx.span_id,
-                        status="OK" if local_retrieval_response else "SKIP",
-                        metrics={"duration_ms": (time.perf_counter() - _ret_t0) * 1000},
+                        status="OK" if ret_streamed_any else "SKIP",
+                        metrics={
+                            "duration_ms": (time.perf_counter() - _ret_t0) * 1000,
+                            "stream_chars": float(ret_streamed_chars),
+                        },
                     )
             except Exception:
                 pass
-            if local_retrieval_response:
+
+            if ret_streamed_any:
                 if _root_ctx:
                     with contextlib.suppress(Exception):
                         obs.end_span(
@@ -745,11 +849,9 @@ class OrchestratorClient:
                             metrics={
                                 "duration_ms": (time.perf_counter() - _t0) * 1000,
                                 "fallback_path": 2.0,
+                                "stream_chars": float(ret_streamed_chars),
                             },
                         )
-                yield self._normalize_stream_event(
-                    {"type": "assistant_delta", "payload": {"content": local_retrieval_response}}
-                )
                 yield self._normalize_stream_event(
                     {"type": "assistant_final", "payload": {"content": ""}}
                 )

--- a/app/services/capabilities/exercise_retrieval.py
+++ b/app/services/capabilities/exercise_retrieval.py
@@ -343,6 +343,82 @@ def load_exercise_content(entry: ExerciseEntry) -> str | None:
     return file_path.read_text(encoding="utf-8")
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# عرض التمرين بشكل نظيف للطالب (D-048)
+#
+# قبل ISS-051: الاسترجاع كان يُرجع كامل محتوى الملف (YAML + نص التمرين +
+# عناصر الإجابة النموذجية) مما يُسبب فوضى بصرية وكشف الحلول قبل الأوان.
+#
+# بعد ISS-051: نُخرج فقط بطاقة الامتحان + نص التمرين، ونحذف:
+#   1. YAML frontmatter
+#   2. كل ما يلي "عناصر الإجابة" أو "الحل" أو "Solution"
+#   3. وسوم البحث في نهاية الملف
+# ─────────────────────────────────────────────────────────────────────────────
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
+
+# قواطع نهاية نص التمرين — أي قسم يبدأ بأحد هذه العناوين يُحذف وما بعده
+_SOLUTION_SECTION_MARKERS: tuple[str, ...] = (
+    "## عناصر الإجابة",
+    "## الإجابة النموذجية",
+    "## الحل",
+    "## الإجابة",
+    "## شرح الحل",
+    "## Solution",
+    "## Model Answer",
+    "## Answer",
+    "## وسوم البحث",
+    "## Tags",
+    "### الجزء I",  # بداية الشرح المفصَّل
+    "### الجزء II",
+    "### الجزء III",
+)
+
+
+def _strip_frontmatter(content: str) -> str:
+    """يحذف YAML frontmatter من بداية ملف markdown."""
+    return _FRONTMATTER_RE.sub("", content, count=1).lstrip()
+
+
+def _trim_at_solution(content: str) -> str:
+    """يقطع المحتوى عند أول قسم يحوي عناصر الإجابة/الحل/الوسوم."""
+    cut_index: int | None = None
+    for marker in _SOLUTION_SECTION_MARKERS:
+        idx = content.find(marker)
+        if idx == -1:
+            continue
+        if cut_index is None or idx < cut_index:
+            cut_index = idx
+    if cut_index is None:
+        return content.rstrip()
+    return content[:cut_index].rstrip()
+
+
+def format_exercise_for_display(entry: ExerciseEntry, raw_content: str) -> str:
+    """
+    يُهيِّئ محتوى التمرين لعرض نظيف للطالب — فقط نص التمرين، بدون YAML أو حل.
+
+    يحل ISS-051:
+      - YAML frontmatter يظهر للطالب
+      - عناصر الإجابة النموذجية تُكشف قبل أن يحل الطالب
+      - وسوم البحث في الأسفل
+      - أكثر من تمرين يظهر في رد واحد (لأن الـ wide-net retrieval كان يقرأ كل
+        ملفات .md؛ الآن نقرأ ملفاً واحداً مطابقاً بالضبط)
+
+    Args:
+        entry: السجل المطابق من knowledge_index.
+        raw_content: محتوى الملف الخام (مع YAML + الحل).
+
+    Returns:
+        محتوى نظيف يحوي: عنوان + بطاقة الامتحان + نص التمرين فقط.
+    """
+    if not raw_content:
+        return ""
+    no_frontmatter = _strip_frontmatter(raw_content)
+    questions_only = _trim_at_solution(no_frontmatter)
+    return questions_only.strip()
+
+
 def make_result(raw_result: str | None, entry: ExerciseEntry | None = None) -> ExerciseRetrievalResult:
     """يحوّل النتيجة الخام إلى عقد موحد دون كسر السلوك التاريخي."""
     if raw_result is None or not raw_result.strip():


### PR DESCRIPTION
Surgical fix for the catastrophic exercise-display issue + primary-model swap to `inclusionai/ring-2.6-1t:free`.

## The catastrophe (before this PR)

Asking *"تمرين 2016 الدورة الأولى الموضوع الثاني التمرين الرابع"* returned:

1. The 2016 numerical functions file ✅
2. **Plus the unrelated 2024 probability file** ❌
3. Raw YAML metadata (`---\nmetadata:\n...---`) leaking into the visible response ❌
4. The full model-answer section exposed before the student even tried to solve ❌
5. All delivered as **one giant non-streaming dump** (~30s wait then burst) ❌

## Five root causes — addressed in one pass

### 1. Wasted `matched_entry` from `knowledge_index`
`_exercise_retrieval_decision()` threw away `ExerciseRetrievalDecision.matched_entry` and kept only the bool. Added `_exercise_retrieval_full_decision()` that preserves the full decision so the indexed entry can drive single-file load.

### 2. Wide-net leakage
`_build_local_retrieval_response()` called `search_educational_content()` with no filters → `local_store` scanned every `.md` in `knowledge_base/` → both files returned. New path: `load_exercise_content(matched_entry)` reads exactly one file. Wide-net retained only as a legacy fallback when `matched_entry is None`.

### 3. YAML + solution + tags pollution
New `format_exercise_for_display()` strips frontmatter and trims at the first solution/tags marker (`## عناصر الإجابة`, `### الجزء I`, `## وسوم البحث`, etc.). Smoke test on bac2016 file: **10884 → 2913 chars (73% noise removed)**, all three exam parts I/II/III intact, solution + YAML + tags gone.

### 4. No streaming for retrieval
`chat_with_agent()` fallback path #2 was yielding the full retrieval response as a single `assistant_delta`. Added `_stream_local_retrieval_response()` that splits on line/word boundaries (≤80-char chunks) and emits each chunk with `asyncio.sleep(0.012)` for visible typing-effect. LaTeX markers (`$$`, `\\(\\)`) are preserved atomically — never split mid-token.

### 5. Primary model: `inclusionai/ring-2.6-1t:free` (final)
`app/core/ai_config.py` `PRIMARY` per user request — Inclusion AI Ring 2.6, 1T-parameter mixture-of-experts, free tier on OpenRouter. Higher-quality Arabic tutoring + math reasoning. Fallback chain unchanged so continuity holds if model unavailable. Override via `OPENROUTER_PRIMARY_MODEL` env var (no rebuild).

> *History note: an earlier commit on this branch tried `google/gemma-4-31b-it:free` first; that was reverted the same day in favor of `inclusionai/ring-2.6-1t:free`. See `.memory/decisions.md` D-049 for the full audit trail.*

## Docs updated

- **CLAUDE.md §6.29** — Indexed Knowledge Retrieval doctrine with the 5 permanent rules + how to add new KB files safely + final model.
- **.memory/issues.md ISS-051** — full forensic breakdown.
- **.memory/decisions.md** — D-048 (Indexed Retrieval) + D-049 (Model Switch with three-step history).

## Test plan

- [x] AST + ruff clean for `app/core/ai_config.py` (other 3 ruff errors are pre-existing, not from this PR).
- [x] Smoke test on `bac2016_s1_math_exp_subject2_ex4_numerical_functions.md`: 10884 → 2913 chars; YAML stripped; solution stripped; all 3 parts present.
- [x] 6/6 intent classifier scenarios pass:
  - catastrophe query → retrieve ✅
  - explanation override (`اشرح الجزء أ من هذا التمرين`) → no retrieve ✅
  - greeting (`السلام عليكم`) → no retrieve ✅
  - concept question (`ما هو التكامل`) → no retrieve ✅
  - explicit probability request → retrieve ✅
- [ ] Live verify in a Codespace: ask the catastrophe query, confirm only the 2016 file appears, with typing-effect, no YAML, no solution.
- [ ] Verify `inclusionai/ring-2.6-1t:free` is reachable via OpenRouter; if 404, fallback chain handles it.

## Architecture invariants (must remain true)

1. `_build_local_retrieval_response()` MUST prefer `matched_entry` before any wide-net call.
2. `_SOLUTION_SECTION_MARKERS` MUST cover every solution-section start in `knowledge_base/`. Adding new KB files requires extending this list if their headers differ.
3. The streaming fallback path #2 MUST call `_stream_local_retrieval_response()` not the non-streaming variant — otherwise the typing-effect contract (D-047) breaks for retrieval queries.
4. `_resolve_primary_model()` is the single entry point for model overrides — do not bypass it.

https://claude.ai/code/session_01LCC8qcAvmqfqDHt1ACFbaT