### PR TITLE
Redesign ProbabilityTree: portal tooltip + humanized fractions + semantic colours

### DIFF
--- a/frontend/app/components/generative/ProbabilityTree.jsx
+++ b/frontend/app/components/generative/ProbabilityTree.jsx
@@ -1,38 +1,110 @@
 "use client";
 
-import React, { memo, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 /**
  * ProbabilityTree — Cognitive UI (Explorable Explanation)
  * ────────────────────────────────────────────────────────
- * يحوّل شجرة الاحتمالات من قائمة عمودية ميتة إلى شجرة SVG تفاعلية:
+ * شجرة احتمالات SVG تفاعلية مُصمَّمة لطلاب الثانوي (لا قراءة آلية):
  *   • فروع منحنية (Bézier) بسماكة تتناسب مع الاحتمال (تدفّق الطاقة).
- *   • ظهور تدريجي متدرّج (staggered spawn) — الجذر ثم تتدفّق الفروع للأبناء.
- *   • عُقد زجاجية (glass-morphism) تفاعلية: hover/tap → تكبير + صيغة الاحتمال
- *     الشرطي P(B|A) واحتمال المسار التراكمي.
+ *   • ترميز لوني دلالي: مسار النجاح (دافئ أحمر/كهرماني) مقابل مسار
+ *     المكمِّل/الفشل (بارد نيلي) — العقدة وحافتها الواردة بنفس اللون.
+ *   • احتمالات بصيغة كسور إنسانية (½ ، ¾ ، 3⁄10) بدل الأرقام العشرية المجرّدة.
+ *   • تلميح (tooltip) يُصيَّر عبر React Portal على مستوى <body> فلا يُقصُّ
+ *     أبداً تحت العُقد الشقيقة (إصلاح كارثة z-index داخل <foreignObject>).
  *
  * شكل props المتوقَّع (من OrchestratorClient._detect_probability_tree):
  *   { title?, is_illustrative?, tree: { label, p?, children?[] } }
  * (نقبل props.data كبديل توافقي.)
  *
- * عند props مشوَّهة / شجرة ضخمة جداً → نُلقي استثناءً ليلتقطه
- * GenerativeUIErrorBoundary ويعرض fallback أنيق.
+ * عند props مشوَّهة / شجرة ضخمة جداً → نُلقي استثناءً يلتقطه
+ * GenerativeUIErrorBoundary فيعرض fallback أنيق.
  */
 
 // ─── هندسة التخطيط (px في فضاء viewBox) ───────────────────────────────────────
 const PAD = 30;
-const NODE_W = 150;
-const NODE_H = 54;
+const NODE_W = 154;
+const NODE_H = 56;
 const LEVEL_GAP = 200; // المسافة الأفقية بين المستويات
-const ROW_GAP = 96; // المسافة العمودية بين الأوراق
+const ROW_GAP = 100; // المسافة العمودية بين الأوراق
 const MAX_NODES = 160; // حدّ أمان — أكبر من ذلك يسقط للنص البديل
 
-const fmt = (p, digits = 2) =>
-    typeof p === 'number' && !Number.isNaN(p) ? p.toFixed(digits) : null;
+// ─── أدوات إنسنة الرياضيات: تحويل عشري → كسر ──────────────────────────────────
+// كسور Unicode الأنيقة لأكثر القيم شيوعاً في تمارين البكالوريا.
+const VULGAR_FRACTIONS = {
+    '1/2': '½',
+    '1/3': '⅓',
+    '2/3': '⅔',
+    '1/4': '¼',
+    '3/4': '¾',
+    '1/5': '⅕',
+    '2/5': '⅖',
+    '3/5': '⅗',
+    '4/5': '⅘',
+    '1/6': '⅙',
+    '5/6': '⅚',
+    '1/8': '⅛',
+    '3/8': '⅜',
+    '5/8': '⅝',
+    '7/8': '⅞',
+};
+
+const gcd = (a, b) => (b === 0 ? a : gcd(b, a % b));
 
 /**
- * يسطّح الشجرة إلى عُقد وحواف مع حساب الصف (row) والعمق واحتمال المسار التراكمي.
- * post-order: الأوراق تأخذ صفوفاً متتابعة، والعقدة الأم = متوسط صفوف أبنائها.
+ * يحوّل احتمالاً (0..1) إلى كسر بسيط إن أمكن (مقام ≤ 20، ضمن هامش صغير)،
+ * وإلا يُعيد القيمة العشرية فقط. يُعيد أيضاً رمز الكسر الأنيق عند توفّره.
+ */
+const decimalToFraction = (p) => {
+    if (typeof p !== 'number' || Number.isNaN(p)) return null;
+    const decimal = p.toFixed(p < 0.1 || p > 0.9 ? 3 : 2).replace(/\.?0+$/, '');
+    if (p <= 0) return { num: 0, den: 1, label: '0', vulgar: null, isClean: true, decimal };
+    if (p >= 1) return { num: 1, den: 1, label: '1', vulgar: null, isClean: true, decimal };
+
+    const MAX_DEN = 20;
+    const EPS = 1.5e-3;
+    let best = null;
+    for (let den = 2; den <= MAX_DEN; den += 1) {
+        const num = Math.round(p * den);
+        if (num <= 0 || num >= den) continue;
+        if (Math.abs(num / den - p) <= EPS) {
+            const g = gcd(num, den);
+            best = { num: num / g, den: den / g };
+            break;
+        }
+    }
+    if (!best) return { num: null, den: null, label: null, vulgar: null, isClean: false, decimal };
+    const key = `${best.num}/${best.den}`;
+    return {
+        num: best.num,
+        den: best.den,
+        label: key,
+        vulgar: VULGAR_FRACTIONS[key] || null,
+        isClean: true,
+        decimal,
+    };
+};
+
+// ─── الترميز اللوني الدلالي حسب نتيجة الفرع ───────────────────────────────────
+// المكمِّل (Ā ، B̄ ، علامة المدّ العلوي U+0304/U+0305 ، نفي صريح) = فشل/بارد.
+// خلاف ذلك = نجاح/دافئ. الجذر محايد.
+const COMPLEMENT_RE =
+    /[̄̅]|[ĀāŌōȲȳ]|\b(?:not|fail|echec|échec)\b|عدم|فشل|أسود|سالب/i;
+
+const classifyOutcome = (label, depth) => {
+    if (depth === 0) return 'root';
+    return COMPLEMENT_RE.test(label) ? 'failure' : 'success';
+};
+
+// قوة السماكة/الشفافية حسب الاحتمال (تدفّق الطاقة عبر الفرع)
+const strokeWidthFor = (p) => 2.5 + (p ?? 0.5) * 9; // 2.5 .. 11.5
+const opacityFor = (p) => 0.34 + (p ?? 0.5) * 0.58; // 0.34 .. 0.92
+
+/**
+ * يسطّح الشجرة إلى عُقد وحواف مع حساب الصف (row) والعمق واحتمال المسار التراكمي
+ * ونتيجة الفرع (outcome). post-order: الأوراق تأخذ صفوفاً متتابعة، والأم = متوسط
+ * صفوف أبنائها.
  */
 const layoutTree = (root) => {
     const nodes = [];
@@ -58,6 +130,7 @@ const layoutTree = (root) => {
             label: node.label,
             p,
             joint: nodeJoint,
+            outcome: classifyOutcome(node.label, depth),
             row: 0,
         };
         nodes.push(rec);
@@ -86,12 +159,27 @@ const layoutTree = (root) => {
     return { nodes, edges, width, height, xOf, yOf, maxDepth };
 };
 
-// قوة اللون/التوهج حسب الاحتمال
-const strokeWidthFor = (p) => 2.5 + (p ?? 0.5) * 9; // 2.5 .. 11.5
-const opacityFor = (p) => 0.32 + (p ?? 0.5) * 0.6; // 0.32 .. 0.92
+// ─── عرض الكسر (Fraction) ─────────────────────────────────────────────────────
+const FractionView = memo(({ frac, compact = false }) => {
+    if (!frac) return null;
+    if (frac.isClean && frac.vulgar) {
+        return <span className="genui-frac-vulgar">{frac.vulgar}</span>;
+    }
+    if (frac.isClean && frac.num !== null) {
+        return (
+            <span className="genui-frac" aria-label={`${frac.num} على ${frac.den}`}>
+                <span className="genui-frac-n">{frac.num}</span>
+                <span className="genui-frac-bar" aria-hidden="true" />
+                <span className="genui-frac-d">{frac.den}</span>
+            </span>
+        );
+    }
+    return <span className={`genui-frac-dec${compact ? ' is-compact' : ''}`}>{frac.decimal}</span>;
+});
+FractionView.displayName = 'FractionView';
 
-const Edge = memo(({ x1, y1, x2, y2, p, depth }) => {
-    // منحنى S أفقي بين حافة الأم اليسرى وحافة الابن اليمنى
+// ─── حافة منحنية موزونة بالاحتمال ولونها حسب نتيجة الابن ──────────────────────
+const Edge = memo(({ x1, y1, x2, y2, p, depth, outcome }) => {
     const dx = Math.max(40, (x1 - x2) * 0.5);
     const d = `M ${x1} ${y1} C ${x1 - dx} ${y1}, ${x2 + dx} ${y2}, ${x2} ${y2}`;
     return (
@@ -99,7 +187,7 @@ const Edge = memo(({ x1, y1, x2, y2, p, depth }) => {
             className="genui-edge"
             d={d}
             fill="none"
-            stroke="url(#genui-edge-grad)"
+            stroke={`url(#genui-edge-${outcome})`}
             strokeWidth={strokeWidthFor(p)}
             strokeLinecap="round"
             pathLength="1"
@@ -113,50 +201,90 @@ const Edge = memo(({ x1, y1, x2, y2, p, depth }) => {
 });
 Edge.displayName = 'Edge';
 
-const GlassNode = memo(({ node, x, y }) => {
-    const pLabel = fmt(node.p);
-    const jointLabel = fmt(node.joint, 3);
-    const isRoot = node.depth === 0;
+// ─── عقدة زجاجية تفاعلية ──────────────────────────────────────────────────────
+const GlassNode = memo(({ node, x, y, onShow, onHide, frac }) => {
+    const ref = useRef(null);
 
-    const formula = isRoot
-        ? 'نقطة البداية'
-        : pLabel !== null
-          ? `P(${node.label}) = ${pLabel}`
-          : `P(${node.label})`;
+    const reveal = useCallback(() => {
+        if (ref.current) onShow(node, ref.current.getBoundingClientRect());
+    }, [node, onShow]);
 
-    const spawnDelay = `${node.depth * 0.16 + (node.row % 4) * 0.04}s`;
+    const toggle = useCallback(() => {
+        if (ref.current) onShow(node, ref.current.getBoundingClientRect(), true);
+    }, [node, onShow]);
 
     return (
-        <foreignObject
-            x={x}
-            y={y}
-            width={NODE_W}
-            height={NODE_H}
-            style={{ overflow: 'visible' }}
-        >
+        <foreignObject x={x} y={y} width={NODE_W} height={NODE_H} style={{ overflow: 'visible' }}>
             <div
-                className={`genui-glass-node${isRoot ? ' genui-glass-root' : ''}`}
-                style={{ animationDelay: spawnDelay }}
+                ref={ref}
+                className="genui-glass-node"
+                data-outcome={node.outcome}
+                style={{ animationDelay: `${node.depth * 0.16 + (node.row % 4) * 0.04}s` }}
                 tabIndex={0}
                 role="button"
-                aria-label={`${node.label}${pLabel !== null ? `، الاحتمال ${pLabel}` : ''}`}
+                aria-label={`${node.label}${frac ? `، الاحتمال ${frac.label || frac.decimal}` : ''}`}
+                onMouseEnter={reveal}
+                onMouseLeave={onHide}
+                onFocus={reveal}
+                onBlur={onHide}
+                onClick={toggle}
             >
                 <span className="genui-node-label">{node.label}</span>
-                {pLabel !== null && <span className="genui-node-prob">{pLabel}</span>}
-
-                <div className="genui-node-tip" role="tooltip">
-                    <span className="genui-tip-formula">{formula}</span>
-                    {!isRoot && (
-                        <span className="genui-tip-joint">
-                            احتمال المسار = <strong>{jointLabel}</strong>
-                        </span>
-                    )}
-                </div>
+                {frac && (
+                    <span className="genui-node-prob" data-outcome={node.outcome}>
+                        <FractionView frac={frac} compact />
+                    </span>
+                )}
             </div>
         </foreignObject>
     );
 });
 GlassNode.displayName = 'GlassNode';
+
+// ─── التلميح عبر Portal (يطفو فوق كل شيء، لا يُقصّ أبداً) ──────────────────────
+const TooltipPortal = memo(({ tip }) => {
+    if (!tip) return null;
+    const { node, left, top, placement, frac, jointFrac } = tip;
+    const isRoot = node.depth === 0;
+    const formula = isRoot ? 'نقطة البداية' : `P(${node.label})`;
+
+    return createPortal(
+        <div
+            className="genui-tip-portal"
+            data-placement={placement}
+            data-outcome={node.outcome}
+            role="tooltip"
+            style={{ left: `${left}px`, top: `${top}px` }}
+        >
+            <span className="genui-tip-formula">
+                {formula}
+                {!isRoot && frac && (
+                    <>
+                        {' = '}
+                        <FractionView frac={frac} />
+                        {frac.decimal && <span className="genui-tip-dec">({frac.decimal})</span>}
+                    </>
+                )}
+            </span>
+            {!isRoot && (
+                <span className="genui-tip-joint">
+                    احتمال المسار ={' '}
+                    {jointFrac ? (
+                        <strong className="genui-tip-joint-val">
+                            <FractionView frac={jointFrac} />
+                            {jointFrac.decimal && (
+                                <span className="genui-tip-dec">({jointFrac.decimal})</span>
+                            )}
+                        </strong>
+                    ) : null}
+                </span>
+            )}
+            <span className="genui-tip-arrow" aria-hidden="true" />
+        </div>,
+        document.body,
+    );
+});
+TooltipPortal.displayName = 'TooltipPortal';
 
 export const ProbabilityTree = memo(({ props }) => {
     if (!props || typeof props !== 'object') {
@@ -169,10 +297,75 @@ export const ProbabilityTree = memo(({ props }) => {
     const { title, is_illustrative: isIllustrative } = props;
 
     // الحساب الهندسي مرة واحدة (يُلقي للـ ErrorBoundary عند التشوّه/الضخامة)
-    const { nodes, edges, width, height, xOf, yOf } = useMemo(
-        () => layoutTree(tree),
-        [tree],
+    const { nodes, edges, width, height, xOf, yOf } = useMemo(() => layoutTree(tree), [tree]);
+
+    // كسور محسوبة مسبقاً لكل عقدة (احتمال الفرع + احتمال المسار التراكمي)
+    const fracById = useMemo(() => {
+        const map = {};
+        for (const n of nodes) {
+            map[n.id] = {
+                p: n.p !== null ? decimalToFraction(n.p) : null,
+                joint: decimalToFraction(n.joint),
+            };
+        }
+        return map;
+    }, [nodes]);
+
+    const [mounted, setMounted] = useState(false);
+    const [tip, setTip] = useState(null);
+    const pinnedRef = useRef(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    const placeTip = useCallback(
+        (node, rect, pin = false) => {
+            // النقر يثبّت/يلغي التثبيت؛ التمرير يعرض فقط إن لم يكن مثبتاً
+            if (pin && pinnedRef.current && tip && tip.node.id === node.id) {
+                pinnedRef.current = false;
+                setTip(null);
+                return;
+            }
+            if (pin) pinnedRef.current = true;
+            const left = rect.left + rect.width / 2;
+            const placeAbove = rect.bottom + 130 > window.innerHeight;
+            setTip({
+                node,
+                left,
+                top: placeAbove ? rect.top - 10 : rect.bottom + 10,
+                placement: placeAbove ? 'above' : 'below',
+                frac: fracById[node.id]?.p || null,
+                jointFrac: fracById[node.id]?.joint || null,
+            });
+        },
+        [fracById, tip],
     );
+
+    const hideTip = useCallback(() => {
+        if (pinnedRef.current) return; // مثبَّت بنقرة → لا يُخفى بمغادرة المؤشر
+        setTip(null);
+    }, []);
+
+    // إغلاق التلميح عند التمرير/تغيير الحجم/مفتاح Escape (تفادي مواضع قديمة)
+    useEffect(() => {
+        if (!tip) return undefined;
+        const close = () => {
+            pinnedRef.current = false;
+            setTip(null);
+        };
+        const onKey = (e) => {
+            if (e.key === 'Escape') close();
+        };
+        window.addEventListener('scroll', close, true);
+        window.addEventListener('resize', close);
+        window.addEventListener('keydown', onKey);
+        return () => {
+            window.removeEventListener('scroll', close, true);
+            window.removeEventListener('resize', close);
+            window.removeEventListener('keydown', onKey);
+        };
+    }, [tip]);
 
     return (
         <div className="genui-probability-tree" dir="rtl">
@@ -200,10 +393,18 @@ export const ProbabilityTree = memo(({ props }) => {
                     aria-label="شجرة احتمالات تفاعلية"
                 >
                     <defs>
-                        <linearGradient id="genui-edge-grad" x1="0" y1="0" x2="1" y2="0">
-                            <stop offset="0%" stopColor="#22d3ee" />
-                            <stop offset="55%" stopColor="#3b82f6" />
+                        {/* تدرّجات لونية حسب نتيجة الفرع */}
+                        <linearGradient id="genui-edge-success" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0%" stopColor="#f59e0b" />
+                            <stop offset="100%" stopColor="#ef4444" />
+                        </linearGradient>
+                        <linearGradient id="genui-edge-failure" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0%" stopColor="#38bdf8" />
                             <stop offset="100%" stopColor="#6366f1" />
+                        </linearGradient>
+                        <linearGradient id="genui-edge-root" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0%" stopColor="#22d3ee" />
+                            <stop offset="100%" stopColor="#3b82f6" />
                         </linearGradient>
                         <filter id="genui-glow" x="-30%" y="-30%" width="160%" height="160%">
                             <feGaussianBlur stdDeviation="2.2" result="blur" />
@@ -223,14 +424,25 @@ export const ProbabilityTree = memo(({ props }) => {
                             y2={yOf(e.to) + NODE_H / 2}
                             p={e.to.p}
                             depth={e.to.depth}
+                            outcome={e.to.outcome}
                         />
                     ))}
 
                     {nodes.map((n) => (
-                        <GlassNode key={`n-${n.id}`} node={n} x={xOf(n)} y={yOf(n)} />
+                        <GlassNode
+                            key={`n-${n.id}`}
+                            node={n}
+                            x={xOf(n)}
+                            y={yOf(n)}
+                            onShow={placeTip}
+                            onHide={hideTip}
+                            frac={fracById[n.id]?.p || null}
+                        />
                     ))}
                 </svg>
             </div>
+
+            {mounted && <TooltipPortal tip={tip} />}
         </div>
     );
 });

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2089,10 +2089,19 @@ body[data-theme='light'] .exam-badge {
     outline: none;
 }
 
-.genui-glass-root {
+.genui-glass-root,
+.genui-glass-node[data-outcome='root'] {
     background: color-mix(in srgb, var(--primary-color) 16%, var(--surface-color));
     border-color: color-mix(in srgb, var(--primary-color) 55%, transparent);
     font-weight: 800;
+}
+
+/* ترميز لوني دلالي للعقدة حسب نتيجة الفرع */
+.genui-glass-node[data-outcome='success'] {
+    border-color: color-mix(in srgb, #ef4444 38%, var(--border-color));
+}
+.genui-glass-node[data-outcome='failure'] {
+    border-color: color-mix(in srgb, #6366f1 38%, var(--border-color));
 }
 
 @keyframes genui-node-spawn {
@@ -2109,11 +2118,28 @@ body[data-theme='light'] .exam-badge {
 .genui-glass-node:hover,
 .genui-glass-node:focus-visible {
     transform: scale(1.07);
+    z-index: 5;
+}
+.genui-glass-node[data-outcome='success']:hover,
+.genui-glass-node[data-outcome='success']:focus-visible {
+    border-color: #ef4444;
+    box-shadow:
+        0 10px 30px rgba(239, 68, 68, 0.32),
+        0 0 0 3px rgba(239, 68, 68, 0.22);
+}
+.genui-glass-node[data-outcome='failure']:hover,
+.genui-glass-node[data-outcome='failure']:focus-visible {
+    border-color: #6366f1;
+    box-shadow:
+        0 10px 30px rgba(99, 102, 241, 0.32),
+        0 0 0 3px rgba(99, 102, 241, 0.22);
+}
+.genui-glass-node[data-outcome='root']:hover,
+.genui-glass-node[data-outcome='root']:focus-visible {
     border-color: var(--primary-color);
     box-shadow:
         0 10px 30px rgba(37, 99, 235, 0.28),
         0 0 0 3px color-mix(in srgb, var(--primary-color) 22%, transparent);
-    z-index: 5;
 }
 
 .genui-node-label {
@@ -2124,58 +2150,153 @@ body[data-theme='light'] .exam-badge {
 }
 
 .genui-node-prob {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.7rem;
     font-variant-numeric: tabular-nums;
     font-weight: 800;
-    font-size: 0.82rem;
+    font-size: 0.84rem;
     color: #fff;
-    background: linear-gradient(135deg, #3b82f6, #6366f1);
-    border-radius: 8px;
+    border-radius: 9px;
     padding: 0.12rem 0.5rem;
     direction: ltr;
+}
+.genui-node-prob[data-outcome='success'] {
+    background: linear-gradient(135deg, #f59e0b, #ef4444);
+    box-shadow: 0 2px 8px rgba(239, 68, 68, 0.4);
+}
+.genui-node-prob[data-outcome='failure'] {
+    background: linear-gradient(135deg, #38bdf8, #6366f1);
+    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.4);
+}
+.genui-node-prob[data-outcome='root'] {
+    background: linear-gradient(135deg, #22d3ee, #3b82f6);
     box-shadow: 0 2px 8px rgba(59, 130, 246, 0.35);
 }
 
-/* التلميح التفاعلي — صيغة الاحتمال الشرطي + احتمال المسار التراكمي */
-.genui-node-tip {
-    position: absolute;
-    top: calc(100% + 8px);
-    right: 50%;
-    transform: translateX(50%) translateY(4px);
-    min-width: 150px;
-    display: flex;
+/* ─── الكسور الإنسانية (½ ، 3⁄10) ─── */
+.genui-frac-vulgar {
+    font-size: 1.05em;
+    line-height: 1;
+}
+.genui-frac {
+    display: inline-flex;
     flex-direction: column;
-    gap: 0.2rem;
-    padding: 0.5rem 0.7rem;
-    border-radius: 10px;
-    background: var(--text-color);
-    color: var(--bg-color);
-    font-size: 0.78rem;
-    line-height: 1.5;
-    text-align: center;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition:
-        opacity 0.16s ease,
-        transform 0.16s ease;
-    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.3);
-    z-index: 10;
+    align-items: center;
+    line-height: 0.92;
+    font-size: 0.74em;
+}
+.genui-frac-n {
+    display: block;
+}
+.genui-frac-bar {
+    display: block;
+    width: 100%;
+    min-width: 0.85em;
+    height: 1px;
+    margin: 0.06em 0;
+    background: currentColor;
+    opacity: 0.85;
+}
+.genui-frac-d {
+    display: block;
+}
+.genui-frac-dec {
+    font-variant-numeric: tabular-nums;
+}
+.genui-frac-dec.is-compact {
+    font-size: 0.92em;
 }
 
-.genui-glass-node:hover .genui-node-tip,
-.genui-glass-node:focus-visible .genui-node-tip,
-.genui-glass-node:focus-within .genui-node-tip {
-    opacity: 1;
-    transform: translateX(50%) translateY(0);
+/* ─── التلميح عبر Portal: يطفو على مستوى <body> فلا يُقصّ أبداً ─── */
+.genui-tip-portal {
+    position: fixed;
+    transform: translateX(-50%);
+    z-index: 99999;
+    min-width: 160px;
+    max-width: 280px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.28rem;
+    padding: 0.55rem 0.8rem;
+    border-radius: 12px;
+    background: var(--text-color);
+    color: var(--bg-color);
+    font-size: 0.8rem;
+    line-height: 1.55;
+    text-align: center;
+    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.42);
+    pointer-events: none;
+    animation: genui-tip-pop 0.14s ease-out;
+    border-top: 3px solid var(--primary-color);
+}
+.genui-tip-portal[data-placement='above'] {
+    transform: translateX(-50%) translateY(-100%);
+}
+.genui-tip-portal[data-outcome='success'] {
+    border-top-color: #ef4444;
+}
+.genui-tip-portal[data-outcome='failure'] {
+    border-top-color: #6366f1;
+}
+
+@keyframes genui-tip-pop {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) scale(0.94);
+    }
+}
+.genui-tip-portal[data-placement='above'] {
+    animation: genui-tip-pop-above 0.14s ease-out;
+}
+@keyframes genui-tip-pop-above {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(-100%) scale(0.94);
+    }
 }
 
 .genui-tip-formula {
     font-weight: 800;
     direction: ltr;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    flex-wrap: wrap;
 }
-
 .genui-tip-joint {
-    opacity: 0.85;
+    opacity: 0.92;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+}
+.genui-tip-joint-val {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+.genui-tip-dec {
+    font-weight: 600;
+    opacity: 0.7;
+    font-size: 0.92em;
+}
+.genui-tip-arrow {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-bottom-color: var(--text-color);
+}
+.genui-tip-portal[data-placement='above'] .genui-tip-arrow {
+    bottom: auto;
+    top: 100%;
+    border-bottom-color: transparent;
+    border-top-color: var(--text-color);
 }
 
 /* stub: مؤشر BKT */

--- a/frontend/tests/generative_ui_streaming.test.mjs
+++ b/frontend/tests/generative_ui_streaming.test.mjs
@@ -150,7 +150,16 @@ check('tree uses SVG (not flexbox list)', /<svg/.test(treeSrc) && /viewBox/.test
 check('tree draws bezier edge paths', /<path/.test(treeSrc) && /C \$\{/.test(treeSrc));
 check('edge stroke-width scales with probability', /strokeWidthFor/.test(treeSrc));
 check('nodes are glass-morphism cards (foreignObject)', /foreignObject/.test(treeSrc) && /genui-glass-node/.test(treeSrc));
-check('interactive tooltip with conditional formula', /genui-node-tip/.test(treeSrc) && /P\(\$\{node\.label\}\)/.test(treeSrc));
+// V4: tooltip is rendered via React Portal to document.body (escapes SVG clipping)
+check('interactive tooltip with conditional formula', /genui-tip-portal/.test(treeSrc) && /P\(\$\{node\.label\}\)/.test(treeSrc));
+check('V4: tooltip uses createPortal to document.body (no SVG z-index clipping)', /createPortal/.test(treeSrc) && /document\.body/.test(treeSrc));
+check('V4: old inline in-SVG tooltip removed', !/genui-node-tip/.test(treeSrc));
+check('V4: probabilities humanized to fractions (decimalToFraction)', /decimalToFraction/.test(treeSrc));
+check('V4: semantic outcome classification (success/failure)', /classifyOutcome/.test(treeSrc) && /'failure'/.test(treeSrc));
+check('V4: per-outcome edge gradients', /genui-edge-\$\{outcome\}/.test(treeSrc));
+check('V4: css portal tooltip floats above (high z-index)', /genui-tip-portal/.test(read('globals.css')) && /z-index:\s*99999/.test(read('globals.css')));
+check('V4: css semantic outcome node colours', /data-outcome='success'/.test(read('globals.css')) && /data-outcome='failure'/.test(read('globals.css')));
+check('V4: css fraction styling', /genui-frac/.test(read('globals.css')));
 check('cumulative path joint probability computed', /joint/.test(treeSrc));
 check('recursive layout (tidy-tree) implemented', /layoutTree/.test(treeSrc) && /maxDepth/.test(treeSrc));
 check('large-tree guard throws (ErrorBoundary fallback)', /tree too large/.test(treeSrc));


### PR DESCRIPTION
## Summary

Re-engineers `frontend/app/components/generative/ProbabilityTree.jsx` from a machine-readable graph into a human-centered, interactive learning experience for high-school students. Fixes the SVG stacking/clipping bug and humanizes the math. **No backend or dependency changes.**

### 1. Tooltip clipping → React Portal
The dark tooltip was an absolutely-positioned div *inside* each SVG `<foreignObject>`. Every `<foreignObject>` is its own stacking context and SVG paint order puts later sibling nodes on top, so `z-index` was meaningless across nodes — the tooltip got clipped under sibling nodes.

**Fix:** a single tooltip is now rendered via `createPortal(…, document.body)` at `position:fixed; z-index:99999`, completely outside the SVG subtree. It can no longer be clipped. Hover, focus (keyboard), and tap (pin/unpin) all open it; it closes on blur, scroll, resize, and `Escape`. It flips above the node near the viewport bottom.

### 2. Humanized math (fractions over raw decimals)
`decimalToFraction()` (GCD-based, denominator ≤ 20, ε-snap) converts probabilities to clean fractions — `0.5 → ½`, `0.75 → ¾`, `0.3 → 3⁄10` — with the decimal kept as context inside the tooltip. Falls back to the decimal when no clean fraction fits.

### 3. Semantic colour coding
`classifyOutcome()` tags each branch as **success** (warm amber→red) or **failure/complement** (cool sky→indigo) by detecting the complement marker (`Ā`, `B̄`, combining overline, negation). Nodes and their **incoming edges** share the outcome colour via per-outcome SVG gradients and CSS accents. Root stays neutral blue.

Preserves the existing RTL layout (root on the right), probability-weighted stroke widths, staggered glass-morphism entrance animations, the large-tree safety guard, and `prefers-reduced-motion`.

## Test plan
- [x] `next build` compiles + type-checks clean
- [x] Server-rendered against the **real** `_detect_probability_tree` payload (p=0.3, cond=0.75): 14/14 assertions — fractions (½/¾/¼/3⁄10/7⁄10), `data-outcome` success/failure/root, per-outcome edge gradients, RTL, and confirmation the old in-SVG tooltip markup is gone
- [x] `frontend/tests/generative_ui_streaming.test.mjs` updated for the V4 portal/fraction/colour contracts — full suite passes
- [ ] **Live browser hover/portal verification** — could not be run in this headless environment (no DOM/browser, dependency install blocked). The clipping fix is structurally guaranteed: the tooltip renders to `document.body`, not inside the SVG. Recommend a quick manual hover check after deploy.

https://claude.ai/code/session_01MQYfFqZAKpvbaeAwEZdhor

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQYfFqZAKpvbaeAwEZdhor)_