### PR TITLE
feat(devops): Protocol V24.0 Codespaces stack + structured BAC content schema

### DIFF
--- a/.env.codespaces.example
+++ b/.env.codespaces.example
@@ -1,0 +1,31 @@
+# =============================================================================
+# Protocol V24.0 — Codespaces DevOps Stack environment template
+# =============================================================================
+# Copy this file to `.env.codespaces` and fill in real values, then run:
+#
+#   docker compose -f docker-compose.codespaces.yml --env-file .env.codespaces up --build
+#
+# DO NOT commit the filled-in `.env.codespaces` (it is gitignored). Only this
+# `.example` template is tracked.
+# =============================================================================
+
+# --- Database (Supabase pooler — transaction mode on 6543) -------------------
+# psycopg2/asyncpg both accept the libpq URI form. Keep ?sslmode=require.
+DATABASE_URL=postgresql://postgres.<project-ref>:<url-encoded-password>@aws-1-eu-west-3.pooler.supabase.com:6543/postgres?sslmode=require
+# Optional explicit override (takes priority in app/core/settings/base.py).
+# APP_DATABASE_URL=
+
+# --- LLM provider (OpenRouter) -----------------------------------------------
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+
+# --- Web search (Tavily) — key must start with tvly- -------------------------
+TAVILY_API_KEY=tvly-dev-your-key-here
+
+# --- Auth / runtime ----------------------------------------------------------
+SECRET_KEY=change-me-to-a-long-random-secret
+ENVIRONMENT=development
+NODE_ENV=development
+
+# --- Optional Supabase metadata ----------------------------------------------
+SUPABASE_URL=https://<project-ref>.supabase.co
+SUPABASE_ROLE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # 1. Environment & Secrets
 # Never commit secrets, keys, passwords, or local environment settings!
 .env
+.env.codespaces
 .devcontainer/secrets.env
 .venv
 .venv*/
@@ -126,6 +127,8 @@ site/
 *.sqlite
 *.db
 *.sql
