### PR TITLE
fix(orchestrator): resolve StateGraph execution hang via bounded structured-output I/O

### DIFF
--- a/microservices/orchestrator_service/src/services/llm/client.py
+++ b/microservices/orchestrator_service/src/services/llm/client.py
@@ -35,14 +35,19 @@ class AIClient:
         if not api_key:
             logger.warning("No API Key found for AI Client. AI features will fail.")
 
+        # DEADLOCK FIX: bound leaf-node streaming/generate I/O. Without an
+        # explicit timeout a stalled OpenRouter stream blocks the node
+        # indefinitely; a bounded client raises so the node's fallback engages.
         self.client = AsyncOpenAI(
             api_key=api_key or "dummy-key",
             base_url=base_url,
+            timeout=45.0,
         )
 
         self.sync_client = OpenAI(
             api_key=api_key or "dummy-key",
             base_url=base_url,
+            timeout=45.0,
         )
         # ISS-069 (2026-05-15): nemotron-3-nano-omni-30b-a3b-reasoning:free يضع الإجابة
         # في message.reasoning لا message.content → content=None مع system prompt.

--- a/microservices/orchestrator_service/src/services/overmind/graph/main.py
+++ b/microservices/orchestrator_service/src/services/overmind/graph/main.py
@@ -500,10 +500,17 @@ def _configure_dspy() -> None:
         ).strip()
         if not dspy_model.startswith("openai/"):
             dspy_model = f"openai/{dspy_model}"
+        # DEADLOCK FIX: bound the structured-output call. Without an explicit
+        # timeout (and with DSPy's default num_retries=8) a stalled free-tier
+        # OpenRouter connection blocks SupervisorNode's worker thread forever,
+        # hanging the graph at its entry node. A bounded call raises instead,
+        # letting the deterministic heuristic fallback engage.
         lm = dspy.LM(
             model=dspy_model,
             api_base="https://openrouter.ai/api/v1",
             api_key=openrouter_key,
+            timeout=25,
+            num_retries=0,
         )
         dspy.settings.configure(lm=lm)
     except Exception as exc:
@@ -589,8 +596,13 @@ class SupervisorNode:
                 return {"intent": "admin", "query": query}
 
         try:
-            result = await asyncio.to_thread(
-                self.dspy_classifier, history=formatted_history, question=query
+            # DEADLOCK FIX: separate routing from I/O — bound the structured-output
+            # classification so a stalled LLM cannot freeze the entry node. On
+            # timeout, asyncio.TimeoutError is caught below and routing falls
+            # through to the deterministic free-response heuristic.
+            result = await asyncio.wait_for(
+                asyncio.to_thread(self.dspy_classifier, history=formatted_history, question=query),
+                timeout=30.0,
             )
             try:
                 conf = float(result.confidence)
@@ -1103,14 +1115,19 @@ def route_intent(state: AgentState) -> str:
     if intent == "search":
         intent = "educational"
 
-    node = {
+    routing_map = {
         "educational": "query_rewriter",
         "admin": "admin_agent",
         "tool": "tool_executor",
         "chat": "chat_fallback",
         "general_knowledge": "general_knowledge",
-    }.get(intent, "query_rewriter")
-    logger.info(f"SUPERVISOR_NODE → routing to → {node}")
+    }
+    # DEADLOCK FIX: guarantee a valid branch. Returning a raw intent absent
+    # from the conditional-edge map raises a LangGraph "unknown branch" error;
+    # clamp unexpected intents to a deterministic default exit.
+    if intent not in routing_map:
+        intent = "educational"
+    logger.info(f"SUPERVISOR_NODE → routing to → {routing_map[intent]}")
     return intent
 
 
@@ -1201,6 +1218,10 @@ def create_unified_graph(admin_app=None, checkpointer=None):
     )  # tool_executor -> validator directly, bypassing synthesizer to not break admin outputs
     graph.add_edge("chat_fallback", "validator")
     graph.add_edge("synthesizer", "validator")
