### PR TITLE
V30.0: Deep-Dive Generative UI + Sub-Case Surgery (no C_2^3=0) + universal text-wall muzzle

### DIFF
--- a/.github/workflows/frontend-theme-ci.yml
+++ b/.github/workflows/frontend-theme-ci.yml
@@ -76,8 +76,15 @@ jobs:
             echo "❌ :root block not found"
             exit 1
           fi
-          # Read 60 lines from :root start (enough to cover all vars)
-          root_block=$(tail -n +"$root_start" frontend/app/globals.css | head -60)
+          # Read 60 lines from :root start (enough to cover all vars).
+          # NOTE: use `sed -n RANGEp` (not `tail | head`). Under `set -o pipefail`,
+          # `tail file | head -60` makes `head` close the pipe early; `tail` then
+          # gets SIGPIPE (exit 141) on its next write whenever the remaining file
+          # content exceeds the 64KB pipe buffer — a latent failure that trips once
+          # globals.css grows past ~64KB from :root. `sed -n` has no pipe, so it is
+          # deterministic regardless of file size.
+          root_end=$((root_start + 59))
+          root_block=$(sed -n "${root_start},${root_end}p" frontend/app/globals.css)
           # `grep -e --` defends against `--code-bg` being parsed as a long-option.
           for var in "--code-bg" "--pre-bg" "--code-color" "--pre-color"; do
             if ! printf '%s\n' "$root_block" | grep -q -e "$var" --; then

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -2146,3 +2146,51 @@ Doctrine bumped `PROBABILITY_CALCULATION_DOCTRINE_VERSION` → 1.1.0 (+2 rules).
 Proven live: `scripts/test_auto_ui_trigger.py` — confusion + "دفعة واحدة" →
 combinations (C(11,3)=165, P(3 same)=14/165), NOT a tree; OpenRouter HTTP 200.
 Tests: +7 V19 unit tests; all V14/V15/V17 regressions green; 111 tests pass.
+
+## D-079 — Deep-Dive Generative UI + Sub-Case Surgery (2026-05-22 · Protocol V30.0)
+
+**المشكلة**: ثلاث كوارث تربوية على مسار الاحتمالات الآني (السحب «دفعة واحدة»):
+1. **تسرّب الحلقة الداخلية**: مجموعة (كرتان بيضاوان) يُطلَب منها C(2,3) → `math.comb`
+   يُرجِع 0 → الواجهة تعرض `C_2^3 = 0` المضلِّل (يبدو خطأً حسابياً للطالب).
+2. **جدار نصّي**: المكوّن البصري (combinations/tree) كان يُبثّ ثم يسقط للمسار النصّي
+   فيتبعه شرح LLM طويل — كارثة Cognitive Overload (CLAUDE.md §0 D-074).
+3. **لا قصة بصرية**: عند حيرة الطالب («اريد شرح خارق لاني لم افهم اي شي») لم تكن
+   هناك حمولة storytelling بصرية (urn_state/event_analysis).
+
+**القرار (V30.0)**:
+- **حارس الحلقة الداخلية** في `ProbabilityCalculatorSkill._build_combinations`:
+  حين `k > count` لمجموعةٍ ما، لا نستدعي `math.comb` ولا نُخرِج `C_n^k=0`؛ بل
+  `is_possible=False` + `pedagogical_string="مستحيل (العدد المتوفر غير كافٍ...)"`.
+  المجموعات الممكنة تحمل `is_possible=True` + `C(count,k)=fav`. (`same_group`
+  يجمع الممكنة فقط → P(3 من نفس الصنف) = 14/165 للتمرين 2024.)
+- **القصة البصرية العميقة (Deep Dive)**: `is_confusion()` → `deep_dive=True` +
+  `urn_state` (كرات ملوّنة) + `event_analysis` (تحليل لكل حدث، بلا معادلات خام).
+  `CombinationsVisualizer.jsx` يُصيّر `pedagogical_string` بدل `C_n^k=0`، يرسم
+  حالة الكيس، ويظهر شارة «شرح خارق».
+- **الكبح النصّي المُعمَّم (V30.0 §4)**: `_build_calculated_ui` يُرجِع الآن
+  `terminate_pipeline=True` + `companion_text` (جملة واحدة ≤ 120 حرف:
+  «إليك الشرح البصري المفصل للتمرين خطوة بخطوة 🪄») لكل مكوّن توليدي
+  (combinations_visualizer + probability_tree)، لا للحالة المستحيلة فقط (V28.0).
+  `chat_with_agent` يُنهي المسار فوراً → صفر جدران نصّية بعد المكوّن البصري.
+
+**قواعد دائمة (لا تُكسر بدون ADR)**:
+1. `k > count` لمجموعة ⇒ `is_possible=False` + رسالة تربوية، ممنوع `C_n^k=0`.
+2. أي مكوّن Generative UI يُبثّ للطالب ⇒ `terminate_pipeline=True` + جملة واحدة.
+3. `same_group_favorable` يجمع المجموعات الممكنة فقط.
+4. الخلفية تُخرج Pydantic منظَّماً فقط — التصيير مسؤولية `GenerativeUIRenderer`.
+
+**تحقق حي (2026-05-22)**: `scripts/v30_live_test.py` يقود `chat_with_agent` كاملاً
+للسيناريو → (1) لا `C_2^3=0`، (2) نص مكبوت 45 حرف جملة واحدة، (3) deep_dive +
+urn_state + event_analysis. OpenRouter LIVE HTTP 200 (358 نموذج). Supabase
+مؤجَّل (sandbox يحجب 6543). 65 اختبار V30 + 646 إجمالي (services+contracts) ✅.
+ruff + runtime_truth + skills-doctrine + validate_structure + ci_guardrails ✅.
+
+**الملفات**: `app/services/skills/probability_skill.py` (CombinationGroup +
+is_possible/pedagogical_string/color + deep_dive/urn_state/event_analysis +
+guardrail) | `app/infrastructure/clients/orchestrator_client.py`
+(`_build_calculated_ui` muzzle + new fields) |
+`frontend/app/components/generative/CombinationsVisualizer.jsx` (pedagogical
+render + UrnState + colors) | `frontend/app/globals.css` (V30 styles) | tests:
+`test_probability_skill.py` (+5) `test_generative_ui_streaming.py` (+4)
+`test_v28_text_wall_muzzle.py` (updated for V30 muzzle generalization)
+`frontend/tests/generative_ui_streaming.test.mjs` (+8) | `scripts/v30_live_test.py`.

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -2081,3 +2081,20 @@ connectivity confirmed. Supabase live row-insert deferred to Codespaces
 (sandbox blocks Postgres ports) — `scripts/verify_bkt_live.py` provided.
 
 **Doctrine**: D-074 + CLAUDE.md §6.52.
