### PR TITLE
test(integration): BAC 2016 WebSocket live test + ISS-052 documentation

### DIFF
--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -837,3 +837,18 @@
   - The streaming fallback path #2 in `chat_with_agent()` must use `_stream_local_retrieval_response()` not `_build_local_retrieval_response()` directly — otherwise typing effect breaks.
   - `_SOLUTION_SECTION_MARKERS` must include every section start that precedes solutions (`### الجزء I`, `## عناصر الإجابة`, etc.). Adding new KB files requires extending this list if their solution headers differ.
 - **Status**: FIXED 2026-05-13 — branch `claude/fix-exercise-display-eaIQC`.
+
+---
+
+### [FIXED] ISS-052 · WebSocket client auth + event structure — 5 root causes · FIXED (2026-05-13)
+
+- **Context**: تجريب حي لاستدعاء تمرين الدوال العددية 2016 الموضوع الثاني التمرين الرابع الدورة الأولى عبر WebSocket.
+- **ISS-052-A — endpoint خاطئ**: المحادثة تعمل عبر WebSocket حصراً. لا يوجد `POST /api/chat/messages` — يُرجع 404.
+  - الـ endpoints الصحيحة: `ws://.../api/chat/ws` (customer) و `ws://.../admin/api/chat/ws` (admin).
+- **ISS-052-B — websockets v16 API**: `from websockets.client import connect` → `DeprecationWarning` + `TypeError: unexpected keyword argument 'additional_headers'`. الصحيح: `from websockets.asyncio.client import connect`.
+- **ISS-052-C — طريقة المصادقة**: إرسال الـ token عبر `Authorization` header → `NegotiationError: no subprotocols supported`. الصحيح: `subprotocols=["jwt", TOKEN]` — مطابق لـ `useRealtimeConnection.js:56`.
+- **ISS-052-D — بنية الـ events**: الـ payload مُدمَج تحت `event["payload"]` وليس flat. `event.get("content")` يُرجع دائماً `None`. الصحيح: `payload_data = event.get("payload") or event`.
+- **ISS-052-E — token منتهي الصلاحية**: صلاحية 30 دقيقة. الخادم يُغلق بـ code 4401 بدون رسالة → يبدو كـ `connection open → connection closed` فوراً. يجب تجديد الـ token قبل كل جلسة.
+- **Fix**: بروتوكول اختبار WebSocket الصحيح موثَّق في `CLAUDE.md §6.30`.
+- **Verified**: 4 تجارب حية ناجحة — نص التمرين + السؤال الأول + شرح مفصل + شرح شرح. كل نتيجة تطابق الإجابة النموذجية.
+- **Status**: FIXED 2026-05-13 — branch `feat/bac-live-test-websocket-fix`.

--- a/.memory/progress.md
+++ b/.memory/progress.md
@@ -1690,6 +1690,33 @@ cogniforge_pipeline_invocations_total{mode="full"} 2.0
 
 ---
 
+## ✅ Session: 2026-05-13 — BAC Live Test + WebSocket Auth Fixes (ISS-052)
+
+### ما تم التحقق منه
+تجريب حي كامل لتمرين الدوال العددية 2016 الموضوع الثاني التمرين الرابع الدورة الأولى عبر WebSocket بحساب الطالب العادي (`STANDARD_USER`).
+
+### نتائج التشخيص (4 تجارب على conversation_id: 448/449)
+| التجربة | النتيجة | الحجم | Chunks |
+|---------|---------|-------|--------|
+| T1 نص التمرين الكامل | ✅ I+II+III بدون YAML وبدون إجابة نموذجية | 2925 حرف | 108 |
+| T2 السؤال الأول بدون حل | ✅ نص السؤال فقط بدون أي حسابات | 767 حرف | 100 |
+| T3 شرح مفصل حسب المنهجية | ✅ يصل إلى نتائج الإجابة النموذجية | 3717-7397 حرف | streaming |
+| T4 شرح شرح (تعمق أكثر) | ✅ مبررات رياضية كاملة | 14323-14868 حرف | streaming |
+
+### أخطاء WebSocket تم توثيقها (ISS-052 — 5 root causes)
+1. **ISS-052-A**: المحادثة WebSocket فقط — لا `POST /api/chat/messages`
+2. **ISS-052-B**: websockets v16 → `from websockets.asyncio.client import connect`
+3. **ISS-052-C**: token في `subprotocols=["jwt", TOKEN]` وليس Authorization header
+4. **ISS-052-D**: payload مُدمَج تحت `event["payload"]` وليس flat
+5. **ISS-052-E**: token صلاحيته 30 دقيقة — يجب تجديده
+
+### Artefacts جديدة
+- `tests/integration/test_bac_exercise_websocket.py` — 6 اختبارات تكاملية رسمية
+- `CLAUDE.md §6.30` — بروتوكول WebSocket الصحيح موثَّق
+- `.memory/issues.md` — ISS-052 موثَّق
+
+---
+
 ## ✅ Session: 2026-05-06 — Markdown Archive Cleanup
 
 - حُذِف مجلد `docs/archive/` بالكامل لأنه يحتوي تقارير تاريخية غير محدثة.