+    # DEADLOCK FIX: general_knowledge had no outgoing edge — a silent dead-end
+    # bypassing the quality gate. Wire it into the validator so every leaf
+    # exits through the single termination path.
+    graph.add_edge("general_knowledge", "validator")
 
     graph.add_conditional_edges("validator", check_quality, {"pass": END, "fail": "supervisor"})
 

--- a/tests/microservices/orchestrator_service/test_graph_deadlock_fix.py
+++ b/tests/microservices/orchestrator_service/test_graph_deadlock_fix.py
@@ -1,0 +1,88 @@
+"""Regression tests for the orchestrator graph deadlock fix.
+
+Root cause (resolved here): the unified StateGraph hung indefinitely at its
+entry node because the structured-output intent classification was unbounded
+I/O — ``dspy.LM`` had no ``timeout`` and ``SupervisorNode`` awaited it with no
+guard. A stalled OpenRouter connection blocked the worker thread forever and
+the deterministic free-response fallback was never reached.
+
+These tests lock in the deterministic-routing guarantees and the bounded /
+graceful-fallback behaviour. They import only from the import-light ``main``
+module (no DB / settings side effects).
+"""
+
+import asyncio
+
+import pytest
+
+from microservices.orchestrator_service.src.services.overmind.graph.main import (
+    SupervisorNode,
+    route_intent,
+)
+
+_VALID_BRANCHES = {"educational", "admin", "tool", "chat", "general_knowledge"}
+
+
+@pytest.mark.parametrize("unknown", ["GIBBERISH_XYZ", "", "search", None])
+def test_route_intent_always_returns_a_valid_branch(unknown):
+    """route_intent must never return a value absent from the conditional-edge
+    map — otherwise LangGraph raises an 'unknown branch' error (a hard exit
+    condition gap)."""
+    state = {} if unknown is None else {"intent": unknown}
+    assert route_intent(state) in _VALID_BRANCHES
+
+
+@pytest.mark.parametrize("intent", sorted(_VALID_BRANCHES))
+def test_route_intent_passes_through_valid_intents(intent):
+    assert route_intent({"intent": intent}) == intent
+
+
+@pytest.mark.asyncio
+async def test_supervisor_falls_back_when_classifier_raises():
+    """If structured-output classification fails, SupervisorNode must still
+    return a valid deterministic route instead of hanging or crashing."""
+    node = SupervisorNode()
+
+    def _failing_classifier(**_kwargs):
+        raise RuntimeError("structured output enforcement failed")
+
+    node.dspy_classifier = _failing_classifier
+    result = await node({"query": "اشرح نظرية النسبية بالتفصيل", "messages": []})
+    assert result.get("intent") in _VALID_BRANCHES
+
+
+@pytest.mark.asyncio
+async def test_supervisor_classification_is_timeout_bounded():
+    """A stalled classifier must not hang the entry node: the wait_for guard
+    fires and routing falls through to the deterministic heuristic. Bound the
+    test well under the production 30s guard via a patched, near-instant guard
+    so CI stays fast while still exercising the real code path."""
+    node = SupervisorNode()
+
+    def _stalling_classifier(**_kwargs):
+        # Cooperative stall longer than the (patched) guard window.
+        import time
+
+        time.sleep(2.0)
+        raise RuntimeError("should never be reached before timeout")
+
+    node.dspy_classifier = _stalling_classifier
+
+    real_wait_for = asyncio.wait_for
+
+    async def _fast_wait_for(awaitable, timeout):  # noqa: ARG001
+        return await real_wait_for(awaitable, timeout=0.2)
+
+    import microservices.orchestrator_service.src.services.overmind.graph.main as graph_main
+
+    original = graph_main.asyncio.wait_for
+    graph_main.asyncio.wait_for = _fast_wait_for
+    try:
+        started = asyncio.get_event_loop().time()
+        result = await node({"query": "اشرح نظرية النسبية بالتفصيل", "messages": []})
+        elapsed = asyncio.get_event_loop().time() - started
+    finally:
+        graph_main.asyncio.wait_for = original
+
+    assert result.get("intent") in _VALID_BRANCHES
+    assert elapsed < 1.5, f"entry node was not timeout-bounded: {elapsed:.2f}s"