+
+## ISS-082 — C(2,3)=0 Sub-Case Leak + Text-Wall on Generative UI (2026-05-22) [RESOLVED]
+
+**الأعراض**: مسألة السحب الآني (كيس 11 كرة، سحب 3 «دفعة واحدة»): الواجهة تعرض
+`C_2^3 = 0` للمجموعة البيضاء (2 متاحة)، يتبعها جدار نصّي طويل من LLM، وعند حيرة
+الطالب لا توجد قصة بصرية.
+
+**السبب الجذري**: (1) `_build_combinations` كان يستدعي `math.comb(c,k)` ويُعيد 0
+حين `c<k` → يصل للواجهة كصيغة. (2) `_build_calculated_ui` كان يُرجِع
+`terminate_pipeline` للحالة المستحيلة فقط، فبقية المكوّنات تسقط للمسار النصّي.
+
+**الإصلاح (D-079 · V30.0)**: حارس الحلقة الداخلية (`is_possible`/`pedagogical_string`)،
+كبح نصّي مُعمَّم (`terminate_pipeline=True` + جملة ≤120 حرف لكل مكوّن توليدي)،
+وقصة بصرية (`deep_dive`/`urn_state`/`event_analysis`) تُفعَّل عبر `is_confusion()`.
+
+**تحقق حي**: `scripts/v30_live_test.py` — 3/3 mandates PASS (OpenRouter HTTP 200).
+**Doctrine**: D-079 + CLAUDE.md §6.56.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5352,3 +5352,48 @@ Skill رسمي جديد `app/services/skills/probability_skill.py` (يحترم �
 - regression: V14 gitpod / V15 generalization / V17 omni — كلها ناجحة ✅
 
 
+
+---
+
+## 6.56 Deep-Dive Generative UI + Sub-Case Surgery (2026-05-22, D-079 · Protocol V30.0)
+
+> ثلاث جراحات على مسار السحب الآني («دفعة واحدة»): إيقاف تسرّب `C_2^3=0`،
+> كبح جدار النص لكل مكوّن توليدي، وقصة بصرية شاملة عند حيرة الطالب.
+
+### الكوارث المُشخَّصة
+1. **تسرّب الحلقة الداخلية**: `math.comb(2,3)=0` لمجموعة (كرتان بيضاوان) →
+   الواجهة تعرض `C_2^3 = 0` المضلِّل (يبدو خطأً حسابياً للطالب).
+2. **جدار نصّي**: المكوّن البصري كان يُبثّ ثم يتبعه شرح LLM طويل (Cognitive Overload).
+3. **لا قصة بصرية**: «اريد شرح خارق لاني لم افهم اي شي» لم يُنتج storytelling بصري.
+
+### الإصلاح (D-079)
+- **حارس الحلقة الداخلية** (`ProbabilityCalculatorSkill._build_combinations`):
+  `k > count` ⇒ لا `math.comb`، لا `C_n^k=0`؛ بل `is_possible=False` +
+  `pedagogical_string="مستحيل (العدد المتوفر غير كافٍ لسحب المطلوب)"`. المجموعات
+  الممكنة: `is_possible=True` + `C(count,k)`. `same_group` يجمع الممكنة فقط
+  (التمرين 2024: أبيض مستحيل، أحمر C(4,3)=4، أخضر C(5,3)=10 → P=14/165).
+- **القصة البصرية (Deep Dive)**: `is_confusion()` ⇒ `deep_dive=True` +
+  `urn_state` (كرات ملوّنة) + `event_analysis`. `CombinationsVisualizer.jsx`
+  يُصيّر `pedagogical_string` بدل `C_n^k=0`، يرسم الكيس، يُظهر شارة «شرح خارق».
+- **الكبح النصّي المُعمَّم**: `_build_calculated_ui` يُرجِع `terminate_pipeline=True`
+  + `companion_text` (جملة ≤ 120 حرف: «إليك الشرح البصري المفصل للتمرين خطوة بخطوة 🪄»)
+  لكل مكوّن توليدي (combinations + tree)، لا الحالة المستحيلة فقط (V28.0).
+
+### قواعد دائمة (لا تُكسر بدون ADR)
+1. `k > count` لمجموعة ⇒ `is_possible=False` + رسالة تربوية، ممنوع منعاً باتاً `C_n^k=0`.
+2. أي Generative UI يُبثّ للطالب ⇒ `terminate_pipeline=True` + جملة مرافقة واحدة.
+3. `same_group_favorable` يجمع المجموعات الممكنة فقط.
+4. الخلفية تُخرج Pydantic منظَّماً فقط — التصيير مسؤولية `GenerativeUIRenderer` (whitelist).
+
+### التحقّق الحي (2026-05-22)
+- `scripts/v30_live_test.py` يقود `chat_with_agent` كاملاً للسيناريو →
+  (1) لا `C_2^3=0` ✅ (2) نص مكبوت 45 حرف جملة واحدة ✅ (3) deep_dive + urn_state +
+  event_analysis ✅. OpenRouter LIVE HTTP 200 (358 نموذج). Supabase مؤجَّل (sandbox
+  يحجب 6543/5432). 65 اختبار V30 + 646 إجمالي (services+contracts) ✅.
+  ruff + runtime_truth + skills-doctrine + validate_structure + ci_guardrails ✅.
+
+### السلسلة الكاملة (D-049 → D-079)
+| Decision | المُصلَح |
+|----------|---------|
+| D-075 → D-078 | dynamic probability engine + generalization + hardening + auto-trigger router |
+| **D-079** | **deep-dive generative UI + sub-case surgery (no C_2^3=0) + universal text-wall muzzle** |

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -1036,6 +1036,7 @@ class OrchestratorClient:
                     "title": result.title,
                     "calculated": True,
                     "draw_mode": "simultaneous",
+                    "deep_dive": result.deep_dive,
                     "n": result.n,
                     "k": result.k,
                     "total_combinations": result.total_combinations,
@@ -1044,14 +1045,26 @@ class OrchestratorClient:
                             "label": g.label,
                             "count": g.count,
                             "favorable_combinations": g.favorable_combinations,
+                            # V30.0 — حارس الحلقة الداخلية: الواجهة تعرض
+                            # pedagogical_string حين is_possible=False بدل C_n^k=0.
+                            "is_possible": g.is_possible,
+                            "pedagogical_string": g.pedagogical_string,
+                            "color": g.color,
                         }
                         for g in result.groups
                     ],
                     "same_group_favorable": result.same_group_favorable,
                     "formula": result.formula,