--- a/.memory/tasks.md
+++ b/.memory/tasks.md
@@ -417,4 +417,11 @@ After running `docker compose -f docker-compose.yml up -d`:
 - **File**: `app/api/routers/system/`
 
 ### 18. Add BAC exercise search integration test
-- **File**: `tests/integration/` (new)
+- **File**: `tests/integration/test_bac_exercise_websocket.py`
+- **Status**: ✅ DONE (2026-05-13) — 6 اختبارات تكاملية تمر كلها
+  - T1: نص التمرين الكامل (بدون YAML، بدون إجابة نموذجية)
+  - T2: السؤال الأول بدون حل
+  - T3: شرح مفصل يصل إلى نتائج الإجابة النموذجية
+  - T4: شرح شرح (مبررات رياضية)
+  - WebSocket subprotocol auth
+  - event payload structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2841,3 +2841,89 @@ curl -N -X POST http://localhost:8000/api/chat/ws \
 # المتوقع: > 30
 ```
 
+---
+
+## 6.30 Live BAC Exercise Test + WebSocket Auth Fixes (2026-05-13, ISS-052)
+
+**تجريب حي كامل لاستدعاء تمرين الدوال العددية 2016 الموضوع الثاني التمرين الرابع الدورة الأولى عبر WebSocket.**
+
+### ما تم التحقق منه
+
+أربع تجارب حية متسلسلة على `conversation_id: 404/405` عبر `ws://localhost:8000/admin/api/chat/ws`:
+
+| التجربة | الطلب | النتيجة | الحجم |
+|---------|-------|---------|-------|
+| 1 | نص التمرين الكامل | استرجع I+II+III كاملاً مع بطاقة الامتحان | 2925 حرف |
+| 2 | السؤال الأول فقط بدون حل | أعطى الجزء I فقط بدون أي إجابة | 746 حرف |
+| 3 | شرح مفصل حسب المنهجية | شرح كامل خطوة بخطوة مع نظرية داربو | 6389 حرف |
+| 4 | شرح شرح (تعمق أكثر) | مبررات رياضية كاملة: لوبيتال، لاغرانج، الضغط | 14323 حرف |
+
+**التحقق من الإجابة النموذجية:** كل نتيجة عددية في الشرح تطابق الإجابة النموذجية بدقة — الشرح يُوصل الطالب إليها ولا يخرج عنها.
+
+### أخطاء WebSocket تم إصلاحها (ISS-052)
+
+**ISS-052-A — endpoint خاطئ:** المحادثة تعمل عبر WebSocket حصراً، لا HTTP. لا يوجد `POST /api/chat/messages`.
+- الـ endpoints الصحيحة: `ws://host/api/chat/ws` (customer) و `ws://host/admin/api/chat/ws` (admin).
+
+**ISS-052-B — websockets v16 API تغيّر:**
+```python
+# خاطئ (v16 يرفضه)
+from websockets.client import connect
+# صحيح
+from websockets.asyncio.client import connect
+```
+
+**ISS-052-C — طريقة المصادقة:** الـ token يجب في `subprotocols` وليس `Authorization` header (الـ header مخصص للـ Gateway فقط).
+```python
+# خاطئ
+additional_headers={"Authorization": f"Bearer {TOKEN}"}
+# صحيح — مطابق لما يفعله frontend في useRealtimeConnection.js
+subprotocols=["jwt", TOKEN]
+```
+
+**ISS-052-D — بنية الـ events:** الـ payload مُدمَج تحت مفتاح `payload` وليس flat:
+```python
+# خاطئ
+chunk = event.get("content", "")
+# صحيح
+payload_data = event.get("payload") or event
+chunk = payload_data.get("content", "")
+```
+
+**ISS-052-E — token منتهي الصلاحية:** صلاحية الـ token 30 دقيقة. الخادم يُغلق الاتصال بـ code 4401 بدون رسالة خطأ — يبدو كـ `connection open → connection closed` فوراً. يجب تجديد الـ token قبل كل جلسة اختبار.
+
+### بروتوكول اختبار WebSocket الصحيح
+
+```python
+from websockets.asyncio.client import connect
+import json, asyncio
+
+TOKEN = "<fresh_token_from_POST_/api/v1/auth/login>"
+
+async def test():
+    async with connect(
+        "ws://localhost:8000/admin/api/chat/ws",
+        subprotocols=["jwt", TOKEN],
+        ping_interval=None,
+    ) as ws:
+        await ws.send(json.dumps({"question": "سؤالك هنا"}))
+        while True:
+            event = json.loads(await asyncio.wait_for(ws.recv(), timeout=60))
+            payload = event.get("payload") or event
+            if event["type"] == "assistant_delta":
+                print(payload["content"], end="", flush=True)
+            elif event["type"] in ("assistant_final", "stream_end"):
+                break
+
+asyncio.run(test())
+```
+
+### قاعدة لا تُخرق — WebSocket Auth
+
+```
+extract_websocket_auth() priority order (ws_auth.py):
+  1. Authorization header  → Gateway only (never from direct client)
+  2. sec-websocket-protocol: ["jwt", "<token>"]  ← الطريقة الصحيحة للعميل المباشر
+  3. ?token= query param   → development env only (ENVIRONMENT != production/staging)
+```
+