--- a/tests/microservices/orchestrator_service/test_graph_deadlock_fix.py
+++ b/tests/microservices/orchestrator_service/test_graph_deadlock_fix.py
@@ -70,7 +70,7 @@ async def test_supervisor_classification_is_timeout_bounded():
 
     real_wait_for = asyncio.wait_for
 
-    async def _fast_wait_for(awaitable, timeout):  # noqa: ARG001
+    async def _fast_wait_for(awaitable, timeout):
         return await real_wait_for(awaitable, timeout=0.2)
 
     import microservices.orchestrator_service.src.services.overmind.graph.main as graph_main


### PR DESCRIPTION
## Summary

Resolves the orchestrator multi-agent graph hanging indefinitely without returning a final response.

### Root Cause Analysis
- **Point of failure:** `SupervisorNode.__call__` (entry node) → `await asyncio.to_thread(self.dspy_classifier, ...)`, backed by `_configure_dspy` where `dspy.LM(...)` was constructed with **no `timeout`** (and DSPy default `num_retries=8`). Secondary surface: `AIClient` `AsyncOpenAI(...)` with no `timeout`.
- **Root cause:** The hang is **not** a routing-topology cycle. It is **unbounded blocking I/O during structured-output classification**: when a free-tier OpenRouter connection stalls, the worker thread blocks forever, `asyncio.to_thread` never returns, and the graph never advances past node #1. The existing deterministic free-response heuristic fallback (which fires on a *raised* error) was never reached because the call neither returned nor raised.
- **Evidence:** Reproduced the exact node/edge topology on langgraph 1.2.0 — the `validator → supervisor` retry loop **terminates** (escape hatch bounds it at 1 retry) and the `general_knowledge` dead-end **ends gracefully**. So the topology cannot deadlock; the unbounded LM I/O is the cause.

### Fix (targeted, minimal)
- `_configure_dspy`: bound `dspy.LM` with `timeout=25, num_retries=0`.
- `SupervisorNode`: wrap the classifier in `asyncio.wait_for(..., 30s)` so a stall yields to the existing heuristic fallback (separates routing from I/O).
- `AIClient`: add `timeout=45s` to `AsyncOpenAI`/`OpenAI` (leaf-node streaming surface).
- `route_intent`: clamp unknown intents to a valid branch — deterministic exit (prevents a LangGraph "unknown branch" error).
- `create_unified_graph`: wire `general_knowledge → validator` (it was a silent dead-end bypassing the quality gate) — completes the single-exit invariant.

Pedagogical/skill routing (educational vs. tool vs. chat) is unchanged.

### Live verification (real OpenRouter)
- **Test A — standard routing:** admin query → `admin` in 0.00s (deterministic guard); factual query → `general_knowledge` in 5.53s (live DSPy structured output, no hang).
- **Test B — fallback routing:** stalled classifier → bounded at 30.0s via the guard → deterministic free-response fallback (`general_knowledge`), no hang, no loop. (Previously: indefinite hang.)
- **Topology:** validator retry loop bounded + new `general_knowledge → validator` edge proven to terminate.
- **Gates:** `ruff check` / `ruff format --check` clean; `runtime_truth.py --check` matches lock; `validate_structure.py` passes. Regression tests pass on Python 3.12 (CI interpreter).

## Test plan
- [ ] CI returns a clean SUCCESS on this branch.
- [x] `ruff` lint + format clean on changed files
- [x] runtime-truth + structure gates pass locally
- [x] New regression tests (`tests/microservices/orchestrator_service/test_graph_deadlock_fix.py`) pass on py3.12
- [x] Live Test A (standard routing) — returns without hanging
- [x] Live Test B (fallback routing) — graceful free-response, no loop

Do not merge.

https://claude.ai/code/session_01MC4CR7f4buNTifW3SZEEQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC4CR7f4buNTifW3SZEEQU)_