+                    # V30.0 — القصة البصرية الشاملة (Deep Dive storytelling).
+                    "urn_state": result.urn_state,
+                    "event_analysis": result.event_analysis,
                 }
                 return {
                     "component": "combinations_visualizer",
+                    # V30.0 — قانون الكبح النصي: المكوّن البصري يُنهي المسار.
+                    # لا جدار نصّي ولا اشتقاق رياضي نصّي يتبع المكوّن.
+                    "terminate_pipeline": True,
+                    "companion_text": "إليك الشرح البصري المفصل للتمرين خطوة بخطوة 🪄",
                     "props": props,
                     "fallback_text": (
                         f"سحب آني: اختيار {result.k} من {result.n} → "
@@ -1080,6 +1093,10 @@ class OrchestratorClient:
                 }
                 return {
                     "component": "probability_tree",
+                    # V30.0 — قانون الكبح النصي: شجرة الاحتمالات تُنهي المسار أيضاً.
+                    # لا اشتقاق رياضي نصّي يتبع المكوّن البصري.
+                    "terminate_pipeline": True,
+                    "companion_text": "إليك الشرح البصري المفصل للتمرين خطوة بخطوة 🪄",
                     "props": props,
                     "fallback_text": ("شجرة الاحتمالات (تعذّر عرض الرسم التفاعلي — هذا نص بديل)."),
                 }

--- a/app/services/skills/probability_skill.py
+++ b/app/services/skills/probability_skill.py
@@ -284,13 +284,32 @@ class ProbabilityModelOutput(RobustBaseModel):
 
 
 class CombinationGroup(RobustBaseModel):
-    """مجموعة (لون/صنف) في مسألة سحب متزامن: عددها وعدد تأليفاتها C(count, k)."""
+    """مجموعة (لون/صنف) في مسألة سحب متزامن: عددها وعدد تأليفاتها C(count, k).
+
+    ## V30.0 — حارس الحلقة الداخلية (Sub-Group Leak Guardrail)
+    حين يكون عدد المجموعة ``count`` أقل من عدد السحب ``k`` (مثل سحب 3 كرات
+    من مجموعتين بيضاوين فقط)، يكون اختيار k منها **مستحيلاً رياضياً**. في هذه
+    الحالة:
+      • لا نُنفِّذ ``math.comb`` (الذي يُرجِع 0 مضلِّلاً).
+      • لا نُخرِج ``C_2^3 = 0`` (يُربك الطالب — يبدو خطأً حسابياً).
+      • نضع ``is_possible=False`` + ``pedagogical_string`` تربوية صريحة.
+    الواجهة تعرض ``pedagogical_string`` حين ``is_possible=False`` بدل أي صيغة.
+    """
 
     label: str = Field(..., min_length=1, max_length=80)
     count: int = Field(..., ge=0, description="عدد عناصر هذه المجموعة")
     favorable_combinations: int = Field(
-        ..., ge=0, description="C(count, k) — تأليفات اختيار k منها"
+        ..., ge=0, description="C(count, k) — تأليفات اختيار k منها (0 إن مستحيل)"
     )
+    is_possible: bool = Field(
+        default=True, description="False إن k > count (اختيار مستحيل — لا تأليف)"
+    )
+    pedagogical_string: str = Field(
+        default="",
+        max_length=160,
+        description="رسالة تربوية حين الاستحالة (بدل C_n^k = 0 المضلِّل)",
+    )
+    color: str = Field(default="", description="رمز CSS للون (red/white/...) لرسم العنصر")
 
 
 class CombinationsModelOutput(RobustBaseModel):
@@ -314,6 +333,18 @@ class CombinationsModelOutput(RobustBaseModel):
         ..., ge=0, description="مجموع C(count, k) لكل المجموعات (حدث «k من نفس الصنف»)"
     )
     formula: str = Field(default="C(n, k) = n! / (k!·(n-k)!)")
+    # V30.0 — وضع الغوص العميق (Deep Dive Generative UI): يُفعَّل حين يعبّر
+    # الطالب عن حيرة كاملة («لم أفهم أي شيء»). يُغذّي القصة البصرية كاملةً
+    # (urn_state + total_draw_visual + event_analysis) بدل جدار نصّي.
+    deep_dive: bool = Field(default=False, description="True = قصة بصرية شاملة (الطالب حائر)")
+    urn_state: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="حالة الكيس البصرية: [{label, count, color}] لرسم العناصر",
+    )
+    event_analysis: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="تحليل بصري للأحداث: [{label, is_possible, pedagogical_string, color, value}]",
+    )
     title: str = "تأليفات السحب الآني"
     duration_ms: int = 0
 
@@ -920,18 +951,33 @@ class ProbabilityCalculatorSkill:
         )
 
     # ── السحب الآني (Combinatorics) — Protocol V19.0 §2.B ────────────────────────────
+    # V30.0 — الرسالة التربوية للمجموعة المستحيلة (بدل C_n^k = 0 المضلِّل).
+    _SUBGROUP_IMPOSSIBLE_MSG: str = "مستحيل (العدد المتوفر غير كافٍ لسحب المطلوب)"
+
+    @classmethod
+    def _color_for(cls, label: str) -> str:
+        """رمز CSS للون من تسمية المجموعة (red/white/...) — '' إن لا لون."""
+        return _COLOR_CSS_TOKEN.get(label, "")
+
     @classmethod
     def _build_combinations(
         cls,
         comp_raw: list[tuple[str, str, int]],
         total: int,
         combined: str,
+        *,
+        deep_dive: bool = False,
     ) -> CombinationsModelOutput | None:
         """يبني نموذج تأليفات للسحب الآني: C(n,k) + C(count,k) لكل مجموعة.
 
         «نسحب k كرات دفعة واحدة» = اختيار غير مرتَّب → فضاء العيّنة C(n,k). لكل
         مجموعة (لون/صنف) عدد تأليفاتها C(count,k) (حدث «k من نفس الصنف»). ممنوع
         تمثيل هذا بشجرة تتابعية (كارثة تربوية).
+
+        ## V30.0 — حارس الحلقة الداخلية (Sub-Group Leak Surgery)
+        حين ``k > count`` لمجموعة ما (مثل سحب 3 من كيس فيه كرتان بيضاوان فقط):
+        لا نستدعي ``math.comb`` ولا نُخرِج ``C_2^3 = 0``؛ بل نضع ``is_possible=False``
+        ورسالة تربوية صريحة. هكذا لا يتسرّب الصفر المضلِّل إلى الواجهة أبداً.
         """
         import math
 
@@ -941,19 +987,62 @@ class ProbabilityCalculatorSkill:
         total_comb = math.comb(total, k)
         if total_comb < 1:
             return None
+
         groups: list[CombinationGroup] = []
         same_group = 0
         for label_pos, _neg, count in comp_raw:
             c = min(count, total)
-            fav = math.comb(c, k) if c >= k else 0
+            color = cls._color_for(label_pos)
+            # ── الحارس: اختيار k من مجموعة فيها c < k مستحيل ──────────────────
+            if k > c:
+                groups.append(
+                    CombinationGroup(
+                        label=label_pos,
+                        count=c,
+                        favorable_combinations=0,
+                        is_possible=False,
+                        pedagogical_string=cls._SUBGROUP_IMPOSSIBLE_MSG,
+                        color=color,
+                    )
+                )
+                continue
+            fav = math.comb(c, k)
             same_group += fav
-            groups.append(CombinationGroup(label=label_pos, count=c, favorable_combinations=fav))
+            groups.append(
+                CombinationGroup(
+                    label=label_pos,
+                    count=c,
+                    favorable_combinations=fav,
+                    is_possible=True,
+                    pedagogical_string=f"C({c},{k}) = {fav}",
+                    color=color,
+                )
+            )
+
+        # ── القصة البصرية الشاملة (Deep Dive) — حالة الكيس + تحليل الأحداث ──────
+        urn_state = [
+            {"label": g.label, "count": g.count, "color": g.color or "muted"} for g in groups
+        ]
+        event_analysis = [
+            {
+                "label": g.label,
+                "is_possible": g.is_possible,
+                "pedagogical_string": g.pedagogical_string,
+                "color": g.color or "muted",
+                "value": g.favorable_combinations,
+            }
+            for g in groups
+        ]
+
         return CombinationsModelOutput(
             n=total,
             k=k,
             total_combinations=total_comb,
             groups=groups,
             same_group_favorable=same_group,
+            deep_dive=deep_dive,
+            urn_state=urn_state,
+            event_analysis=event_analysis,
             title=f"تأليفات السحب الآني (اختيار {k} من {total})",
         )
 