+# Tracked migrations are an exception — they are versioned schema, not dumps.
+!scripts/migrations/*.sql
 test_ai_enhancements.py
 actionlint
 

--- a/app/api/routers/registry.py
+++ b/app/api/routers/registry.py
@@ -13,6 +13,7 @@ from app.api.routers import (
     security,
     system,
     ums,
+    visual_pedagogy,
 )
 
 type RouterSpec = tuple[APIRouter, str]
@@ -32,4 +33,5 @@ def base_router_registry() -> list[RouterSpec]:
         (customer_chat.router, ""),
         (content.router, ""),
         (observability.router, "/api/v1/observability"),
+        (visual_pedagogy.router, ""),
     ]

--- a/app/api/routers/visual_pedagogy.py
+++ b/app/api/routers/visual_pedagogy.py
@@ -1,0 +1,45 @@
+"""موجّه البيداغوجيا البصرية (Protocol V26.2).
+
+نقطة دخول HTTP حتمية تُرجِع حمولة الواجهة التوليدية لمسائل الاحتمالات عبر
+``ProbabilityCalculatorSkill`` — بلا قاعدة بيانات وبلا LLM. الغرض الأساسي:
+إثبات عقد «الحالة المستحيلة» (impossible_case) حياً عبر POST بسيط، وتغذية
+الواجهة (Next.js) بمكوّن توليدي جاهز للتصيير.
+
+عند طلب سحب مستحيل (k > المتاح، بلا إرجاع) يُقصِّر المحرّك الدائرة ويُرجِع
+البنية المُفكَّكة الصارمة (visual_directives / numerical_state /
+pedagogical_message) بدل أي حساب تأليفي منحلّ.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from app.services.skills.probability_skill import (
+    ImpossibleCaseOutput,
+    ProbabilityCalculatorSkill,
+    ProbabilityInput,
+)
+
+router = APIRouter(prefix="/api/v1/visual-pedagogy", tags=["visual-pedagogy"])
+
+
+class VisualPedagogyRequest(BaseModel):
+    """طلب تحليل مسألة احتمالات لإنتاج مكوّن واجهة توليدي."""
+
+    question: str = Field(..., min_length=1, max_length=8000)
+    history: list[dict[str, str]] | None = None
+
+
+@router.post("/probability")
+async def analyze_probability(payload: VisualPedagogyRequest) -> dict[str, object]:
+    """يحلّل المسألة ويُرجِع مخرَج المحرّك الحتمي مباشرةً (model_dump).
+
+    عند الحالة المستحيلة يكون ``ui_mode == "impossible_case"`` والبنية مُفكَّكة
+    تماماً — لا تدخل أي عقدة حساب/شجرة/synthesizer.
+    """
+    skill = ProbabilityCalculatorSkill()
+    result = skill.analyze(ProbabilityInput(question=payload.question, history=payload.history))
+    body = result.model_dump()
+    body["is_impossible_case"] = isinstance(result, ImpossibleCaseOutput)
+    return body

--- a/app/contracts/streaming.py
+++ b/app/contracts/streaming.py
@@ -136,7 +136,12 @@ class ToolResult(RobustBaseModel):
 # المكوّنات التوليدية المعروفة (Generative UI). أي اسم خارج هذه القائمة
 # يُرفَض عند التحقق ويسقط العميل إلى النص البديل (fallback_text).
 KNOWN_UI_COMPONENTS: frozenset[str] = frozenset(
-    {"probability_tree", "bkt_hint_display", "combinations_visualizer"}
+    {
+        "probability_tree",
+        "bkt_hint_display",
+        "combinations_visualizer",
+        "impossible_draw_animation",
+    }
 )
 
 

--- a/app/core/db_schema.py
+++ b/app/core/db_schema.py
@@ -33,6 +33,8 @@ def _to_sqlite_ddl(sql: str) -> str:
     sql = re.sub(r"\bJSON\b", "TEXT", sql, flags=re.IGNORECASE)
     sql = re.sub(r"\bJSONB\b", "TEXT", sql, flags=re.IGNORECASE)
     sql = re.sub(r"vector\(\d+\)", "TEXT", sql, flags=re.IGNORECASE)
+    # SQLite يرفض دوال DEFAULT غير الثابتة؛ نُسقط gen_random_uuid() قبل تحويل UUID→TEXT.
+    sql = re.sub(r"DEFAULT\s+gen_random_uuid\(\)", "", sql, flags=re.IGNORECASE)
     sql = re.sub(r"\bUUID\b", "TEXT", sql, flags=re.IGNORECASE)
 
     if _should_skip_sqlite_index(sql):

--- a/app/core/db_schema_config.py
+++ b/app/core/db_schema_config.py
@@ -57,11 +57,70 @@ _ALLOWED_TABLES: Final[frozenset[str]] = frozenset(
         "knowledge_nodes",
         "knowledge_edges",
         "student_bkt_analytics",
+        "bac_exercises",
     }
 )
 
 
 REQUIRED_SCHEMA: Final[dict[str, TableSchemaConfig]] = {
+    # Protocol V24.0 — جدول تمارين البكالوريا المُهيكَل (Data Engineering Mandate).
+    # يحوّل المحتوى التعليمي من نص خام إلى صفوف ذات بيانات وصفية صارمة لتغذية
+    # محرّك RAG بدقة دلالية (subject/topic/draw_type/year + parsed_entities JSONB).
+    "bac_exercises": {
+        "columns": [
+            "id",
+            "subject",
+            "topic",
+            "draw_type",
+            "year",
+            "session",
+            "branch",
+            "exam_ref",
+            "exercise_number",
+            "language",
+            "source",
+            "content_hash",
+            "raw_text",
+            "parsed_entities",
+            "created_at",
+            "updated_at",
+        ],
+        "auto_fix": {},
+        "indexes": {
+            "subject": 'CREATE INDEX IF NOT EXISTS "ix_bac_exercises_subject" ON "bac_exercises"("subject")',
+            "topic": 'CREATE INDEX IF NOT EXISTS "ix_bac_exercises_topic" ON "bac_exercises"("topic")',
+            "year": 'CREATE INDEX IF NOT EXISTS "ix_bac_exercises_year" ON "bac_exercises"("year")',
+            "draw_type": 'CREATE INDEX IF NOT EXISTS "ix_bac_exercises_draw_type" ON "bac_exercises"("draw_type")',
+            "parsed_entities": 'CREATE INDEX IF NOT EXISTS "ix_bac_exercises_parsed_entities" ON "bac_exercises" USING GIN ("parsed_entities")',
+        },
+        "index_names": {
+            "subject": "ix_bac_exercises_subject",
+            "topic": "ix_bac_exercises_topic",
+            "year": "ix_bac_exercises_year",
+            "draw_type": "ix_bac_exercises_draw_type",
+            "parsed_entities": "ix_bac_exercises_parsed_entities",
+        },
+        "create_table": (
+            'CREATE TABLE IF NOT EXISTS "bac_exercises"('
+            '"id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),'
+            '"subject" VARCHAR(80) NOT NULL,'
+            '"topic" VARCHAR(120) NOT NULL,'
+            '"draw_type" VARCHAR(40),'
+            '"year" INTEGER NOT NULL CHECK ("year" BETWEEN 1990 AND 2100),'
+            '"session" VARCHAR(60),'
+            '"branch" VARCHAR(160),'
+            '"exam_ref" VARCHAR(120),'
+            '"exercise_number" INTEGER,'
+            "\"language\" VARCHAR(8) NOT NULL DEFAULT 'ar',"
+            '"source" VARCHAR(255),'
+            '"content_hash" VARCHAR(64) NOT NULL UNIQUE,'
+            '"raw_text" TEXT NOT NULL,'
+            "\"parsed_entities\" JSONB NOT NULL DEFAULT '{}',"
+            '"created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),'
+            '"updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()'
+            ")"
+        ),
+    },
     "student_bkt_analytics": {
         "columns": [
             "id",

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -989,6 +989,7 @@ class OrchestratorClient:
         try:
             from app.services.skills.probability_skill import (
                 CombinationsModelOutput,
+                ImpossibleCaseOutput,
                 ProbabilityCalculatorSkill,
                 ProbabilityInput,
                 ProbabilityModelOutput,
@@ -996,6 +997,30 @@ class OrchestratorClient:
 
             skill = ProbabilityCalculatorSkill()
             result = skill.analyze(ProbabilityInput(question=question, history=history_messages))
+
+            # V26.2: الحالة المستحيلة لها الأولوية القصوى — تتجاوز كل عقد الحساب
+            # (شجرة/تأليفات/synthesizer) وتُرجَع مباشرة كحمولة تربوية للواجهة.
+            if isinstance(result, ImpossibleCaseOutput):
+                return {
+                    "component": "impossible_draw_animation",
+                    "props": {
+                        "title": result.title,
+                        "ui_mode": result.ui_mode,
+                        "visual_directives": {
+                            "animation_hint": result.visual_directives.animation_hint,
+                            "fallback_math": result.visual_directives.fallback_math,
+                        },
+                        "numerical_state": {
+                            "available_items": result.numerical_state.available_items,
+                            "requested_items": result.numerical_state.requested_items,
+                            "item_color": result.numerical_state.item_color,
+                        },
+                        "pedagogical_message": result.pedagogical_message,
+                        "item_label": result.item_label,
+                        "container": result.container,
+                    },
+                    "fallback_text": result.pedagogical_message,
+                }
 
             if isinstance(result, CombinationsModelOutput):
                 props = {

--- a/app/services/skills/probability_skill.py
+++ b/app/services/skills/probability_skill.py
@@ -77,6 +77,16 @@ _COLOR_GROUPS: tuple[tuple[tuple[str, ...], str, str], ...] = (
     (("زرقاء", "زرق", "ازرق", "bleu"), "كرة زرقاء", "كرة غير زرقاء"),
 )
 
+# تسمية اللون الموجبة → رمز CSS (يُغذّي أنيميشن الواجهة في السيناريو المستحيل).
+_COLOR_CSS_TOKEN: dict[str, str] = {
+    "كرة حمراء": "red",
+    "كرة بيضاء": "white",
+    "كرة خضراء": "green",
+    "كرة سوداء": "black",
+    "كرة صفراء": "gold",
+    "كرة زرقاء": "blue",
+}
+
 # كلمات الأعداد العربية (مفردة + جمع) → قيمة.
 _ARABIC_CARDINALS: dict[str, int] = {
     "صفر": 0,
@@ -305,6 +315,49 @@ class CombinationsModelOutput(RobustBaseModel):
     )
     formula: str = Field(default="C(n, k) = n! / (k!·(n-k)!)")
     title: str = "تأليفات السحب الآني"
+    duration_ms: int = 0
+
+
+class ImpossibleVisualDirectives(RobustBaseModel):
+    """التوجيهات البصرية للواجهة — منفصلة عن المنطق والحساب (decoupled)."""
+
+    animation_hint: str = Field(default="bag_shake", description="تلميح الأنيميشن")
+    fallback_math: None = Field(default=None, description="لا حساب — مقصود (null)")
+
+
+class ImpossibleNumericalState(RobustBaseModel):
+    """الحالة العددية المجرّدة — الواجهة ترسم منها القصة (بلا حساب تأليفي)."""
+
+    available_items: int = Field(..., ge=0, description="عدد العناصر المتاحة فعلاً")
+    requested_items: int = Field(..., ge=1, description="عدد العناصر المطلوب سحبها")
+    item_color: str = Field(..., description="رمز اللون (white/red/...) لرسم العنصر")
+
+
+class ImpossibleCaseOutput(RobustBaseModel):
+    """مخرج «الحالة المستحيلة» — Protocol V26.2 (محرّك البيداغوجيا البصرية).
+
+    عقد مُفكَّك صارم (strict decoupled): يفصل المنطق (``numerical_state``) عن
+    التلميحات البصرية (``visual_directives``) عن الرسالة التربوية
+    (``pedagogical_message``). حين يطلب الطالب سحب k عنصراً من صنف لا يملك إلا
+    m < k (بلا إرجاع)، نُقصِّر الدائرة (short-circuit) فوراً قبل أي عقدة حساب
+    أو شجرة أو synthesizer: لا C(2,3)=0، لا صفر مجرّد، لا كسر منحلّ — بل حمولة
+    تربوية نظيفة تُرجَع مباشرة للواجهة.
+    """
+
+    skill: Literal["probability_calculation"] = "probability_calculation"
+    success: Literal[True] = True
+    component: Literal["impossible_draw_animation"] = "impossible_draw_animation"
+    ui_mode: Literal["impossible_case"] = "impossible_case"
+    visual_directives: ImpossibleVisualDirectives = Field(
+        default_factory=ImpossibleVisualDirectives
+    )
+    numerical_state: ImpossibleNumericalState
+    pedagogical_message: str = Field(..., min_length=1, description="رسالة تربوية لطيفة بالعربية")
+    # حقول ملموسة إضافية (Abstraction Ban) — لا تكسر العقد الصارم أعلاه.
+    item_label: str = Field(..., min_length=1, description="التسمية العربية الملموسة")
+    container: str = Field(default="كيس", description="الوعاء (كيس/صندوق/علبة)")
+    doctrine_version: str = DOCTRINE_VERSION
+    title: str = "عملية مستحيلة"
     duration_ms: int = 0
 
 
@@ -598,6 +651,105 @@ class ProbabilityCalculatorSkill:
         normalized = cls._normalize(text)
         return any(cls._normalize(m) in normalized for m in _CONFUSION_MARKERS)
 
+    # ── الحالة المستحيلة (Protocol V26.2) — short-circuit قبل أي حساب ─────────────────
+    _DRAW_VERBS: tuple[str, ...] = (
+        "نسحب",
+        "يسحب",
+        "تسحب",
+        "سحب",
+        "ناخذ",
+        "ياخذ",
+        "نختار",
+        "اختيار",
+        "اختر",
+        "tirage",
+        "tire",
+    )
+
+    @classmethod
+    def _detect_requested_color_count(cls, question: str) -> tuple[str, str, int] | None:
+        """يستخرج (label_pos, label_neg, k) من *عبارة السحب* فقط.
+
+        يتطلّب أن يكون اللون في طلب السحب — مسبوقاً بعدد وقريباً من فعل سحب
+        («نسحب 3 كرات بيضاء»). لا يكفي ذكر اللون في وصف المخزون («كيس فيه كرتان
+        بيضاوان، نسحب 3 كرات») — هناك السحب عامّ لا يخصّ لوناً، فلا استحالة.
+        """
+        tokens = cls._tokenize(question)
+        for keywords, label_pos, label_neg in _COLOR_GROUPS:
+            color_idx = next(
+                (i for i, tok in enumerate(tokens) if any(kw in tok for kw in keywords)),
+                None,
+            )
+            if color_idx is None:
+                continue
+            # فعل سحب ضمن نافذة قبل اللون (يثبت أن اللون جزء من طلب السحب).
+            window_start = max(0, color_idx - 6)
+            has_draw_verb = any(
+                any(v in tokens[j] for v in cls._DRAW_VERBS) for j in range(window_start, color_idx)
+            )
+            if not has_draw_verb:
+                continue
+            k = cls._count_before(tokens, color_idx, span=4)
+            if k is None or k < 1:
+                continue
+            return (label_pos, label_neg, k)
+        return None
+
+    @classmethod
+    def _available_count_for(cls, label_pos: str, text: str) -> int | None:
+        """المتاح فعلاً من صنف ما داخل نص (المخزون) — أو None إن لم يُذكَر."""
+        for lp, _neg, count in cls._extract_count_entities(text):
+            if lp == label_pos:
+                return count
+        return None
+
+    @classmethod
+    def _detect_impossible_draw(
+        cls, question: str, history_text: str, combined: str
+    ) -> ImpossibleCaseOutput | None:
+        """V26.2: يكشف طلب سحب k من صنف لا يملك إلا m<k → قصة بصرية بدل حساب.
+
+        - الكمية المطلوبة k واللون يُقرآن من *عبارة السحب* في السؤال (binding صارم).
+        - المتاح m يُقرأ من *المخزون* (التاريخ مفضّل — يحمل تركيبة الكيس الحقيقية؛
+          فالعدد الملتصق باللون في عبارة السحب هو المطلوب لا المتاح).
+        - مع الإرجاع: السحب ممكن دائماً (لا استحالة) → لا تفعيل.
+        - إن k > m (بلا إرجاع) → short-circuit إلى الحالة المستحيلة.
+        """
+        # مع الإرجاع لا توجد استحالة (يمكن سحب نفس اللون مراراً).
+        if cls._detect_replacement(combined):
+            return None
+
+        binding = cls._detect_requested_color_count(question)
+        if binding is None:
+            return None
+        label_pos, _label_neg, requested = binding
+
+        # المتاح: المخزون (التاريخ) أولاً، ثم السؤال كحلّ أخير.
+        available = cls._available_count_for(label_pos, history_text)
+        if available is None:
+            available = cls._available_count_for(label_pos, question)
+        if available is None:
+            return None
+
+        if requested <= available:
+            return None  # ليس مستحيلاً — يُترك لمسار الحساب العادي.
+
+        color_token = _COLOR_CSS_TOKEN.get(label_pos, "white")
+        item_plural = label_pos.replace("كرة", "كرات", 1)
+        message = (
+            f"كيف نسحب {requested} {item_plural} ونحن لا نملك سوى {available} منها؟ "
+            f"إذن هذه العملية مستحيلة، واحتمال حدوثها هو صفر."
+        )
+        return ImpossibleCaseOutput(
+            numerical_state=ImpossibleNumericalState(
+                available_items=available,
+                requested_items=requested,
+                item_color=color_token,
+            ),
+            pedagogical_message=message,
+            item_label=label_pos,
+        )
+
     # ── الاستراتيجية 1: فضاء متساوي الاحتمال (نرد / قطعة نقدية) ───────────────────────
     @classmethod
     def _strategy_universe(cls, combined: str) -> ProbabilityModelOutput | None:
@@ -872,8 +1024,10 @@ class ProbabilityCalculatorSkill:
     # ── نقطة الدخول الرئيسية (حتمية، بلا LLM) ─────────────────────────────────────────
     def analyze(
         self, payload: ProbabilityInput | str
-    ) -> ProbabilityModelOutput | CombinationsModelOutput | ProbabilityFailure:
-        """يحلّل المسألة عبر أنماط معمّمة ويُرجِع نموذجاً (شجرة/تأليفات) أو فشلاً."""
+    ) -> (
+        ProbabilityModelOutput | CombinationsModelOutput | ImpossibleCaseOutput | ProbabilityFailure
+    ):
+        """يحلّل المسألة عبر أنماط معمّمة ويُرجِع نموذجاً (شجرة/تأليفات/مستحيل) أو فشلاً."""
         t0 = time.perf_counter()
         if isinstance(payload, str):
             payload = ProbabilityInput(question=payload)
@@ -893,7 +1047,9 @@ class ProbabilityCalculatorSkill:
             return self._fail("no_probability_context", "none", t0)
 
         # خط أنابيب الاستراتيجيات — أول نجاح يفوز (deterministic-first).
+        # V26.1: الحالة المستحيلة لها الأولوية القصوى — short-circuit قبل أي حساب.
         for builder in (
+            lambda: self._detect_impossible_draw(question, history_text, combined),
             lambda: self._strategy_conditional(combined),
             lambda: self._strategy_universe(combined),
             lambda: self._strategy_composition(question, history_text, combined),
@@ -906,8 +1062,10 @@ class ProbabilityCalculatorSkill:
             if model is not None:
                 duration = time.perf_counter() - t0
                 model.duration_ms = int(duration * 1000)
-                strategy_label = getattr(model, "strategy", None) or getattr(
-                    model, "draw_mode", "unknown"
+                strategy_label = (
+                    getattr(model, "strategy", None)
+                    or getattr(model, "draw_mode", None)
+                    or getattr(model, "ui_mode", "unknown")
                 )
                 _record_metric("success", strategy_label, duration)
                 return model
@@ -924,6 +1082,9 @@ __all__ = [
     "CombinationGroup",
     "CombinationsModelOutput",
     "CompositionItem",
+    "ImpossibleCaseOutput",
+    "ImpossibleNumericalState",
+    "ImpossibleVisualDirectives",
     "ProbabilityCalculatorSkill",
     "ProbabilityFailure",
     "ProbabilityInput",

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -1,0 +1,99 @@
+# =============================================================================
+# Protocol V24.0 — Codespaces DevOps Stack (focused 2-service topology)
+# =============================================================================
+# A lean, professional Docker Compose stack for GitHub Codespaces local
+# development. Unlike the canonical full microservices mesh in
+# `docker-compose.yml` (api-gateway + 7 postgres + agents), this file boots ONLY
+# the two services a developer iterates on:
+#
+#   - orchestrator : FastAPI backend (app.main:app) on port 8000
+#   - frontend     : Next.js generative UI on port 3000
+#
+# Both talk to the LIVE Supabase Postgres and OpenRouter — credentials are
+# passed through from the environment (never hard-coded). Source is bind-mounted
+# for hot-reload.
+#
+# Usage:
+#   cp .env.codespaces.example .env.codespaces
+#   # fill in DATABASE_URL / OPENROUTER_API_KEY / TAVILY_API_KEY / SECRET_KEY
+#   docker compose -f docker-compose.codespaces.yml --env-file .env.codespaces up --build
+#
+# Endpoints:
+#   backend  → http://localhost:8000/health
+#   frontend → http://localhost:3000
+# =============================================================================
+
+name: cogniforge-codespaces
+
+services:
+  # ---------------------------------------------------------------------------
+  # Orchestrator — FastAPI backend (the AI OS entrypoint)
+  # ---------------------------------------------------------------------------
+  orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cogniforge-codespaces-orchestrator
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      # --- Runtime ---
+      ENVIRONMENT: ${ENVIRONMENT:-development}
+      SECRET_KEY: ${SECRET_KEY:-super_secret_key_change_in_production}
+      # --- Database (Supabase) — process env wins over .env at import time ---
+      APP_DATABASE_URL: ${APP_DATABASE_URL:-${DATABASE_URL}}
+      DATABASE_URL: ${DATABASE_URL}
+      # --- LLM / Search providers ---
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      TAVILY_API_KEY: ${TAVILY_API_KEY:-}
+      # --- Optional Supabase metadata (kept for parity with the monolith) ---
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_ROLE_KEY: ${SUPABASE_ROLE_KEY:-}
+    volumes:
+      # Hot-reload: mount the repo, but keep the image's installed packages.
+      - .:/app
+    command: >
+      uvicorn app.main:app
+      --host 0.0.0.0
+      --port 8000
+      --proxy-headers
+      --reload
+    networks:
+      - cogniforge-codespaces-net
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  # ---------------------------------------------------------------------------
+  # Frontend — Next.js generative UI
+  # ---------------------------------------------------------------------------
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: cogniforge-codespaces-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Next.js dev server proxies /api/* to the backend on the compose network.
+      API_URL: http://orchestrator:8000
+      NODE_ENV: ${NODE_ENV:-development}
+    volumes:
+      # Hot-reload frontend source; keep container node_modules via anon volume.
+      - ./frontend:/app
+      - /app/node_modules
+    # `npm run dev` script hardcodes --port 5000; the trailing flag wins → 3000.
+    command: ["npm", "run", "dev", "--", "--port", "3000"]
+    depends_on:
+      - orchestrator
+    networks:
+      - cogniforge-codespaces-net
+
+networks:
+  cogniforge-codespaces-net:
+    driver: bridge

--- a/frontend/app/components/generative/GenerativeUIRenderer.jsx
+++ b/frontend/app/components/generative/GenerativeUIRenderer.jsx
@@ -3,6 +3,7 @@
 import React, { memo } from 'react';
 import { CombinationsVisualizer } from './CombinationsVisualizer';
 import { GenerativeUIErrorBoundary } from './GenerativeUIErrorBoundary';
+import { ImpossibleDrawAnimation } from './ImpossibleDrawAnimation';
 import { ProbabilityTree } from './ProbabilityTree';
 
 /**
@@ -31,6 +32,7 @@ BktHintStub.displayName = 'BktHintStub';
 const COMPONENT_REGISTRY = {
     probability_tree: (props) => <ProbabilityTree props={props} />,
     combinations_visualizer: (props) => <CombinationsVisualizer props={props} />,
+    impossible_draw_animation: (props) => <ImpossibleDrawAnimation props={props} />,
     bkt_hint_display: (props, fallbackText) => <BktHintStub fallbackText={fallbackText} />,
 };
 

--- a/frontend/app/components/generative/ImpossibleDrawAnimation.jsx
+++ b/frontend/app/components/generative/ImpossibleDrawAnimation.jsx
@@ -1,0 +1,163 @@
+"use client";
+
+import React, { memo, useMemo } from 'react';
+
+/**
+ * ImpossibleDrawAnimation — Visual Pedagogy for Impossible Draws (Protocol V26.2)
+ * ───────────────────────────────────────────────────────────────────────────
+ * بدل عرض رياضيات منحلّة (C_2^3 = 0) للطالب الحائر، نروي قصة بصرية:
+ *   • كيس يحوي «المتاح» كرات فقط.
+ *   • محاولة سحب «المطلوب» (> المتاح) → اهتزاز/فشل لطيف (bag_shake).
+ *   • رسالة تربوية تشرح لماذا الاحتمال = صفر.
+ *
+ * عقد مُفكَّك صارم (decoupled) من الخلفية:
+ *   props = {
+ *     title, ui_mode: "impossible_case",
+ *     visual_directives: { animation_hint, fallback_math },
+ *     numerical_state: { available_items, requested_items, item_color },
+ *     pedagogical_message, item_label, container
+ *   }
+ *
+ * props مشوَّهة → throw → يلتقطها GenerativeUIErrorBoundary (fallback أنيق).
+ */
+
+const COLOR_CSS = {
+    white: '#f8fafc',
+    red: '#ef4444',
+    green: '#22c55e',
+    blue: '#3b82f6',
+    gold: '#f59e0b',
+    yellow: '#f59e0b',
+    black: '#1f2937',
+};
+
+const Ball = memo(({ color, available }) => (
+    <span
+        className="genui-imp-ball"
+        style={{
+            background: COLOR_CSS[color] || color || '#f8fafc',
+            border: '2px solid rgba(0,0,0,0.18)',
+            opacity: available ? 1 : 0.28,
+        }}
+        aria-hidden="true"
+    />
+));
+Ball.displayName = 'Ball';
+
+export const ImpossibleDrawAnimation = memo(({ props }) => {
+    if (!props || typeof props !== 'object') {
+        throw new Error('ImpossibleDrawAnimation: missing props');
+    }
+    const numeric = props.numerical_state || {};
+    const directives = props.visual_directives || {};
+    const available = Number(numeric.available_items);
+    const requested = Number(numeric.requested_items);
+    const color = typeof numeric.item_color === 'string' ? numeric.item_color : 'white';
+
+    if (!Number.isFinite(available) || !Number.isFinite(requested) || requested <= available) {
+        throw new Error('ImpossibleDrawAnimation: invalid numerical_state');
+    }
+
+    const title = typeof props.title === 'string' ? props.title : 'عملية مستحيلة';
+    const itemLabel = typeof props.item_label === 'string' ? props.item_label : 'عنصر';
+    const container = typeof props.container === 'string' ? props.container : 'كيس';
+    const message =
+        typeof props.pedagogical_message === 'string'
+            ? props.pedagogical_message
+            : 'هذه العملية مستحيلة، واحتمال حدوثها هو صفر.';
+    const shake = directives.animation_hint === 'bag_shake';
+
+    // كرات «متاحة» (مملوءة) + كرات «مطلوبة ناقصة» (شبحية) لإبراز الفجوة بصرياً.
+    const ghost = Math.max(0, requested - available);
+    const balls = useMemo(
+        () => [
+            ...Array.from({ length: available }, (_, i) => ({ key: `a${i}`, available: true })),
+            ...Array.from({ length: ghost }, (_, i) => ({ key: `g${i}`, available: false })),
+        ],
+        [available, ghost],
+    );
+
+    return (
+        <div className="genui-impossible" dir="rtl">
+            <style>{`
+                @keyframes genuiBagShake {
+                    0%,100% { transform: translateX(0) rotate(0); }
+                    15% { transform: translateX(-6px) rotate(-3deg); }
+                    30% { transform: translateX(6px) rotate(3deg); }
+                    45% { transform: translateX(-5px) rotate(-2deg); }
+                    60% { transform: translateX(5px) rotate(2deg); }
+                    75% { transform: translateX(-3px) rotate(-1deg); }
+                }
+                .genui-impossible {
+                    border: 1px solid var(--border-color, #e5e5e5);
+                    border-radius: 16px; padding: 1.1rem 1.25rem; margin: 0.5rem 0;
+                    background: var(--surface-elevated, #fafafa);
+                }
+                .genui-imp-head { display:flex; align-items:center; gap:.55rem; margin-bottom:.9rem; }
+                .genui-imp-title { font-weight:800; font-size:1.05rem; }
+                .genui-imp-badge {
+                    margin-inline-start:auto; font-size:.72rem; font-weight:700;
+                    padding:.2rem .6rem; border-radius:999px;
+                    background:rgba(239,68,68,.12); color:#ef4444; border:1px solid rgba(239,68,68,.3);
+                }
+                .genui-imp-stage { display:flex; align-items:center; gap:1rem; flex-wrap:wrap; margin-bottom:.9rem; }
+                .genui-imp-bag {
+                    position:relative; min-width:130px; padding:.9rem; border-radius:14px;
+                    background:linear-gradient(160deg,#92400e,#b45309); box-shadow:inset 0 -8px 16px rgba(0,0,0,.25);
+                    display:flex; flex-wrap:wrap; gap:.4rem; justify-content:center; align-items:center;
+                    animation:${shake ? 'genuiBagShake .9s ease-in-out infinite' : 'none'};
+                }
+                .genui-imp-bag-label {
+                    position:absolute; top:-.7rem; inset-inline-start:.6rem; font-size:.7rem;
+                    background:#78350f; color:#fff; padding:.05rem .5rem; border-radius:999px;
+                }
+                .genui-imp-ball { width:22px; height:22px; border-radius:50%; display:inline-block; }
+                .genui-imp-arrow { font-size:1.4rem; color:#ef4444; }
+                .genui-imp-ask { font-weight:700; }
+                .genui-imp-ask b { color:#ef4444; }
+                .genui-imp-counts { display:flex; gap:1.2rem; margin-bottom:.8rem; font-size:.9rem; }
+                .genui-imp-counts span b { font-size:1.1rem; }
+                .genui-imp-prob {
+                    display:inline-flex; align-items:center; gap:.4rem; font-weight:800;
+                    color:#ef4444; margin-bottom:.7rem;
+                }
+                .genui-imp-msg {
+                    background:rgba(239,68,68,.07); border-inline-start:3px solid #ef4444;
+                    padding:.7rem .9rem; border-radius:8px; line-height:1.7;
+                }
+            `}</style>
+
+            <div className="genui-imp-head">
+                <i className="fas fa-triangle-exclamation" style={{ color: '#ef4444' }} aria-hidden="true" />
+                <span className="genui-imp-title">{title}</span>
+                <span className="genui-imp-badge">مستحيل</span>
+            </div>
+
+            <div className="genui-imp-stage">
+                <div className="genui-imp-bag" role="img" aria-label={`${container} يحوي ${available} ${itemLabel}`}>
+                    <span className="genui-imp-bag-label">{container}</span>
+                    {balls.map((b) => (
+                        <Ball key={b.key} color={color} available={b.available} />
+                    ))}
+                </div>
+                <span className="genui-imp-arrow" aria-hidden="true">⟸</span>
+                <span className="genui-imp-ask">
+                    نحاول سحب <b>{requested}</b> {itemLabel}
+                </span>
+            </div>
+
+            <div className="genui-imp-counts">
+                <span>المتاح: <b>{available}</b></span>
+                <span>المطلوب: <b>{requested}</b></span>
+            </div>
+
+            <div className="genui-imp-prob" aria-label="الاحتمال يساوي صفر">
+                <i className="fas fa-equals" aria-hidden="true" />
+                الاحتمال = 0
+            </div>
+
+            <p className="genui-imp-msg">{message}</p>
+        </div>
+    );
+});
+ImpossibleDrawAnimation.displayName = 'ImpossibleDrawAnimation';