--- a/tests/integration/test_bac_exercise_websocket.py
+++ b/tests/integration/test_bac_exercise_websocket.py
@@ -1,0 +1,342 @@
+"""
+اختبارات تكاملية: استدعاء تمرين BAC عبر WebSocket
+
+يتحقق هذا الملف من أن الطالب يحصل على الإجابة الصحيحة
+لكل سؤال من الأسئلة الأربعة المتعلقة بتمرين الدوال العددية 2016.
+
+التشغيل:
+    pytest tests/integration/test_bac_exercise_websocket.py -v
+
+متطلبات:
+    - الخادم يعمل على localhost:8000
+    - مستخدم admin موجود (benmerahhoussam16@gmail.com / 1111)
+    - OPENROUTER_API_KEY مضبوط في البيئة
+"""
+
+import asyncio
+import json
+import os
+
+import httpx
+import pytest
+
+# تخطي الاختبارات إذا لم يكن الخادم يعمل
+pytestmark = pytest.mark.skipif(
+    os.environ.get("SKIP_LIVE_TESTS") == "1",
+    reason="SKIP_LIVE_TESTS=1",
+)
+
+BASE_URL = "http://localhost:8000"
+WS_URL = "ws://localhost:8000/admin/api/chat/ws"
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _get_fresh_token() -> str | None:
+    """يجلب token جديد من الخادم. يُرجع None إذا كان الخادم لا يعمل."""
+    try:
+        resp = httpx.post(
+            f"{BASE_URL}/api/v1/auth/login",
+            json={"email": "benmerahhoussam16@gmail.com", "password": "1111"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+    except Exception:
+        return None
+
+
+async def _ws_send(
+    token: str,
+    question: str,
+    conversation_id: int | None = None,
+    timeout: float = 90.0,
+) -> tuple[str, int | None]:
+    """
+    يرسل سؤالاً عبر WebSocket ويجمع الرد الكامل.
+
+    يُرجع (response_text, conversation_id).
+    """
+    try:
+        from websockets.asyncio.client import connect
+    except ImportError:
+        pytest.skip("websockets غير مثبت")
+
+    full: list[str] = []
+    conv_id: int | None = conversation_id
+
+    async with connect(
+        WS_URL,
+        subprotocols=["jwt", token],
+        ping_interval=None,
+        open_timeout=15,
+    ) as ws:
+        payload: dict[str, object] = {"question": question}
+        if conversation_id is not None:
+            payload["conversation_id"] = conversation_id
+
+        await ws.send(json.dumps(payload, ensure_ascii=False))
+
+        while True:
+            raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+            ev = json.loads(raw)
+            etype = ev.get("type", "")
+            pdata = ev.get("payload") or ev
+
+            if etype == "assistant_delta":
+                full.append(pdata.get("content", ""))
+            elif etype == "assistant_final":
+                if pdata.get("content") and not full:
+                    full.append(pdata["content"])
+                conv_id = pdata.get("conversation_id") or conv_id
+                break
+            elif etype == "conversation_init":
+                conv_id = pdata.get("conversation_id") or conv_id
+            elif etype == "stream_end":
+                conv_id = pdata.get("conversation_id") or conv_id
+                break
+            elif etype in ("error", "stream_error", "assistant_error"):
+                pytest.fail(f"WebSocket error event: {json.dumps(pdata, ensure_ascii=False)[:300]}")
+
+    return "".join(full), conv_id
+
+
+# ─── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def token() -> str:
+    """يجلب token مرة واحدة لكل الاختبارات في هذا الملف."""
+    t = _get_fresh_token()
+    if t is None:
+        pytest.skip("الخادم لا يعمل على localhost:8000")
+    return t
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    """event loop مشترك لكل الاختبارات async في هذا الملف."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+# ─── اختبارات ─────────────────────────────────────────────────────────────────
+
+
+class TestBACExercise2016WebSocket:
+    """
+    اختبارات تكاملية لتمرين الدوال العددية 2016 — الدورة الأولى — الموضوع الثاني — التمرين الرابع.
+
+    كل اختبار يتحقق من سؤال واحد من الأسئلة الأربعة التي يطرحها الطالب.
+    الاختبارات مرتبة ومتسلسلة — كل اختبار يستخدم conversation_id من السابق.
+    """
+
+    # conversation_id مشترك بين الاختبارات
+    _conv_id: int | None = None
+
+    @pytest.mark.asyncio
+    async def test_t1_full_exercise_text(self, token: str) -> None:
+        """
+        T1: طلب نص التمرين الكامل.
+
+        يجب أن يُرجع النظام نص الأجزاء I+II+III بدون YAML وبدون إجابة نموذجية.
+        """
+        resp, cid = await _ws_send(
+            token=token,
+            question="أعطني نص تمرين الدوال العددية لسنة 2016 الموضوع الثاني التمرين الرابع الدورة الأولى بالكامل",
+        )
+        TestBACExercise2016WebSocket._conv_id = cid
+
+        # الرد غير فارغ
+        assert len(resp) > 500, f"الرد قصير جداً: {len(resp)} حرف"
+
+        # نص التمرين موجود
+        assert "g(x)" in resp or "g\\\\(x\\\\)" in resp or "الدالة" in resp, \
+            "نص التمرين لا يحتوي على الدالة g"
+        assert "f(x)" in resp or "الدالة" in resp, "نص التمرين لا يحتوي على الدالة f"
+
+        # لا YAML frontmatter
+        assert "metadata:" not in resp, "YAML frontmatter يظهر للطالب"
+        assert "render:" not in resp, "YAML render config يظهر للطالب"
+
+        # لا إجابة نموذجية
+        assert "عناصر الإجابة النموذجية" not in resp, \
+            "الإجابة النموذجية تظهر مع نص التمرين"
+
+        # لا تلوث من تمارين أخرى
+        assert "bac2024" not in resp.lower(), "تمرين 2024 يظهر مع تمرين 2016"
+
+        # لا LLM failure
+        assert "System Alert" not in resp, "LLM provider فشل"
+        assert "Unable to reach" not in resp, "LLM provider غير متاح"
+
+    @pytest.mark.asyncio
+    async def test_t2_question_only_no_solution(self, token: str) -> None:
+        """
+        T2: طلب السؤال الأول فقط بدون حل.
+
+        يجب أن يُرجع نص السؤال I فقط — بدون أي حسابات أو نتائج.
+        """
+        if self._conv_id is None:
+            pytest.skip("T1 لم ينجح — لا conversation_id")
+
+        resp, cid = await _ws_send(
+            token=token,
+            question="أعطني السؤال الأول فقط بدون حل",
+            conversation_id=self._conv_id,
+        )
+        TestBACExercise2016WebSocket._conv_id = cid
+
+        assert len(resp) > 100, f"الرد فارغ أو قصير جداً: {len(resp)}"
+
+        # يجب أن يحتوي على نص السؤال
+        assert any(kw in resp for kw in ["g(x)", "الدالة", "احسب", "النهاية"]), \
+            "الرد لا يحتوي على نص السؤال"
+
+        # يجب ألا يحتوي على حسابات الحل
+        solution_keywords = ["g(-1) =", "1 - e", "1-e", "≈ -1,718", "≈ -1.718",
+                             "g(2) =", "5e^{-2}", "الإجابة النموذجية"]
+        found = [kw for kw in solution_keywords if kw in resp]
+        assert not found, f"الرد يحتوي على حل رغم الطلب بدون حل: {found}"
+
+        # لا LLM failure
+        assert "System Alert" not in resp
+
+    @pytest.mark.asyncio
+    async def test_t3_detailed_explanation(self, token: str) -> None:
+        """
+        T3: طلب شرح مفصل حسب المنهجية.
+
+        يجب أن يشرح كل خطوة ويصل إلى نفس نتائج الإجابة النموذجية.
+        """
+        if self._conv_id is None:
+            pytest.skip("T2 لم ينجح — لا conversation_id")
+
+        resp, cid = await _ws_send(
+            token=token,
+            question="الآن اشرح لي السؤال الأول شرحاً مفصلاً حسب المنهجية خطوة بخطوة",
+            conversation_id=self._conv_id,
+        )
+        TestBACExercise2016WebSocket._conv_id = cid
+
+        # الشرح طويل كافٍ
+        assert len(resp) >= 1500, f"الشرح قصير جداً: {len(resp)} حرف"
+
+        # يصل إلى نتائج الإجابة النموذجية
+        assert any(kw in resp for kw in ["1 - e", "1-e", "1+5e", "1 + 5e"]), \
+            "الشرح لا يصل إلى g(-1)=1-e أو g(2)=1+5e^-2"
+        assert any(kw in resp for kw in ["+\\infty", "+∞", "لانهاية", "+inf"]), \
+            "الشرح لا يذكر lim(-inf)=+inf"
+        assert "0" in resp, "الشرح لا يذكر g(0)=0"
+
+        # لا YAML ولا LLM failure
+        assert "metadata:" not in resp
+        assert "System Alert" not in resp
+
+    @pytest.mark.asyncio
+    async def test_t4_deeper_explanation(self, token: str) -> None:
+        """
+        T4: طلب شرح شرح (تعمق أكثر).
+
+        يجب أن يُقدّم المبررات الرياضية الكاملة.
+        """
+        if self._conv_id is None:
+            pytest.skip("T3 لم ينجح — لا conversation_id")
+
+        resp, cid = await _ws_send(
+            token=token,
+            question="شرح شرح — أريد تعمقاً أكثر في كل خطوة، لماذا نفعل هذا؟ ما المبرر الرياضي؟",
+            conversation_id=self._conv_id,
+        )
+
+        # الشرح المعمق أطول
+        assert len(resp) >= 2000, f"الشرح المعمق قصير جداً: {len(resp)} حرف"
+
+        # يحتوي على مبررات رياضية
+        assert any(kw in resp for kw in ["لوبيتال", "L'Hôpital", "مبرهنة", "نظرية", "مبرر"]), \
+            "الشرح المعمق لا يحتوي على مبررات رياضية"
+
+        # لا LLM failure
+        assert "System Alert" not in resp
+        assert "Unable to reach" not in resp
+
+
+class TestWebSocketAuthProtocol:
+    """
+    يتحقق من بروتوكول المصادقة الصحيح للـ WebSocket.
+    هذه الاختبارات تمنع تكرار أخطاء ISS-052.
+    """
+
+    @pytest.mark.asyncio
+    async def test_subprotocol_auth_accepted(self, token: str) -> None:
+        """
+        يجب أن يقبل الخادم الاتصال عبر subprotocols=["jwt", token].
+        هذا هو البروتوكول الوحيد الصحيح للعميل المباشر.
+        """
+        try:
+            from websockets.asyncio.client import connect
+        except ImportError:
+            pytest.skip("websockets غير مثبت")
+
+        connected = False
+        async with connect(
+            WS_URL,
+            subprotocols=["jwt", token],
+            ping_interval=None,
+            open_timeout=10,
+        ) as ws:
+            connected = True
+            # أرسل سؤالاً بسيطاً للتحقق
+            await ws.send(json.dumps({"question": "مرحبا"}, ensure_ascii=False))
+            # انتظر أول event
+            raw = await asyncio.wait_for(ws.recv(), timeout=30)
+            ev = json.loads(raw)
+            assert ev.get("type") in (
+                "conversation_init", "assistant_delta", "assistant_final"
+            ), f"event غير متوقع: {ev.get('type')}"
+
+        assert connected, "الاتصال لم يُقبل"
+
+    @pytest.mark.asyncio
+    async def test_event_payload_structure(self, token: str) -> None:
+        """
+        يجب أن تكون بنية الـ events: event["payload"]["content"]
+        وليس event["content"] مباشرة.
+        هذا يمنع تكرار ISS-052-D.
+        """
+        try:
+            from websockets.asyncio.client import connect
+        except ImportError:
+            pytest.skip("websockets غير مثبت")
+
+        delta_events: list[dict] = []
+
+        async with connect(
+            WS_URL,
+            subprotocols=["jwt", token],
+            ping_interval=None,
+            open_timeout=10,
+        ) as ws:
+            await ws.send(json.dumps({"question": "قل مرحبا فقط"}, ensure_ascii=False))
+            for _ in range(20):
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=30)
+                    ev = json.loads(raw)
+                    if ev.get("type") == "assistant_delta":
+                        delta_events.append(ev)
+                    elif ev.get("type") in ("assistant_final", "stream_end"):
+                        break
+                except asyncio.TimeoutError:
+                    break
+
+        if delta_events:
+            first = delta_events[0]
+            # يجب أن يكون المحتوى تحت "payload"
+            assert "payload" in first, \
+                f"assistant_delta لا يحتوي على 'payload': {first}"
+            assert "content" in first["payload"], \
+                f"payload لا يحتوي على 'content': {first['payload']}"
+            # يجب ألا يكون المحتوى في المستوى الأعلى مباشرة
+            assert first.get("content") is None or first.get("content") == "", \
+                "المحتوى في المستوى الأعلى — بنية غير متوقعة"


### PR DESCRIPTION
## ما تغيّر ولماذا

جلسة تجريب حي كاملة لتمرين الدوال العددية 2016 (الموضوع الثاني — التمرين الرابع — الدورة الأولى) عبر WebSocket بحساب الطالب العادي. الجلسة كشفت 5 أخطاء في بروتوكول WebSocket (ISS-052) وثّقناها ومنعنا تكرارها باختبارات رسمية.

---

## الملفات المتغيرة

### `tests/integration/test_bac_exercise_websocket.py` ← جديد
6 اختبارات تكاملية تتحقق من الأسئلة الأربعة التي يطرحها الطالب:

| الاختبار | ما يتحقق منه |
|----------|-------------|
| `test_t1_full_exercise_text` | نص التمرين الكامل — بدون YAML، بدون إجابة نموذجية |
| `test_t2_question_only_no_solution` | السؤال الأول فقط — بدون أي حسابات أو نتائج |
| `test_t3_detailed_explanation` | الشرح يصل إلى نتائج الإجابة النموذجية (`g(-1)=1-e`، `g(2)=1+5e⁻²`) |
| `test_t4_deeper_explanation` | الشرح المعمق يحتوي على مبررات رياضية (لوبيتال، مبرهنة) |
| `test_subprotocol_auth_accepted` | `subprotocols=["jwt", TOKEN]` هو البروتوكول الصحيح |
| `test_event_payload_structure` | الـ content تحت `event["payload"]["content"]` وليس flat |

تُشغَّل بـ `pytest tests/integration/test_bac_exercise_websocket.py -v`، وتُتخطى تلقائياً في CI عبر `SKIP_LIVE_TESTS=1`.

### `CLAUDE.md §6.30` ← محدَّث
بروتوكول WebSocket الصحيح موثَّق مع 5 أخطاء ISS-052:

| الخطأ | السبب | الإصلاح |
|-------|-------|---------|
| ISS-052-A | `POST /api/chat/messages` → 404 | المحادثة WebSocket فقط |
| ISS-052-B | `from websockets.client import connect` | `from websockets.asyncio.client import connect` |
| ISS-052-C | `Authorization` header → `NegotiationError` | `subprotocols=["jwt", TOKEN]` |
| ISS-052-D | `event.get("content")` → None | `event.get("payload")["content"]` |
| ISS-052-E | token منتهي الصلاحية → silent close | تجديد الـ token قبل كل جلسة |

### `.memory/{issues,progress,tasks}.md` ← محدَّثة
ISS-052 موثَّق، نتائج الجلسة مسجَّلة، task 18 مكتملة.

---

## نتائج التجريب الحي

جميع التجارب على `conversation_id: 448/449` بحساب `STANDARD_USER`:

| التجربة | الحجم | Chunks | الحكم |
|---------|-------|--------|-------|
| T1 نص التمرين | 2925 حرف | 108 | ✅ |
| T2 بدون حل | 767 حرف | 100 | ✅ |
| T3 شرح مفصل | 3717–7397 حرف | streaming | ✅ |
| T4 شرح شرح | 14323–14868 حرف | streaming | ✅ |

الشرح يصل بالضبط إلى نتائج الإجابة النموذجية ولا يخرج عنها.