@@ -981,7 +1070,9 @@ class ProbabilityCalculatorSkill:
         # (Combinatorics)، ممنوع تمثيله بشجرة تتابعية.
         draw_mode = cls._detect_draw_mode(combined)
         if draw_mode == "simultaneous":
-            combo = cls._build_combinations(comp_raw, total, combined)
+            # V30.0: حيرة الطالب («لم أفهم أي شيء») تُفعِّل القصة البصرية الشاملة.
+            deep_dive = cls.is_confusion(question) or cls.is_confusion(combined)
+            combo = cls._build_combinations(comp_raw, total, combined, deep_dive=deep_dive)
             if combo is not None:
                 return combo
             # إن تعذّر بناء التأليف (k غير صالح) لا نسقط لشجرة مضلِّلة — نفشل بنظافة.

--- a/frontend/app/components/generative/CombinationsVisualizer.jsx
+++ b/frontend/app/components/generative/CombinationsVisualizer.jsx
@@ -13,8 +13,17 @@ import React, { memo, useMemo } from 'react';
  *   • لكل مجموعة (لون/صنف): عددها وعدد تأليفات «k من نفس الصنف» = C(count, k).
  *   • احتمال الحدث «k من نفس الصنف» = Σ C(countᵢ, k) / C(n, k) ككسر دقيق.
  *
+ * ## V30.0 — حارس الحلقة الداخلية (Sub-Group Leak)
+ * حين تكون المجموعة غير قابلة للسحب (k > count) يصل ``is_possible=false`` و
+ * ``pedagogical_string``. نعرض الرسالة التربوية بدل ``C_2^3 = 0`` المضلِّل.
+ *
+ * ## V30.0 — القصة البصرية الشاملة (Deep Dive)
+ * حين ``deep_dive=true`` (الطالب حائر) نعرض حالة الكيس (``urn_state``) بكرات
+ * ملوّنة + تحليل الأحداث (``event_analysis``) قبل النتيجة — قصة بصرية لا نصّية.
+ *
  * شكل props المتوقَّع (من OrchestratorClient._build_calculated_ui):