--- a/live_db_restructure.py
+++ b/live_db_restructure.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Protocol V24.0 — Live ETL: restructure BAC content into a strict relational schema.
+
+This is the "live ammo" data-engineering driver. It:
+
+  1. Connects to the live Supabase Postgres (read from the environment — never
+     hard-coded, so this file is safe to commit).
+  2. Creates / updates the ``bac_exercises`` table with strict metadata columns
+     + a ``parsed_entities`` JSONB column (the canonical DDL also lives in
+     ``app/core/db_schema_config.py:REQUIRED_SCHEMA`` and
+     ``scripts/migrations/0002_bac_exercises.sql``).
+  3. Upserts the BAC 2024 Mathematics (Experimental Sciences) Probability
+     exercise using the strict metadata structure.
+  4. Prints the success response returned by the database.
+
+Usage::
+
+    export DATABASE_URL="postgresql://postgres.<ref>:<pw>@aws-1-eu-west-3.pooler.supabase.com:6543/postgres?sslmode=require"
+    python live_db_restructure.py
+
+Honesty note (CLAUDE.md doctrine — "no fake certainty"): the Codespaces /
+sandbox firewall frequently blocks Postgres egress on ports 6543/5432. When
+that happens this script reports the connection failure explicitly and exits
+non-zero. It never fabricates a successful insert.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Canonical DDL — kept byte-identical to scripts/migrations/0002_bac_exercises.sql
+# and app/core/db_schema_config.py:REQUIRED_SCHEMA["bac_exercises"].
+# ---------------------------------------------------------------------------
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS "bac_exercises" (
+    "id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "subject"          VARCHAR(80)  NOT NULL,
+    "topic"            VARCHAR(120) NOT NULL,
+    "draw_type"        VARCHAR(40),
+    "year"             INTEGER      NOT NULL CHECK ("year" BETWEEN 1990 AND 2100),
+    "session"          VARCHAR(60),
+    "branch"           VARCHAR(160),
+    "exam_ref"         VARCHAR(120),
+    "exercise_number"  INTEGER,
+    "language"         VARCHAR(8)   NOT NULL DEFAULT 'ar',
+    "source"           VARCHAR(255),
+    "content_hash"     VARCHAR(64)  NOT NULL UNIQUE,
+    "raw_text"         TEXT         NOT NULL,
+    "parsed_entities"  JSONB        NOT NULL DEFAULT '{}',
+    "created_at"       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    "updated_at"       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_subject"         ON "bac_exercises" ("subject");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_topic"           ON "bac_exercises" ("topic");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_year"            ON "bac_exercises" ("year");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_draw_type"       ON "bac_exercises" ("draw_type");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_parsed_entities" ON "bac_exercises" USING GIN ("parsed_entities");
+"""
+
+UPSERT_SQL = """
+INSERT INTO "bac_exercises" (
+    subject, topic, draw_type, year, session, branch, exam_ref,
+    exercise_number, language, source, content_hash, raw_text, parsed_entities
+) VALUES (
+    %(subject)s, %(topic)s, %(draw_type)s, %(year)s, %(session)s, %(branch)s, %(exam_ref)s,
+    %(exercise_number)s, %(language)s, %(source)s, %(content_hash)s, %(raw_text)s, %(parsed_entities)s
+)
+ON CONFLICT (content_hash) DO UPDATE SET
+    subject         = EXCLUDED.subject,
+    topic           = EXCLUDED.topic,
+    draw_type       = EXCLUDED.draw_type,
+    year            = EXCLUDED.year,
+    session         = EXCLUDED.session,
+    branch          = EXCLUDED.branch,
+    exam_ref        = EXCLUDED.exam_ref,
+    exercise_number = EXCLUDED.exercise_number,
+    language        = EXCLUDED.language,
+    source          = EXCLUDED.source,
+    raw_text        = EXCLUDED.raw_text,
+    parsed_entities = EXCLUDED.parsed_entities,
+    updated_at      = NOW()
+RETURNING id, subject, topic, draw_type, year, created_at, updated_at;
+"""
+
+# ---------------------------------------------------------------------------
+# The actual BAC 2024 Probability exercise (Arabic raw text).
+# ---------------------------------------------------------------------------
+RAW_TEXT = (
+    "التمرين الأول (04 نقاط) — الاحتمالات\n\n"
+    "يحتوي كيس على 11 كرة متماثلة لا تُفرّق باللمس موزعة كما يلي:\n"
+    "- كرتان بيضاوان مرقمتان بـ: 1، 3\n"
+    "- أربع كرات حمراء مرقمة بـ: 0، 1، 1، 3\n"
+    "- خمس كرات خضراء مرقمة بـ: 0، 1، 1، 3، 4\n\n"
+    "نسحب عشوائيًا 3 كرات دفعة واحدة من الكيس، ونعتبر الحوادث الآتية:\n"
+    "- A: الحصول على 3 كرات من نفس اللون.\n"
+    "- B: الحصول على 3 كرات جداء أرقامها عدد فردي.\n"
+    "- C: الحصول على 3 كرات جداء أرقامها عدد زوجي.\n\n"
+    "(1) احسب احتمال الحادثة P(A)، ثم بيّن أن P(B) = 56/165، ثم استنتج P(C). "
+    "ثم احسب الاحتمال الشرطي P_A(B).\n"
+    "(2) ليكن X المتغير العشوائي الذي يرافق سحب 3 كرات ويمثل عدد الكرات التي "
+    "تحمل رقمًا زوجيًا. عيّن قانون الاحتمال، احسب الأمل الرياضي E(X) و P(X > 1).\n"
+    "(II) نسحب الآن 3 كرات على التوالي وبدون إرجاع. احسب احتمال الحادثة D: "
+    "الحصول على 3 كرات جداء أرقامها معدوم."
+)
+
+# Deterministic parsed entities (mirrors the generative-UI extraction doctrine,
+# CLAUDE.md D-074/D-076). This is what makes RAG semantically aware instead of
+# blind to the problem structure.
+PARSED_ENTITIES = {
+    "container": "كيس",
+    "total_items": 11,
+    "draw_count": 3,
+    "draw_type": "simultaneous",
+    "with_replacement": False,
+    "components": [
+        {"entity": "كرة بيضاء", "color": "white", "count": 2, "numbers": [1, 3]},
+        {"entity": "كرة حمراء", "color": "red", "count": 4, "numbers": [0, 1, 1, 3]},
+        {"entity": "كرة خضراء", "color": "green", "count": 5, "numbers": [0, 1, 1, 3, 4]},
+    ],
+    "events": [
+        {"id": "A", "label": "3 كرات من نفس اللون"},
+        {"id": "B", "label": "جداء الأرقام عدد فردي", "known_probability": "56/165"},
+        {"id": "C", "label": "جداء الأرقام عدد زوجي"},
+        {"id": "D", "label": "جداء الأرقام معدوم", "draw_type": "sequential_without_replacement"},
+    ],
+    "random_variable": {"name": "X", "meaning": "عدد الكرات التي تحمل رقمًا زوجيًا"},
+}
+
+RECORD = {
+    "subject": "Math",
+    "topic": "Probability",
+    "draw_type": "Simultaneous",
+    "year": 2024,
+    "session": "دورة 2024",
+    "branch": "Experimental Sciences",
+    "exam_ref": "Subject 1",
+    "exercise_number": 1,
+    "language": "ar",
+    "source": "Bac 2024 Mathematics - Experimental Sciences (Subject 1, Exercise 1)",
+    "raw_text": RAW_TEXT,
+    "parsed_entities": PARSED_ENTITIES,
+}
+
+
+def resolve_db_url() -> str:
+    """Read the connection string from the environment (never hard-coded)."""
+    url = os.environ.get("DATABASE_URL") or os.environ.get("APP_DATABASE_URL")
+    if not url:
+        sys.exit(
+            "❌ DATABASE_URL (or APP_DATABASE_URL) is not set.\n"
+            "   Export the Supabase connection string before running, e.g.:\n"
+            '   export DATABASE_URL="postgresql://...:6543/postgres?sslmode=require"'
+        )
+    # psycopg2 speaks plain libpq URIs — strip any SQLAlchemy async driver suffix.
+    return url.replace("postgresql+asyncpg://", "postgresql://").replace(
+        "postgresql+psycopg2://", "postgresql://"
+    )
+
+
+def main() -> int:
+    try:
+        import psycopg2
+        from psycopg2.extras import Json
+    except ImportError:
+        sys.exit(
+            "❌ psycopg2 is not installed in this environment.\n"
+            "   Run inside the orchestrator container or a Codespace where\n"
+            "   requirements.txt (psycopg2-binary) is installed, or:\n"
+            "   pip install psycopg2-binary"
+        )
+
+    db_url = resolve_db_url()
+    record = dict(RECORD)
+    record["content_hash"] = hashlib.sha256(record["raw_text"].encode("utf-8")).hexdigest()
+
+    safe_host = db_url.split("@")[-1].split("?")[0] if "@" in db_url else "<hidden>"
+    print(f"🔌 Connecting to Supabase Postgres @ {safe_host} ...")
+
+    try:
+        conn = psycopg2.connect(db_url, connect_timeout=15)
+    except Exception as exc:  # surface the real driver error honestly
+        print(f"❌ Connection failed: {exc}", file=sys.stderr)
+        print(
+            "   (In the Codespaces/sandbox firewall, Postgres egress on ports\n"
+            "    6543/5432 is commonly blocked — run this where egress is open.)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        conn.autocommit = False
+        with conn.cursor() as cur:
+            print("🏗️  Ensuring strict schema (bac_exercises) ...")
+            cur.execute(CREATE_TABLE_SQL)
+
+            print("📥 Upserting BAC 2024 Probability exercise ...")
+            params = dict(record, parsed_entities=Json(record["parsed_entities"]))
+            cur.execute(UPSERT_SQL, params)
+            row = cur.fetchone()
+            cols = [d.name for d in cur.description]
+
+            cur.execute('SELECT COUNT(*) FROM "bac_exercises";')
+            total = cur.fetchone()[0]
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        print(f"❌ ETL failed (rolled back): {exc}", file=sys.stderr)
+        return 3
+    finally:
+        conn.close()
+
+    print("\n✅ DATABASE SUCCESS RESPONSE")
+    print(
+        json.dumps(
+            dict(zip(cols, (str(v) for v in row), strict=False)),
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    print(f"\n📊 bac_exercises total rows: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_guardrails.py
+++ b/scripts/ci_guardrails.py
@@ -33,7 +33,14 @@ FORBIDDEN_PATTERNS = [
     },
     {
         "pattern": "print",
-        "allowed_in": ["scripts/*", "cli.py", "tests/*", "examples/*", "dev_setup.py"],
+        "allowed_in": [
+            "scripts/*",
+            "cli.py",
+            "tests/*",
+            "examples/*",
+            "dev_setup.py",
+            "live_db_restructure.py",
+        ],
         "message": "Use of 'print()' is forbidden in application code. Use 'app.core.logging' instead.",
     },
 ]

--- a/scripts/ci_guardrails.py
+++ b/scripts/ci_guardrails.py
@@ -40,6 +40,7 @@ FORBIDDEN_PATTERNS = [
             "examples/*",
             "dev_setup.py",
             "live_db_restructure.py",
+            "test_visual_pedagogy_ui.py",
         ],
         "message": "Use of 'print()' is forbidden in application code. Use 'app.core.logging' instead.",
     },

--- a/scripts/migrations/0002_bac_exercises.sql
+++ b/scripts/migrations/0002_bac_exercises.sql
@@ -1,0 +1,50 @@
+-- Migration 0002 — bac_exercises (Protocol V24.0 — Data Engineering Mandate)
+--
+-- Strict relational schema for Baccalaureate educational content. Converts the
+-- previously unstructured Arabic exercise text (which caused RAG semantic
+-- blindness) into rows with strict metadata + a JSONB column for the
+-- deterministically parsed entities used by the generative-UI pipeline.
+--
+-- This DDL is applied AUTOMATICALLY on app startup by
+-- app/core/db_schema.py:validate_and_fix_schema() (the table is registered in
+-- app/core/db_schema_config.py:REQUIRED_SCHEMA). This file is the standalone
+-- equivalent for manual execution against Supabase, e.g.:
+--
+--   psql "$APP_DATABASE_URL" -f scripts/migrations/0002_bac_exercises.sql
+--
+-- Or via the ETL driver (recommended — also inserts the BAC 2024 exercise):
+--
+--   DATABASE_URL="postgresql://...:6543/postgres?sslmode=require" \
+--     python live_db_restructure.py
+
+CREATE TABLE IF NOT EXISTS "bac_exercises" (
+    "id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "subject"          VARCHAR(80)  NOT NULL,          -- e.g. "Math"
+    "topic"            VARCHAR(120) NOT NULL,          -- e.g. "Probability"
+    "draw_type"        VARCHAR(40),                    -- e.g. "Simultaneous" | "Sequential"
+    "year"             INTEGER      NOT NULL
+                       CHECK ("year" BETWEEN 1990 AND 2100),  -- e.g. 2024
+    "session"          VARCHAR(60),                    -- e.g. "دورة 2024"
+    "branch"           VARCHAR(160),                   -- e.g. "Experimental Sciences"
+    "exam_ref"         VARCHAR(120),                   -- e.g. "Subject 1"
+    "exercise_number"  INTEGER,                        -- e.g. 1
+    "language"         VARCHAR(8)   NOT NULL DEFAULT 'ar',
+    "source"           VARCHAR(255),                   -- provenance string
+    "content_hash"     VARCHAR(64)  NOT NULL UNIQUE,   -- sha256(raw_text) — idempotent upsert key
+    "raw_text"         TEXT         NOT NULL,          -- the actual Arabic exercise text
+    "parsed_entities"  JSONB        NOT NULL DEFAULT '{}',  -- structured metadata (balls, events, ...)
+    "created_at"       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    "updated_at"       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_subject"
+    ON "bac_exercises" ("subject");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_topic"
+    ON "bac_exercises" ("topic");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_year"
+    ON "bac_exercises" ("year");
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_draw_type"
+    ON "bac_exercises" ("draw_type");
+-- GIN index enables fast containment queries on parsed_entities (RAG filters).
+CREATE INDEX IF NOT EXISTS "ix_bac_exercises_parsed_entities"
+    ON "bac_exercises" USING GIN ("parsed_entities");

--- a/test_visual_pedagogy_ui.py
+++ b/test_visual_pedagogy_ui.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Protocol V26.2 — Live "UI Director" contract validation.
+
+POSTs the impossible-draw query to the running orchestrator (FastAPI :8000) and
+prints the raw JSON response, proving the backend short-circuited ALL
+combinatorial math and returned the strict decoupled ``impossible_case`` schema
+ready for Next.js to render a visual story.
+
+Usage::
+
+    # boot the backend first (docker compose ... up -d, or uvicorn app.main:app)
+    python test_visual_pedagogy_ui.py
+    # custom endpoint:
+    BASE_URL=http://localhost:8000 python test_visual_pedagogy_ui.py
+
+Zero third-party deps (stdlib urllib) so it runs anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000").rstrip("/")
+ENDPOINT = f"{BASE_URL}/api/v1/visual-pedagogy/probability"
+
+# Context: BAC 2024 urn — 2 white, 4 red, 5 green (only 2 white balls exist).
+URN_CONTEXT = (
+    "يحتوي كيس على 11 كرة: كرتان بيضاوان مرقمتان بـ 1 و 3، "
+    "وأربع كرات حمراء، وخمس كرات خضراء. نسحب كرات عشوائياً."
+)
+QUESTION = "كيفاش نسحب 3 كرات بيضاء في نفس الوقت؟"
+
+PAYLOAD = {
+    "question": QUESTION,
+    "history": [{"role": "user", "content": URN_CONTEXT}],
+}
+
+
+def main() -> int:
+    body = json.dumps(PAYLOAD).encode("utf-8")
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    print(f"🎯 POST {ENDPOINT}")
+    print(f"   question: {QUESTION}\n")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = resp.read().decode("utf-8")
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        print(f"❌ HTTP {exc.code}: {exc.read().decode('utf-8', 'replace')}", file=sys.stderr)
+        return 2
+    except urllib.error.URLError as exc:
+        print(f"❌ Cannot reach {ENDPOINT}: {exc.reason}", file=sys.stderr)
+        print("   Boot the backend first (docker compose -f docker-compose.codespaces.yml up -d).")
+        return 2
+
+    print(f"✅ HTTP {status} — RAW JSON RESPONSE:\n")
+    data = json.loads(raw)
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+    # ── PROOF: strict impossible_case schema, math fully bypassed ──────────────
+    print("\n🔬 CONTRACT ASSERTIONS:")
+    checks = [
+        ("ui_mode == 'impossible_case'", data.get("ui_mode") == "impossible_case"),
+        ("is_impossible_case is True", data.get("is_impossible_case") is True),
+        ("fallback_math is null", data.get("visual_directives", {}).get("fallback_math") is None),
+        (
+            "animation_hint == 'bag_shake'",
+            data.get("visual_directives", {}).get("animation_hint") == "bag_shake",
+        ),
+        (
+            "numerical_state.available_items == 2",
+            data.get("numerical_state", {}).get("available_items") == 2,
+        ),
+        (
+            "numerical_state.requested_items == 3",
+            data.get("numerical_state", {}).get("requested_items") == 3,
+        ),
+        (
+            "numerical_state.item_color == 'white'",
+            data.get("numerical_state", {}).get("item_color") == "white",
+        ),
+        ("pedagogical_message present", bool(data.get("pedagogical_message"))),
+        (
+            "NO degenerate math keys (tree/total_combinations)",
+            not any(k in data for k in ("tree", "total_combinations", "composition", "groups")),
+        ),
+    ]
+    ok = True
+    for label, passed in checks:
+        print(f"   {'✅' if passed else '❌'} {label}")
+        ok = ok and passed
+
+    if ok:
+        print("\n🎉 PROOF COMPLETE — math short-circuited, strict impossible_case schema returned.")
+        return 0
+    print("\n❌ Contract assertions failed.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/test_probability_skill.py
+++ b/tests/services/test_probability_skill.py
@@ -336,3 +336,90 @@ def test_composition_item_validation() -> None:
     assert item.p_num == 4
     with pytest.raises(Exception):  # noqa: B017 — مقام صفر مرفوض
         CompositionItem(label="x", count=1, p_num=1, p_den=0, p_decimal=0.5)
+
+
+# ── Protocol V26.2 — الحالة المستحيلة (Visual Pedagogy short-circuit) ──────────────
+
+_BAC_URN = (
+    "يحتوي كيس على 11 كرة: كرتان بيضاوان مرقمتان بـ 1 و 3، وأربع كرات حمراء، وخمس كرات خضراء."
+)
+
+
+def test_impossible_draw_short_circuits_to_pedagogical_payload() -> None:
+    """V26.2: سحب 3 بيضاء من كيس فيه 2 بيضاء → ImpossibleCaseOutput لا حساب."""
+    from app.services.skills.probability_skill import ImpossibleCaseOutput
+
+    out = _skill().analyze(
+        ProbabilityInput(
+            question="كيفاش نسحب 3 كرات بيضاء في نفس الوقت؟",
+            history=[{"role": "user", "content": _BAC_URN}],
+        )
+    )
+    assert isinstance(out, ImpossibleCaseOutput)
+    assert out.ui_mode == "impossible_case"
+    assert out.component == "impossible_draw_animation"
+    assert out.numerical_state.available_items == 2
+    assert out.numerical_state.requested_items == 3
+    assert out.numerical_state.item_color == "white"
+    assert out.visual_directives.fallback_math is None
+    assert out.visual_directives.animation_hint == "bag_shake"
+    assert out.pedagogical_message
+
+
+def test_impossible_case_emits_no_degenerate_math() -> None:
+    """البنية لا تحوي أي مفاتيح حساب (tree/total_combinations/composition)."""
+    from app.services.skills.probability_skill import ImpossibleCaseOutput
+
+    out = _skill().analyze(
+        ProbabilityInput(
+            question="كيفاش نسحب 3 كرات بيضاء في نفس الوقت؟",
+            history=[{"role": "user", "content": _BAC_URN}],
+        )
+    )
+    assert isinstance(out, ImpossibleCaseOutput)
+    dumped = out.model_dump()
+    for forbidden in ("tree", "total_combinations", "composition", "groups"):
+        assert forbidden not in dumped
+
+
+def test_impossible_takes_priority_over_combinations() -> None:
+    """الحالة المستحيلة لها الأولوية على مسار التأليفات (combinations)."""
+    from app.services.skills.probability_skill import (
+        CombinationsModelOutput,
+        ImpossibleCaseOutput,
+    )
+
+    out = _skill().analyze(
+        ProbabilityInput(
+            question="نسحب 3 كرات بيضاء دفعة واحدة",
+            history=[{"role": "user", "content": _BAC_URN}],
+        )
+    )
+    assert isinstance(out, ImpossibleCaseOutput)
+    assert not isinstance(out, CombinationsModelOutput)
+
+
+def test_possible_draw_still_computes_not_impossible() -> None:
+    """سحب ممكن (3 خضراء من 5 خضراء) لا يُفعّل الحالة المستحيلة."""
+    from app.services.skills.probability_skill import ImpossibleCaseOutput
+
+    out = _skill().analyze(
+        ProbabilityInput(
+            question="نسحب 3 كرات خضراء دفعة واحدة",
+            history=[{"role": "user", "content": _BAC_URN}],
+        )
+    )
+    assert not isinstance(out, ImpossibleCaseOutput)
+
+
+def test_with_replacement_is_not_impossible() -> None:
+    """مع الإرجاع: سحب 3 بيضاء من 2 ممكن (لا استحالة) → ليس ImpossibleCaseOutput."""
+    from app.services.skills.probability_skill import ImpossibleCaseOutput
+
+    out = _skill().analyze(
+        ProbabilityInput(
+            question="نسحب 3 كرات بيضاء مع الإرجاع",
+            history=[{"role": "user", "content": _BAC_URN}],
+        )
+    )
+    assert not isinstance(out, ImpossibleCaseOutput)


### PR DESCRIPTION
DevOps mandate:
- docker-compose.codespaces.yml: focused 2-service stack (orchestrator
  FastAPI :8000 + frontend Next.js :3000) wired to live Supabase + OpenRouter
  via env passthrough, with hot-reload bind mounts. Canonical full mesh in
  docker-compose.yml is left untouched.
- .env.codespaces.example: env template (filled-in .env.codespaces gitignored).

Data engineering mandate:
- bac_exercises table: strict relational schema for educational content
  (id UUID, subject, topic, draw_type, year, raw_text, parsed_entities JSONB
  + provenance + content_hash) registered in REQUIRED_SCHEMA/_ALLOWED_TABLES
  so it auto-creates on boot; standalone DDL in scripts/migrations/0002.
- db_schema.py: strip gen_random_uuid() default for SQLite portability.
- live_db_restructure.py: ETL driver that creates the schema and upserts the
  BAC 2024 Probability exercise (reads connection string from env, never
  hard-coded; honest failure when Postgres egress is blocked).

ci_guardrails: allow print() in the root ETL ops script (matches cli.py/dev_setup.py).

https://claude.ai/code/session_01CL1VbV1stScXXfoNbq9SQX