- *   { title?, n, k, total_combinations, groups:[{label,count,favorable_combinations}],
+ *   { title?, n, k, total_combinations, deep_dive?, urn_state?, event_analysis?,
+ *     groups:[{label,count,favorable_combinations,is_possible?,pedagogical_string?,color?}],
  *     same_group_favorable, formula? }
  *
  * عند props مشوَّهة → يُلقي استثناءً يلتقطه GenerativeUIErrorBoundary (fallback أنيق).
@@ -22,6 +31,20 @@ import React, { memo, useMemo } from 'react';
 
 // ألوان دلالية للمجموعات (تدوير لطيف، لا يحمل دلالة "نجاح/فشل")
 const GROUP_PALETTE = ['#f59e0b', '#ef4444', '#22c55e', '#3b82f6', '#a855f7', '#14b8a6'];
+
+// V30.0 — رموز الألوان من الخلفية (urn_state.color) → ألوان CSS فعلية.
+const COLOR_TOKENS = {
+    red: '#ef4444',
+    white: '#e5e7eb',
+    green: '#22c55e',
+    black: '#111827',
+    gold: '#f59e0b',
+    blue: '#3b82f6',
+    muted: '#94a3b8',
+};
+
+const colorFor = (token, i) =>
+    (token && COLOR_TOKENS[token]) || GROUP_PALETTE[i % GROUP_PALETTE.length];
 
 const SymbolCnk = memo(({ n, k }) => (
     <span className="genui-cnk" aria-label={`عدد التأليفات: اختيار ${k} من ${n}`}>
@@ -34,6 +57,40 @@ const SymbolCnk = memo(({ n, k }) => (
 ));
 SymbolCnk.displayName = 'SymbolCnk';
 
+// V30.0 — حالة الكيس البصرية: كرات ملوّنة بعددها (urn_state).
+const UrnState = memo(({ urn }) => {
+    if (!Array.isArray(urn) || urn.length === 0) return null;
+    return (
+        <div className="genui-comb-urn" aria-label="حالة الكيس">
+            <span className="genui-comb-urn-label">
+                <i className="fas fa-sack-dollar" aria-hidden="true" /> ما يحويه الكيس
+            </span>
+            <div className="genui-comb-urn-balls">
+                {urn.map((u, i) => {
+                    const count = Math.max(0, Number(u.count) || 0);
+                    const color = colorFor(u.color, i);
+                    return (
+                        <span className="genui-comb-urn-group" key={`${u.label}-${i}`}>
+                            {Array.from({ length: Math.min(count, 12) }).map((_, b) => (
+                                <span
+                                    className="genui-comb-ball"
+                                    key={b}
+                                    style={{ background: color }}
+                                    aria-hidden="true"
+                                />
+                            ))}
+                            <span className="genui-comb-urn-tag">
+                                {u.label} ({count})
+                            </span>
+                        </span>
+                    );
+                })}
+            </div>
+        </div>
+    );
+});
+UrnState.displayName = 'UrnState';
+
 export const CombinationsVisualizer = memo(({ props }) => {
     if (!props || typeof props !== 'object') {
         throw new Error('CombinationsVisualizer: missing props');
@@ -43,6 +100,8 @@ export const CombinationsVisualizer = memo(({ props }) => {
     const totalCombinations = Number(props.total_combinations);
     const groups = Array.isArray(props.groups) ? props.groups : [];
     const sameGroupFavorable = Number(props.same_group_favorable ?? 0);
+    const deepDive = props.deep_dive === true;
+    const urnState = Array.isArray(props.urn_state) ? props.urn_state : [];
 
     if (!Number.isFinite(n) || !Number.isFinite(k) || !Number.isFinite(totalCombinations) || totalCombinations < 1) {
         throw new Error('CombinationsVisualizer: invalid n/k/total');
@@ -66,11 +125,19 @@ export const CombinationsVisualizer = memo(({ props }) => {
                 <span className="genui-comb-badge" title="سحب آني (دفعة واحدة) — تأليفي لا تتابعي">
                     دفعة واحدة
                 </span>
+                {deepDive && (
+                    <span className="genui-comb-badge genui-comb-badge-deep" title="شرح بصري شامل">
+                        <i className="fas fa-wand-magic-sparkles" aria-hidden="true" /> شرح خارق
+                    </span>
+                )}
             </div>
+
+            {/* V30.0 — القصة البصرية: حالة الكيس (urn_state) */}
+            {deepDive && <UrnState urn={urnState} />}
 
             {/* فضاء العيّنة */}
             <div className="genui-comb-space">
-                <span className="genui-comb-space-label">فضاء العيّنة</span>
+                <span className="genui-comb-space-label">فضاء العيّنة (كل الطرق الممكنة لسحب {k})</span>
                 <span className="genui-comb-space-formula">
                     <SymbolCnk n={n} k={k} />
                     <span className="genui-comb-eq">=</span>
@@ -83,7 +150,8 @@ export const CombinationsVisualizer = memo(({ props }) => {
                 {groups.map((g, i) => {
                     const count = Number(g.count) || 0;
                     const fav = Number(g.favorable_combinations) || 0;
-                    const color = GROUP_PALETTE[i % GROUP_PALETTE.length];
+                    const isPossible = g.is_possible !== false;
+                    const color = colorFor(g.color, i);
                     const width = `${Math.round((fav / maxFav) * 100)}%`;
                     return (
                         <div className="genui-comb-group" key={`${g.label}-${i}`}>
@@ -92,16 +160,26 @@ export const CombinationsVisualizer = memo(({ props }) => {
                                 <span className="genui-comb-group-label">{g.label}</span>
                                 <span className="genui-comb-group-count">العدد: {count}</span>
                             </div>
-                            <div className="genui-comb-bar-track">
-                                <div
-                                    className="genui-comb-bar"
-                                    style={{ width, background: color }}
-                                    aria-hidden="true"
-                                />
-                                <span className="genui-comb-bar-val">
-                                    <SymbolCnk n={count} k={k} /> = {fav}
-                                </span>
-                            </div>
+                            {isPossible ? (
+                                <div className="genui-comb-bar-track">
+                                    <div
+                                        className="genui-comb-bar"
+                                        style={{ width, background: color }}
+                                        aria-hidden="true"
+                                    />
+                                    <span className="genui-comb-bar-val">
+                                        <SymbolCnk n={count} k={k} /> = {fav}
+                                    </span>
+                                </div>
+                            ) : (
+                                // V30.0 — لا نعرض C_2^3 = 0 المضلِّل، بل رسالة تربوية.
+                                <div className="genui-comb-impossible" role="note">
+                                    <i className="fas fa-ban genui-comb-impossible-icon" aria-hidden="true" />
+                                    <span className="genui-comb-impossible-text">
+                                        {g.pedagogical_string || 'مستحيل (العدد المتوفر غير كافٍ لسحب المطلوب)'}
+                                    </span>
+                                </div>
+                            )}
                         </div>
                     );
                 })}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2350,6 +2350,79 @@ body[data-theme='light'] .exam-badge {
     white-space: nowrap;
 }
 
+/* V30.0 — شارة الشرح الخارق (Deep Dive) */
+.genui-comb-badge-deep {
+    margin-inline-start: 0.4rem;
+    border-color: color-mix(in srgb, var(--primary-color) 45%, transparent);
+    color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 10%, transparent);
+}
+
+/* V30.0 — حالة الكيس البصرية (urn_state): كرات ملوّنة */
+.genui-comb-urn {
+    margin-bottom: 0.9rem;
+    padding: 0.7rem 0.85rem;
+    border-radius: 12px;
+    border: 1px dashed var(--border-color);
+    background: color-mix(in srgb, var(--primary-color) 5%, transparent);
+}
+
+.genui-comb-urn-label {
+    display: block;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.5rem;
+}
+
+.genui-comb-urn-balls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+}
+
+.genui-comb-urn-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.genui-comb-ball {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    box-shadow: inset 0 -2px 3px rgba(0, 0, 0, 0.25), 0 1px 2px rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.genui-comb-urn-tag {
+    font-size: 0.78rem;
+    color: var(--text-color);
+    margin-inline-start: 0.3rem;
+    white-space: nowrap;
+}
+
+/* V30.0 — المجموعة المستحيلة (k > count): رسالة تربوية بدل C_n^k = 0 */
+.genui-comb-impossible {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.7rem;
+    border-radius: 10px;
+    border: 1px solid color-mix(in srgb, #f59e0b 40%, transparent);
+    background: color-mix(in srgb, #f59e0b 9%, transparent);
+}
+
+.genui-comb-impossible-icon {
+    color: #d97706;
+    flex-shrink: 0;
+}
+
+.genui-comb-impossible-text {
+    font-size: 0.84rem;
+    color: var(--text-color);
+}
+
 .genui-cnk {
     display: inline-flex;
     align-items: center;

--- a/frontend/tests/generative_ui_streaming.test.mjs
+++ b/frontend/tests/generative_ui_streaming.test.mjs
@@ -208,6 +208,31 @@ check('joint probability P(A)·P(B|A) = 0.24', Math.abs(leafBA.joint - 0.24) < 1
 const rootNode = layout.nodes.find((n) => n.label === 'البداية');
 check('root row = mean of subtree (centered)', rootNode.row === 1.5);
 
+// ─── V30.0: CombinationsVisualizer — Sub-Group Leak + Deep Dive ──────────────────
+const combSrc = read('components/generative/CombinationsVisualizer.jsx');
+check('V30: reads is_possible flag', /is_possible/.test(combSrc));
+check('V30: renders pedagogical_string for impossible group', /pedagogical_string/.test(combSrc));
+check(
+    'V30: impossible branch does NOT render SymbolCnk (no C_n^k = 0 leak)',
+    /isPossible\s*\?[\s\S]*?SymbolCnk[\s\S]*?:\s*\([\s\S]*?genui-comb-impossible/.test(combSrc),
+);
+check('V30: deep_dive prop consumed', /deep_dive/.test(combSrc));
+check('V30: urn_state visualized (UrnState)', /UrnState/.test(combSrc) && /urn_state/.test(combSrc));
+check('V30: color tokens mapped (urn balls)', /COLOR_TOKENS/.test(combSrc));
+
+// behavioral: simulate the guardrail rendering decision per group
+const renderGroup = (g, k) => {
+    const isPossible = g.is_possible !== false;
+    if (isPossible) return { kind: 'formula', text: `C(${g.count},${k}) = ${g.favorable_combinations}` };
+    return { kind: 'pedagogical', text: g.pedagogical_string || 'مستحيل' };
+};
+const whiteGroup = { label: 'كرة بيضاء', count: 2, favorable_combinations: 0, is_possible: false, pedagogical_string: 'مستحيل (العدد المتوفر غير كافٍ لسحب المطلوب)' };
+const redGroup = { label: 'كرة حمراء', count: 4, favorable_combinations: 4, is_possible: true };
+const wr = renderGroup(whiteGroup, 3);
+const rr = renderGroup(redGroup, 3);
+check('V30: white(2) drawing 3 → pedagogical, not formula', wr.kind === 'pedagogical' && !/C\(/.test(wr.text));
+check('V30: red(4) drawing 3 → formula C(4,3) = 4', rr.kind === 'formula' && rr.text === 'C(4,3) = 4');
+
 // ─── النتيجة ────────────────────────────────────────────────────────────────────
 if (failed > 0) {
     console.log(`\n❌ ${failed} check(s) failed`);

--- a/scripts/v30_live_test.py
+++ b/scripts/v30_live_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Protocol V30.0 §5 — Live Verification (Deep-Dive Generative UI + Sub-Case Surgery).
+
+يحاكي المسار الإنتاجي الكامل عبر ``OrchestratorClient.chat_with_agent`` ويُثبت
+حيّاً المطالب الثلاثة:
+
+  1. لا ``C_2^3 = 0`` (ولا أي C(n,k)=0) في حمولة الـ JSON المُولَّدة.
+  2. كبح جدار النص: مجموع النص المبثوث جملة واحدة فقط (≤ 120 حرف).
+  3. حمولة الواجهة تحوي القصة البصرية العميقة (urn_state + event_analysis + deep_dive).
+
+المسار: «اعطني تمرين الاحتمالات 2024 ...» → «اريد شرح خارق لاني لم افهم اي شي».
+
+التشغيل:
+    python scripts/v30_live_test.py
+
+الأسرار تُقرأ من البيئة فقط (لا تُكتب في الملف أبداً):
+    OPENROUTER_API_KEY  — اختياري: ping حيّ لإثبات الاتصال.
+    DATABASE_URL        — اختياري: SELECT 1 حيّ لإثبات اتصال Supabase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-ci-pipeline-secure-length")
+os.environ.setdefault("ENVIRONMENT", "testing")
+os.environ.setdefault("LLM_MOCK_MODE", "1")
+os.environ.setdefault("SUPABASE_URL", "https://dummy.supabase.co")
+os.environ.setdefault("SUPABASE_ROLE_KEY", "dummy")
+
+# التمرين المُسترجَع (يصبح سياق المحادثة) — كيس 11 كرة، سحب 3 دفعة واحدة (آني).
+BAC_2024_SIMUL = (
+    "يحتوي كيس على 11 كرة متماثلة: كرتان بيضاوان، أربع كرات حمراء، خمس كرات خضراء. "
+    "نسحب 3 كرات دفعة واحدة."
+)
+
+CONFUSION_PROMPT = "اريد شرح خارق لاني لم افهم اي شي"
+
+
+def _scan_combination_leak(payload: dict, bad: list[str]) -> None:
+    """يبحث عن أي C(n,k)=0 مُسرَّب في حمولة combinations_visualizer."""
+    blob = json.dumps(payload, ensure_ascii=False)
+    for needle in ("C(2,3)", "C_2^3", "C(0,", "C(1,3)", "C(1,2)"):
+        if needle in blob:
+            bad.append(f"leak: '{needle}' present in payload JSON")
+    props = payload.get("payload", payload).get("props", {})
+    for g in props.get("groups", []):
+        if g.get("is_possible") is False and "C(" in str(g.get("pedagogical_string", "")):
+            bad.append(f"impossible group renders formula: {g.get('label')}")
+
+
+async def _live_connectivity() -> None:
+    key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if key:
+        try:
+            import httpx
+
+            async with httpx.AsyncClient(timeout=15.0) as c:
+                r = await c.get(
+                    "https://openrouter.ai/api/v1/models",
+                    headers={"Authorization": f"Bearer {key}"},
+                )
+                n = len(r.json().get("data", [])) if r.status_code == 200 else 0
+                print(f"  OpenRouter LIVE: HTTP {r.status_code}, {n} models reachable")
+        except Exception as exc:
+            print(f"  OpenRouter ping failed: {exc}")
+    else:
+        print("  OPENROUTER_API_KEY not set — skipping live LLM ping")
+
+    db = os.environ.get("DATABASE_URL", "")
+    if db.startswith("postgres"):
+        try:
+            import asyncpg  # type: ignore
+
+            dsn = db.replace("postgresql+asyncpg://", "postgresql://").split("?")[0]
+            conn = await asyncio.wait_for(asyncpg.connect(dsn), timeout=15.0)
+            val = await conn.fetchval("SELECT 1")
+            await conn.close()
+            print(f"  Supabase LIVE: SELECT 1 -> {val}")
+        except Exception as exc:
+            print(f"  Supabase connect failed: {exc}")
+    else:
+        print("  DATABASE_URL not a postgres DSN — skipping live DB probe")
+
+
+async def main() -> int:
+    print("=" * 74)
+    print("Protocol V30.0 §5 — LIVE: Deep-Dive UI + Sub-Case Surgery")
+    print("=" * 74)
+    print("\n[0] Live connectivity (secrets from env):")
+    await _live_connectivity()
+
+    from app.infrastructure.clients.orchestrator_client import OrchestratorClient
+
+    client = OrchestratorClient.__new__(OrchestratorClient)
+
+    history = [
+        {"role": "user", "content": "اعطني تمرين الاحتمالات 2024"},
+        {"role": "assistant", "content": BAC_2024_SIMUL},
+    ]
+
+    print(f"\n[1] Driving chat_with_agent for: «{CONFUSION_PROMPT}»")
+    ui_events: list[dict] = []
+    text_chunks: list[str] = []
+    async for ev in client.chat_with_agent(
+        CONFUSION_PROMPT, user_id=1, conversation_id=1, history_messages=history
+    ):
+        if not isinstance(ev, dict):
+            text_chunks.append(str(ev))
+            continue
+        etype = ev.get("type")
+        payload = ev.get("payload") or {}
+        if etype == "ui_component":
+            ui_events.append(payload)
+        elif etype == "assistant_delta":
+            content = payload.get("content", "")
+            if content:
+                text_chunks.append(content)
+
+    full_text = "".join(text_chunks).strip()
+
+    print("\n[2] Verification of the three mandates:")
+    ok = True
+
+    # Mandate 1 — no C(n,k)=0 leak
+    bad: list[str] = []
+    if not ui_events:
+        bad.append("no ui_component emitted")
+    for p in ui_events:
+        _scan_combination_leak(p, bad)
+    if bad:
+        ok = False
+        print("  [1] C(n,k)=0 leak: FAIL")
+        for b in bad:
+            print(f"        - {b}")
+    else:
+        print("  [1] No C_2^3=0 (no impossible-group formula) — PASS")
+
+    # Mandate 2 — text-wall muzzle (<= 1 sentence)
+    sentence_count = sum(full_text.count(s) for s in (".", "!", "؟", "?")) or (
+        1 if full_text else 0
+    )
+    muzzled = len(full_text) <= 120 and "\n" not in full_text
+    if muzzled:
+        print(f"  [2] Text wall muzzled — PASS (len={len(full_text)}, text=«{full_text}»)")
+    else:
+        ok = False
+        print(
+            f"  [2] Text wall NOT muzzled — FAIL (len={len(full_text)}, sentences~{sentence_count})"
+        )
+
+    # Mandate 3 — deep visual storytelling payload
+    deep_ok = False
+    for p in ui_events:
+        if p.get("component") == "combinations_visualizer":
+            props = p.get("props", {})
+            if props.get("deep_dive") and props.get("urn_state") and props.get("event_analysis"):
+                deep_ok = True
+    if deep_ok:
+        print("  [3] Deep-dive payload (urn_state + event_analysis + deep_dive) — PASS")
+    else:
+        ok = False
+        print("  [3] Deep-dive storytelling payload missing — FAIL")
+
+    print("\n[3] Emitted ui_component payload (truncated):")
+    if ui_events:
+        print(json.dumps(ui_events[0], ensure_ascii=False, indent=2)[:1800])
+
+    print("\n" + "=" * 74)
+    if ok:
+        print("PASSED — no C_2^3=0, text muzzled to one sentence, deep visual payload present.")
+        return 0
+    print("FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/contracts/test_generative_ui_streaming.py
+++ b/tests/contracts/test_generative_ui_streaming.py
@@ -133,6 +133,68 @@ def test_calculated_tree_none_for_non_probability() -> None:
     assert OrchestratorClient._build_calculated_tree_props("اشرح قانون نيوتن") is None
 
 
+# ─── V30.0: _build_calculated_ui — Sub-Group Leak + Text-Wall Muzzle ─────────────
+
+_V30_URN_SIMUL = (
+    "يحتوي كيس على 11 كرة: كرتان بيضاوان، أربع كرات حمراء، خمس كرات خضراء. نسحب 3 كرات دفعة واحدة."
+)
+
+
+def test_calculated_ui_combinations_no_c_2_3_leak() -> None:
+    """V30.0: حمولة combinations لا تحوي C(2,3)=0 — المجموعة المستحيلة تربوية."""
+    import json
+
+    ev = OrchestratorClient._build_calculated_ui(
+        "اريد شرح خارق لاني لم افهم اي شي",
+        history_messages=[{"role": "user", "content": _V30_URN_SIMUL}],
+    )
+    assert ev is not None
+    assert ev["component"] == "combinations_visualizer"
+    blob = json.dumps(ev, ensure_ascii=False)
+    assert "C(2,3)" not in blob and "C_2^3" not in blob
+    white = next(g for g in ev["props"]["groups"] if "بيضاء" in g["label"])
+    assert white["is_possible"] is False
+    assert white["favorable_combinations"] == 0
+    assert "مستحيل" in white["pedagogical_string"]
+
+
+def test_calculated_ui_combinations_text_wall_muzzle() -> None:
+    """V30.0: المكوّن البصري يُنهي المسار (terminate_pipeline) بجملة واحدة."""
+    ev = OrchestratorClient._build_calculated_ui(
+        "اريد شرح خارق لاني لم افهم اي شي",
+        history_messages=[{"role": "user", "content": _V30_URN_SIMUL}],
+    )
+    assert ev is not None
+    assert ev["terminate_pipeline"] is True
+    companion = ev["companion_text"]
+    assert isinstance(companion, str) and 0 < len(companion) <= 120
+    # جملة واحدة فقط (لا فقرات/قوائم)
+    assert "\n" not in companion
+
+
+def test_calculated_ui_deep_dive_storytelling_payload() -> None:
+    """V30.0: حمولة الغوص العميق تحمل urn_state + event_analysis للقصة البصرية."""
+    ev = OrchestratorClient._build_calculated_ui(
+        "اريد شرح خارق لاني لم افهم اي شي",
+        history_messages=[{"role": "user", "content": _V30_URN_SIMUL}],
+    )
+    assert ev is not None
+    props = ev["props"]
+    assert props["deep_dive"] is True
+    assert isinstance(props["urn_state"], list) and props["urn_state"]
+    assert isinstance(props["event_analysis"], list) and props["event_analysis"]
+
+
+def test_calculated_ui_probability_tree_also_muzzles() -> None:
+    """V30.0: شجرة الاحتمالات (تتابعي) تُنهي المسار أيضاً (لا جدار نصّي)."""
+    ev = OrchestratorClient._build_calculated_ui(
+        "كيس فيه 11 كرة: 4 حمراء و7 خضراء. نسحب كرتين على التوالي وبدون إرجاع، احتمال"
+    )
+    assert ev is not None
+    assert ev["component"] == "probability_tree"
+    assert ev["terminate_pipeline"] is True
+
+
 # ─── _normalize_ui_component_event ──────────────────────────────────────────────
 
 

--- a/tests/services/test_probability_skill.py
+++ b/tests/services/test_probability_skill.py
@@ -423,3 +423,81 @@ def test_with_replacement_is_not_impossible() -> None:
         )
     )
     assert not isinstance(out, ImpossibleCaseOutput)
+
+
+# ─── V30.0: Sub-Group Leak Surgery + Deep Dive Generative UI ─────────────────────
+
+_BAC_URN_SIMUL = (
+    "يحتوي كيس على 11 كرة: كرتان بيضاوان، أربع كرات حمراء، خمس كرات خضراء. نسحب 3 كرات دفعة واحدة."
+)
+
+
+def test_subgroup_leak_guardrail_no_c_2_3_equals_zero() -> None:
+    """V30.0: المجموعة المستحيلة (بيضاء 2، سحب 3) لا تُخرِج C_2^3=0 مضلِّلاً."""
+    from app.services.skills.probability_skill import CombinationsModelOutput
+
+    out = _skill().analyze(_BAC_URN_SIMUL)
+    assert isinstance(out, CombinationsModelOutput)
+    white = next(g for g in out.groups if "بيضاء" in g.label)
+    assert white.is_possible is False
+    assert white.favorable_combinations == 0
+    assert "مستحيل" in white.pedagogical_string
+    # حارس صريح: لا صيغة C(...) في رسالة المجموعة المستحيلة
+    assert "C(" not in white.pedagogical_string
+
+
+def test_subgroup_possible_groups_carry_formula_string() -> None:
+    """V30.0: المجموعات الممكنة تحمل is_possible=True + صيغة C(count,k)."""
+    from app.services.skills.probability_skill import CombinationsModelOutput
+
+    out = _skill().analyze(_BAC_URN_SIMUL)
+    assert isinstance(out, CombinationsModelOutput)
+    red = next(g for g in out.groups if "حمراء" in g.label)
+    green = next(g for g in out.groups if "خضراء" in g.label)
+    assert red.is_possible is True and red.favorable_combinations == 4
+    assert red.pedagogical_string == "C(4,3) = 4"
+    assert green.is_possible is True and green.favorable_combinations == 10
+    assert green.pedagogical_string == "C(5,3) = 10"
+    # same_group: 4 + 10 = 14 (المستحيلة لا تُضاف)
+    assert out.same_group_favorable == 14
+
+
+def test_deep_dive_activated_by_confusion() -> None:
+    """V30.0: حيرة الطالب («لم أفهم أي شيء») تُفعّل deep_dive + القصة البصرية."""
+    from app.services.skills.probability_skill import CombinationsModelOutput
+
+    out = _skill().analyze(
+        ProbabilityInput(
+            question="اريد شرح خارق لاني لم افهم اي شي",
+            history=[{"role": "user", "content": _BAC_URN_SIMUL}],
+        )
+    )
+    assert isinstance(out, CombinationsModelOutput)
+    assert out.deep_dive is True
+    # حالة الكيس وتحليل الأحداث مملوءان للقصة البصرية
+    assert len(out.urn_state) == len(out.groups)
+    assert len(out.event_analysis) == len(out.groups)
+    assert all("color" in u for u in out.urn_state)
+    impossible = [e for e in out.event_analysis if e["is_possible"] is False]
+    assert impossible and all(e["value"] == 0 for e in impossible)
+
+
+def test_deep_dive_off_without_confusion() -> None:
+    """V30.0: بلا حيرة → deep_dive=False (لا قصة بصرية مفروضة)."""
+    from app.services.skills.probability_skill import CombinationsModelOutput
+
+    out = _skill().analyze(_BAC_URN_SIMUL)
+    assert isinstance(out, CombinationsModelOutput)
+    assert out.deep_dive is False
+
+
+def test_combination_group_color_tokens() -> None:
+    """V30.0: المجموعات الملوّنة تحمل رمز CSS صحيح (red/white/green)."""
+    from app.services.skills.probability_skill import CombinationsModelOutput
+
+    out = _skill().analyze(_BAC_URN_SIMUL)
+    assert isinstance(out, CombinationsModelOutput)
+    colors = {g.label: g.color for g in out.groups}
+    assert colors["كرة حمراء"] == "red"
+    assert colors["كرة بيضاء"] == "white"
+    assert colors["كرة خضراء"] == "green"

--- a/tests/services/test_v28_text_wall_muzzle.py
+++ b/tests/services/test_v28_text_wall_muzzle.py
@@ -4,7 +4,7 @@ Protocol V28.0 — Text-Wall Muzzle & Pipeline Bypass tests.
 يغطي:
   • companion_text (≤ 120 حرف) موجود في ImpossibleCaseOutput.
   • terminate_pipeline=True في مخرج _build_calculated_ui للحالة المستحيلة.
-  • المكوّنات العادية لا تُوقف الـ pipeline.
+  • V30.0: كل مكوّن توليدي (combinations/tree) يُوقف الـ pipeline بجملة واحدة.
   • العقد المُفكَّك الصارم (visual_directives / numerical_state / pedagogical_message).
   • لا مفاتيح حساب منحلّة (tree/total_combinations/composition/groups) في props.
   • visual_pedagogy endpoint يُرجِع terminate_pipeline=True للحالة المستحيلة.
@@ -94,19 +94,29 @@ def test_build_calculated_ui_terminate_pipeline_true_for_impossible() -> None:
     assert len(result["companion_text"]) <= 120
 
 
-def test_build_calculated_ui_no_terminate_for_possible_draw() -> None:
-    """V28.0: المكوّنات العادية لا تُوقف الـ pipeline (terminate_pipeline absent/False)."""
+def test_build_calculated_ui_muzzles_all_generative_ui() -> None:
+    """V30.0 (يُحدِّث V28.0): كل مكوّن توليدي يُوقف الـ pipeline بجملة واحدة.
+
+    قانون الكبح النصي الصارم (Protocol V30.0 §4): «إذا استُدعيت أداة Generative
+    UI، يجب إنهاء/تقييد مخرج LLM إلى جملة واحدة». كان V28.0 يُطبِّق هذا على
+    الحالة المستحيلة فقط؛ V30.0 يعمّمه على combinations_visualizer (والشجرة)
+    لإنهاء جدران النص نهائياً.
+    """
     from app.infrastructure.clients.orchestrator_client import OrchestratorClient
 
     result = OrchestratorClient._build_calculated_ui(
         _POSSIBLE_Q,
         history_messages=[{"role": "user", "content": _BAC_URN}],
     )
-    # قد يُرجع None أو مكوّناً عادياً — في كلتا الحالتين terminate_pipeline يجب أن يكون False/absent
-    if result is not None:
-        assert result.get("terminate_pipeline") is not True, (
-            f"terminate_pipeline must NOT be True for component={result.get('component')}"
-        )
+    assert result is not None
+    assert result.get("component") == "combinations_visualizer"
+    # V30.0: المكوّن البصري يُنهي المسار بجملة مرافقة واحدة (لا جدار نصّي).
+    assert result.get("terminate_pipeline") is True, (
+        "V30.0 mandate: generative UI must muzzle the text wall (terminate_pipeline=True)"
+    )
+    companion = result.get("companion_text", "")
+    assert isinstance(companion, str) and 0 < len(companion) <= 120
+    assert "\n" not in companion
 
 
 # ── strict decoupled schema ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary (Protocol V30.0 · D-079)

Three surgical fixes to the simultaneous-draw probability path so the struggling student sees an **imaginative visual explanation**, never a misleading formula or a text wall.

### 1. 🔪 Inner-loop sub-group leak surgery
`ProbabilityCalculatorSkill._build_combinations` previously called `math.comb(2, 3)` for a sub-group with fewer items than the draw count and emitted `C_2^3 = 0` — confusing students. Now, when `k > count`:
- **No** `math.comb`, **no** `C_n^k = 0`.
- Emits `is_possible=False` + `pedagogical_string="مستحيل (العدد المتوفر غير كافٍ لسحب المطلوب)"`.
- `CombinationsVisualizer.jsx` renders the pedagogical string, never the formula.
- `same_group_favorable` sums only possible groups (BAC 2024: white impossible, red `C(4,3)=4`, green `C(5,3)=10` → P = 14/165).

### 2. 🤐 Universal text-wall muzzle
`_build_calculated_ui` now returns `terminate_pipeline=True` + a single `companion_text` ("إليك الشرح البصري المفصل للتمرين خطوة بخطوة 🪄") for **every** generative-UI component (combinations_visualizer + probability_tree), not just the impossible case. `chat_with_agent` ends the stream immediately after the visual component — zero LLM essays follow.

### 3. 🎨 Deep-Dive storytelling
When the student is confused ("اريد شرح خارق لاني لم افهم اي شي"), `is_confusion()` triggers `deep_dive=True` plus a visual `urn_state` (colored balls) and `event_analysis` (per-event blocks with colors, not raw equations). The visualizer paints the bag and the analysis instead of a text essay.

## Files
- `app/services/skills/probability_skill.py` — `CombinationGroup` (`is_possible`/`pedagogical_string`/`color`), `CombinationsModelOutput` (`deep_dive`/`urn_state`/`event_analysis`), inner-loop guardrail.
- `app/infrastructure/clients/orchestrator_client.py` — `_build_calculated_ui` muzzle + new fields.
- `frontend/app/components/generative/CombinationsVisualizer.jsx` — pedagogical render, `UrnState`, color tokens.
- `frontend/app/globals.css` — V30.0 styles.
- Tests: `test_probability_skill.py` (+5), `test_generative_ui_streaming.py` (+4), `test_v28_text_wall_muzzle.py` (updated for the generalized muzzle), `frontend/tests/generative_ui_streaming.test.mjs` (+8).
- `scripts/v30_live_test.py` — live end-to-end verification.
- Memory: `CLAUDE.md` §6.56, `.memory/decisions.md` D-079, `.memory/issues.md` ISS-082.

## Live verification (`scripts/v30_live_test.py`, secrets from env)
Drives `chat_with_agent` end-to-end for the exact scenario prompt:
- **[1] No `C_2^3=0`** in the generated JSON — ✅
- **[2] Text wall muzzled** to one 45-char sentence — ✅
- **[3] Deep-dive payload** (`urn_state` + `event_analysis` + `deep_dive`) present — ✅
- OpenRouter LIVE HTTP 200 (358 models). Supabase live row-probe deferred — the sandbox blocks Postgres egress (6543/5432), consistent with prior D-074 entries.

## Test plan
- [x] `pytest tests/services tests/contracts` → 646 passed
- [x] V30.0 slice (probability + contracts + muzzle) → 65 passed
- [x] `node frontend/tests/generative_ui_streaming.test.mjs` → all checks pass (incl. 8 V30 guards)
- [x] `ruff check .` + `ruff format --check` → clean
- [x] `runtime_truth --check` + `skills-doctrine` + `validate_structure` + `ci_guardrails` → green
- [x] esbuild parse of changed JSX → OK
- [ ] Full Next.js production build not run in-sandbox (no `node_modules`); JSX mirrors the existing working component patterns.

Do **not** merge — review only.

https://claude.ai/code/session_01YWnnRkDDsdBYGaXiQcMVG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWnnRkDDsdBYGaXiQcMVG3)_