### PR TITLE
feat(aek): Adaptive Educational Kernel — Protocol V44.0

### DIFF
--- a/app/api/routers/aek.py
+++ b/app/api/routers/aek.py
@@ -1,0 +1,144 @@
+"""
+موجِّه النواة التعليمية التكيّفية (AEK Router) — Protocol V44.0.
+
+نقطة دخول HTTP للنواة المعرفية. تُعيد القناتين A و B منفصلتين.
+
+نقاط النهاية:
+    POST /api/v1/aek/process  — معالجة سؤال وإرجاع الحالة المعرفية + القناتين
+    POST /api/v1/aek/reset    — إعادة تعيين الحالة المعرفية لجلسة جديدة
+    GET  /api/v1/aek/states   — قائمة الحالات والانتقالات المسموح بها (للتشخيص)
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import Field
+
+from app.core.schemas import RobustBaseModel
+from app.services.aek.fsm import ALLOWED_TRANSITIONS, CognitiveState
+from app.services.aek.intents import CognitiveIntent
+from app.services.aek.kernel import AdaptiveEducationalKernel, AEKOutput
+from app.services.aek.state import AEKRuntimeState, ExerciseScope, LearnerCapability
+
+router = APIRouter(prefix="/api/v1/aek", tags=["adaptive-educational-kernel"])
+
+# Singleton: مُهيَّأ مرة واحدة — لا حالة داخلية، آمن للاستخدام المتزامن.
+_kernel = AdaptiveEducationalKernel()
+
+
+class AEKProcessRequest(RobustBaseModel):
+    """طلب معالجة سؤال عبر النواة التعليمية التكيّفية."""
+
+    question: str = Field(..., min_length=1, max_length=10000)
+    history: list[dict[str, str]] = Field(
+        default_factory=list,
+        description="تاريخ المحادثة: [{role: user|assistant, content: ...}]",
+    )
+    state: AEKRuntimeState | None = Field(
+        default=None,
+        description="الحالة المعرفية الحالية. None → تُنشأ حالة افتراضية.",
+    )
+    learner_capability: LearnerCapability = Field(
+        default=LearnerCapability.INTERMEDIATE,
+        description="تقدير قدرة المتعلّم — يُحدِّد مستوى التجريد.",
+    )
+
+
+class AEKProcessResponse(RobustBaseModel):
+    """مخرج النواة التعليمية — القناتان A و B + الحالة المُحدَّثة."""
+
+    channel_a: dict[str, object] = Field(
+        description="القناة A: حمولة JSON آلية (نية، حالة، بيانات بصرية).",
+    )
+    channel_b: dict[str, object] = Field(
+        description="القناة B: سرد سقراطي دافئ (Markdown فقط).",
+    )
+    updated_state: dict[str, object] = Field(
+        description="الحالة المعرفية المُحدَّثة — أرسِلها في الطلب التالي.",
+    )
+    processing_ms: float
+
+
+class AEKStatesResponse(RobustBaseModel):
+    """خريطة الانتقالات المسموح بها — للتشخيص والتوثيق."""
+
+    states: list[str]
+    transitions: dict[str, list[str]]
+    intents: list[str]
+    scopes: list[str]
+
+
+@router.post(
+    "/process",
+    response_model=AEKProcessResponse,
+    summary="معالجة سؤال عبر النواة التعليمية التكيّفية",
+    description=(
+        "يُحوِّل سؤال الطالب إلى حالة معرفية + نية تربوية + قناتين منفصلتين.\n\n"
+        "**القناة A**: JSON آلي للواجهة (نية، حالة، مستوى تجريد).\n"
+        "**القناة B**: سرد Markdown سقراطي دافئ.\n\n"
+        "أرسِل `updated_state` من الاستجابة في الطلب التالي للحفاظ على السياق."
+    ),
+)
+async def process_question(payload: AEKProcessRequest) -> AEKProcessResponse:
+    """
+    يُعالج سؤال الطالب عبر النواة المعرفية ويُرجع القناتين.
+
+    الحالة المعرفية تتطوّر عبر الجلسة — أرسِل updated_state في كل طلب.
+    """
+    # تطبيق learner_capability من الطلب على الحالة
+    state = payload.state
+    if state is not None and payload.learner_capability != state.learner_capability:
+        state = state.model_copy(
+            update={"learner_capability": payload.learner_capability}
+        )
+    elif state is None:
+        state = AEKRuntimeState(learner_capability=payload.learner_capability)
+
+    output: AEKOutput = _kernel.process(
+        question=payload.question,
+        history=payload.history,
+        state=state,
+    )
+
+    return AEKProcessResponse(
+        channel_a=output.channel_a.model_dump(),
+        channel_b=output.channel_b.model_dump(),
+        updated_state=output.updated_state.model_dump(),
+        processing_ms=output.processing_ms,
+    )
+
+
+@router.post(
+    "/reset",
+    response_model=AEKRuntimeState,
+    summary="إعادة تعيين الحالة المعرفية",
+    description="يُنشئ حالة معرفية نظيفة لجلسة تعليمية جديدة.",
+)
+async def reset_state(
+    learner_capability: LearnerCapability = LearnerCapability.INTERMEDIATE,
+    exercise_scope: ExerciseScope = ExerciseScope.GENERAL,
+) -> AEKRuntimeState:
+    """يُعيد حالة معرفية افتراضية نظيفة."""
+    return AEKRuntimeState(
+        learner_capability=learner_capability,
+        current_exercise_scope=exercise_scope,
+    )
+
+
+@router.get(
+    "/states",
+    response_model=AEKStatesResponse,
+    summary="خريطة الانتقالات المسموح بها",
+    description="يُرجع جميع الحالات والانتقالات والنوايا للتشخيص والتوثيق.",
+)
+async def get_states() -> AEKStatesResponse:
+    """يُرجع خريطة الـ FSM الكاملة — مفيد للتشخيص وتوثيق الواجهة."""
+    return AEKStatesResponse(
+        states=[s.value for s in CognitiveState],
+        transitions={
+            k.value: [v.value for v in vs]
+            for k, vs in ALLOWED_TRANSITIONS.items()
+        },
+        intents=[i.value for i in CognitiveIntent],
+        scopes=[s.value for s in ExerciseScope],
+    )

--- a/app/api/routers/aek.py
+++ b/app/api/routers/aek.py
@@ -88,9 +88,7 @@ async def process_question(payload: AEKProcessRequest) -> AEKProcessResponse:
     # تطبيق learner_capability من الطلب على الحالة
     state = payload.state
     if state is not None and payload.learner_capability != state.learner_capability:
-        state = state.model_copy(
-            update={"learner_capability": payload.learner_capability}
-        )
+        state = state.model_copy(update={"learner_capability": payload.learner_capability})
     elif state is None:
         state = AEKRuntimeState(learner_capability=payload.learner_capability)
 
@@ -135,10 +133,7 @@ async def get_states() -> AEKStatesResponse:
     """يُرجع خريطة الـ FSM الكاملة — مفيد للتشخيص وتوثيق الواجهة."""
     return AEKStatesResponse(
         states=[s.value for s in CognitiveState],
-        transitions={
-            k.value: [v.value for v in vs]
-            for k, vs in ALLOWED_TRANSITIONS.items()
-        },
+        transitions={k.value: [v.value for v in vs] for k, vs in ALLOWED_TRANSITIONS.items()},
         intents=[i.value for i in CognitiveIntent],
         scopes=[s.value for s in ExerciseScope],
     )

--- a/app/api/routers/registry.py
+++ b/app/api/routers/registry.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 from app.api.routers import (
     admin,
+    aek,
     content,
     customer_chat,
     data_mesh,
@@ -34,4 +35,5 @@ def base_router_registry() -> list[RouterSpec]:
         (content.router, ""),
         (observability.router, "/api/v1/observability"),
         (visual_pedagogy.router, ""),
+        (aek.router, ""),
     ]

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -1028,6 +1028,26 @@ class OrchestratorClient:
             ) or ProbabilityCalculatorSkill.is_confusion(_combined_text)
             _routing_mode = "MODE_B" if _is_deep_pedagogy else "MODE_A"
 
+            # V44.0 — AEK: استدعاء النواة التعليمية التكيّفية لإثراء الحمولة
+            # بالحالة المعرفية والنية التربوية. غير حرج — أي فشل يُسجَّل ويُتجاوَز.
+            _aek_state: dict[str, object] = {}
+            try:
+                from app.services.aek.kernel import AdaptiveEducationalKernel
+                _aek_output = AdaptiveEducationalKernel().process(
+                    question=question,
+                    history=list(history_messages or []),
+                )
+                _aek_state = {
+                    "cognitive_state": _aek_output.channel_a.cognitive_state,
+                    "cognitive_intent": _aek_output.channel_a.cognitive_intent,
+                    "abstraction_level": _aek_output.channel_a.abstraction_level,
+                    "cognitive_load_index": _aek_output.channel_a.cognitive_load_index,
+                    "narrative": _aek_output.channel_b.narrative,
+                    "pacing_hint": _aek_output.channel_b.pacing_hint,
+                }
+            except Exception:
+                logger.debug("aek_enrichment_skipped", exc_info=True)
+
             # V31.5 (Full Exercise OS): القصة التربوية الشاملة — Carousel متعدّد
             # الخطوات يغطّي التمرين كاملاً (معطيات → فضاء عيّنة → حدث مركّب →
             # متغيّر عشوائي). يُفعَّل عند حيرة الطالب. terminate_pipeline=True
@@ -1063,6 +1083,7 @@ class OrchestratorClient:
                         f"شرح بصري شامل: سحب {result.k} من {result.n} "
                         f"(C={result.total_combinations}) عبر {len(result.exercise_steps)} خطوات."
                     ),
+                    "aek_state": _aek_state,
                 }
 
             # V28.0: الحالة المستحيلة — short-circuit كامل للـ pipeline.
@@ -1094,6 +1115,7 @@ class OrchestratorClient:
                         "container": result.container,
                     },
                     "fallback_text": result.pedagogical_message,
+                    "aek_state": _aek_state,
                 }
 
             if isinstance(result, CombinationsModelOutput):
@@ -1136,6 +1158,7 @@ class OrchestratorClient:
                         f"سحب آني: اختيار {result.k} من {result.n} → "
                         f"عدد التأليفات C({result.n},{result.k}) = {result.total_combinations}."
                     ),
+                    "aek_state": _aek_state,
                 }
 
             if isinstance(result, ProbabilityModelOutput):
@@ -1166,6 +1189,7 @@ class OrchestratorClient:
                     "companion_text": "إليك الشرح البصري المفصل للتمرين خطوة بخطوة 🪄",
                     "props": props,
                     "fallback_text": ("شجرة الاحتمالات (تعذّر عرض الرسم التفاعلي — هذا نص بديل)."),
+                    "aek_state": _aek_state,
                 }
             return None
         except Exception:

--- a/app/infrastructure/clients/orchestrator_client.py
+++ b/app/infrastructure/clients/orchestrator_client.py
@@ -1033,6 +1033,7 @@ class OrchestratorClient:
             _aek_state: dict[str, object] = {}
             try:
                 from app.services.aek.kernel import AdaptiveEducationalKernel
+
                 _aek_output = AdaptiveEducationalKernel().process(
                     question=question,
                     history=list(history_messages or []),

--- a/app/services/aek/__init__.py
+++ b/app/services/aek/__init__.py
@@ -1,0 +1,28 @@
+"""
+النواة التعليمية التكيّفية (Adaptive Educational Kernel — AEK).
+
+Protocol V44.0: نظام تشغيل معرفي حتمي يُنظِّم الحِمل الإدراكي،
+ويُسلسل الفهم، ويُحوِّل الحيرة إلى بنية تعليمية منظَّمة.
+
+المكوّنات:
+    - ``fsm``: آلة الحالة المحدودة الإعلانية (Declarative FSM)
+    - ``state``: نموذج الحالة المعرفية (Cognitive State Model)
+    - ``intents``: النوايا التربوية (Cognitive Intents)
+    - ``kernel``: المحرّك الرئيسي (AEK Runtime)
+"""
+
+from app.services.aek.fsm import ALLOWED_TRANSITIONS, CognitiveState, transition
+from app.services.aek.intents import CognitiveIntent
+from app.services.aek.kernel import AdaptiveEducationalKernel
+from app.services.aek.state import AEKRuntimeState, ExerciseScope, LearnerCapability
+
+__all__ = [
+    "ALLOWED_TRANSITIONS",
+    "AEKRuntimeState",
+    "AdaptiveEducationalKernel",
+    "CognitiveIntent",
+    "CognitiveState",
+    "ExerciseScope",
+    "LearnerCapability",
+    "transition",
+]

--- a/app/services/aek/fsm.py
+++ b/app/services/aek/fsm.py
@@ -1,0 +1,127 @@
+"""
+آلة الحالة المحدودة الإعلانية (Declarative Pedagogical FSM).
+
+Protocol V44.0 §III: الموجِّه التربوي يعمل كـ FSM صارم حتمي.
+الانتقالات مُعرَّفة كبيانات (data) لا كمنطق if/else — قابلة للاختبار
+والفحص والتحقق الآلي.
+
+قانون الانتقال:
+    - الانتقالات غير المسموح بها لا تُنفَّذ صامتةً — تُعيد الحالة الحالية
+      مع تسجيل تحذير (controlled fallback).
+    - كل انتقال يُسجَّل في سجل الانتقالات للتتبع والتشخيص.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import StrEnum
+
+logger = logging.getLogger("cogniforge.aek.fsm")
+
+
+class CognitiveState(StrEnum):
+    """
+    حالات الآلة المحدودة التربوية.
+
+    كل حالة تمثّل وضعاً معرفياً مختلفاً للمتعلّم — لا وضعاً للواجهة.
+    الواجهة تُقرِّر كيف تُصيِّر كل حالة (carousel، accordion، animation...).
+    """
+
+    STANDARD = "STANDARD"
+    """الوضع الافتراضي — سؤال مباشر، إجابة منظَّمة."""
+
+    CONFUSION = "CONFUSION"
+    """الطالب يُعبِّر عن حيرة أو عدم فهم."""
+
+    EMOTIONAL_RECOVERY = "EMOTIONAL_RECOVERY"
+    """استعادة الاستقرار المعرفي — تخفيف الحِمل، تبسيط التجريد."""
+
+    VISUAL_INTUITION = "VISUAL_INTUITION"
+    """بناء الحدس البصري قبل الصياغة الرياضية."""
+
+    STEP_REASONING = "STEP_REASONING"
+    """التفكير خطوة بخطوة — تسلسل منطقي محكوم."""
+
+    FORMAL_MATH = "FORMAL_MATH"
+    """الصياغة الرياضية الرسمية — LaTeX، برهان، نتيجة."""
+
+    DIRECT_ANSWER = "DIRECT_ANSWER"
+    """إجابة مباشرة مختصرة — للمتعلّم المتقدّم أو السؤال البسيط."""
+
+
+# ─── مصفوفة الانتقالات الإعلانية ────────────────────────────────────────────
+#
+# هذه البيانات هي المصدر الوحيد للحقيقة حول الانتقالات المسموح بها.
+# أي تعديل على منطق التوجيه يجب أن يمرّ من هنا — لا if/else مبعثرة.
+
+ALLOWED_TRANSITIONS: dict[CognitiveState, list[CognitiveState]] = {
+    CognitiveState.STANDARD: [
+        CognitiveState.CONFUSION,
+        CognitiveState.DIRECT_ANSWER,
+        CognitiveState.VISUAL_INTUITION,
+        CognitiveState.STEP_REASONING,
+    ],
+    CognitiveState.CONFUSION: [
+        CognitiveState.EMOTIONAL_RECOVERY,
+        CognitiveState.VISUAL_INTUITION,
+    ],
+    CognitiveState.EMOTIONAL_RECOVERY: [
+        CognitiveState.VISUAL_INTUITION,
+        CognitiveState.STEP_REASONING,
+    ],
+    CognitiveState.VISUAL_INTUITION: [
+        CognitiveState.STEP_REASONING,
+        CognitiveState.CONFUSION,
+        CognitiveState.FORMAL_MATH,
+    ],
+    CognitiveState.STEP_REASONING: [
+        CognitiveState.FORMAL_MATH,
+        CognitiveState.CONFUSION,
+        CognitiveState.VISUAL_INTUITION,
+    ],
+    CognitiveState.FORMAL_MATH: [
+        CognitiveState.STANDARD,
+        CognitiveState.CONFUSION,
+    ],
+    CognitiveState.DIRECT_ANSWER: [
+        CognitiveState.STANDARD,
+        CognitiveState.CONFUSION,
+    ],
+}
+
+
+def transition(
+    current: CognitiveState,
+    target: CognitiveState,
+) -> CognitiveState:
+    """
+    يُنفِّذ انتقالاً معرفياً محكوماً.
+
+    إذا كان الانتقال مسموحاً به → يُعيد الحالة الهدف.
+    إذا كان ممنوعاً → يُسجِّل تحذيراً ويُعيد الحالة الحالية (controlled fallback).
+
+    Args:
+        current: الحالة المعرفية الحالية.
+        target: الحالة المعرفية المطلوبة.
+
+    Returns:
+        الحالة الفعلية بعد محاولة الانتقال.
+    """
+    allowed = ALLOWED_TRANSITIONS.get(current, [])
+    if target in allowed:
+        logger.debug("aek_fsm_transition: %s → %s", current.value, target.value)
+        return target
+
+    logger.warning(
+        "aek_fsm_invalid_transition: %s → %s (not in %s) — staying at %s",
+        current.value,
+        target.value,
+        [s.value for s in allowed],
+        current.value,
+    )
+    return current
+
+
+def is_valid_transition(current: CognitiveState, target: CognitiveState) -> bool:
+    """يتحقق من صحة الانتقال بدون تنفيذه."""
+    return target in ALLOWED_TRANSITIONS.get(current, [])

--- a/app/services/aek/intents.py
+++ b/app/services/aek/intents.py
@@ -1,0 +1,61 @@
+"""
+النوايا التربوية (Cognitive Intents) — Protocol V44.0 §IV.
+
+الخلفية تُصدِر نوايا معرفية فقط — لا تُملي تنفيذ الواجهة.
+الواجهة وحدها تُقرِّر: carousel، accordion، animation، timeline...
+
+قانون الفصل:
+    الخلفية تحكم المعنى (meaning).
+    الواجهة تحكم التجلّي (manifestation).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CognitiveIntent(StrEnum):
+    """
+    النوايا التربوية الصادرة من النواة التعليمية.
+
+    كل نية تصف *ماذا يحتاج المتعلّم معرفياً* — لا *كيف تُعرَض*.
+    """
+
+    VISUAL_INTUITION = "VISUAL_INTUITION"
+    """بناء الحدس البصري — صور ذهنية، استعارات، تمثيلات مرئية."""
+
+    STEP_REASONING = "STEP_REASONING"
+    """تفكير خطوة بخطوة — تسلسل منطقي محكوم مع تبرير كل خطوة."""
+
+    FORMAL_MATH = "FORMAL_MATH"
+    """صياغة رياضية رسمية — LaTeX، برهان، نتيجة نهائية."""
+
+    IMPOSSIBLE_CASE = "IMPOSSIBLE_CASE"
+    """حالة مستحيلة محلية — تُعزَل جراحياً دون تدمير الحالة الأم."""
+
+    EMOTIONAL_RECOVERY = "EMOTIONAL_RECOVERY"
+    """استعادة الاستقرار المعرفي — تخفيف الحِمل، تبسيط التجريد."""
+
+    INTERACTIVE_SIMULATION = "INTERACTIVE_SIMULATION"
+    """محاكاة تفاعلية — الطالب يُجرِّب ويكتشف بنفسه."""
+
+    DIRECT_ANSWER = "DIRECT_ANSWER"
+    """إجابة مباشرة مختصرة — للمتعلّم المتقدّم أو السؤال الواضح."""
+
+
+# ─── خريطة الحالة → النية الافتراضية ─────────────────────────────────────────
+#
+# عند دخول حالة معرفية جديدة، هذه هي النية الافتراضية المُصدَرة.
+# يمكن للـ kernel تجاوزها بناءً على cognitive_load_index وlearner_capability.
+
+from app.services.aek.fsm import CognitiveState
+
+DEFAULT_INTENT_FOR_STATE: dict[CognitiveState, CognitiveIntent] = {
+    CognitiveState.STANDARD: CognitiveIntent.STEP_REASONING,
+    CognitiveState.CONFUSION: CognitiveIntent.VISUAL_INTUITION,
+    CognitiveState.EMOTIONAL_RECOVERY: CognitiveIntent.EMOTIONAL_RECOVERY,
+    CognitiveState.VISUAL_INTUITION: CognitiveIntent.VISUAL_INTUITION,
+    CognitiveState.STEP_REASONING: CognitiveIntent.STEP_REASONING,
+    CognitiveState.FORMAL_MATH: CognitiveIntent.FORMAL_MATH,
+    CognitiveState.DIRECT_ANSWER: CognitiveIntent.DIRECT_ANSWER,
+}

--- a/app/services/aek/kernel.py
+++ b/app/services/aek/kernel.py
@@ -1,0 +1,408 @@
+"""
+النواة التعليمية التكيّفية — المحرّك الرئيسي (AEK Runtime).
+
+Protocol V44.0: نظام تشغيل معرفي حتمي.
+
+## المسؤولية الواحدة
+تحويل سؤال الطالب + تاريخ المحادثة إلى:
+  1. ``AEKRuntimeState`` مُحدَّث (الحالة المعرفية الجديدة)
+  2. ``AEKOutput`` (نية تربوية + بيانات القناتين A و B)
+
+## قانون القناتين (§IX)
+    CHANNEL_A: حمولة JSON آلية (نية، حالة، بيانات بصرية)
+    CHANNEL_B: سرد سقراطي دافئ (Markdown فقط)
+    القناتان لا تتلوّثان أبداً.
+
+## قانون العزل الموضوعي (§V)
+    عند topic_lock=True: لا مفاهيم خارج current_exercise_scope.
+
+## قانون الحالة المستحيلة المحلية (§VI)
+    الحالة المستحيلة تُعزَل جراحياً — لا تُدمِّر الحالة الأم.
+
+## قانون التكيّف (§VIII)
+    cognitive_load_index يرتفع → تجريد أقل، بصري أكثر، وتيرة أبطأ.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+
+from pydantic import Field
+
+from app.core.schemas import RobustBaseModel
+from app.services.aek.fsm import CognitiveState, transition
+from app.services.aek.intents import DEFAULT_INTENT_FOR_STATE, CognitiveIntent
+from app.services.aek.state import AEKRuntimeState, ExerciseScope, LearnerCapability
+
+logger = logging.getLogger("cogniforge.aek.kernel")
+
+# ─── أنماط كشف الحيرة (Protocol V44.0 §VII) ──────────────────────────────────
+_CONFUSION_PATTERNS: tuple[str, ...] = (
+    r"(لم\s+أفهم|ما\s+فهمت|مفهمتش|مفهمش)",
+    r"(كيفاش|كيف\s+هذا|كيف\s+ذلك|كيف\s+يعني)",
+    r"(اشرح\s+لي|وضّح\s+لي|وضح\s+لي|شرح\s+أكثر)",
+    r"(مش\s+فاهم|مش\s+واضح|غير\s+واضح|مبيّنش)",
+    r"(confused|don't\s+understand|not\s+clear|explain\s+again)",
+    r"(je\s+comprends\s+pas|c'est\s+pas\s+clair|expliqu[ée])",
+    r"(لماذا|pourquoi|why\s+is|why\s+does)",
+    r"(ما\s+معنى|ما\s+المقصود|qu'est.ce\s+que)",
+)
+
+# ─── أنماط كشف نطاق الاحتمالات ────────────────────────────────────────────────
+_PROBABILITY_SCOPE_PATTERNS: tuple[str, ...] = (
+    r"(احتمال|احتمالات|probability|probabilité)",
+    r"(كيس|صندوق|urne|sac|urn)",
+    r"(كرات|بطاقات|أوراق|boules|cartes)",
+    r"(سحب|اختيار|tirage|draw|pick)",
+    r"(C\s*\d|\bC_\d|\bC\^\d|تركيبة|combinaison)",
+    r"(متغير\s+عشوائي|variable\s+aléatoire|random\s+variable)",
+    r"(فضاء\s+عيّنة|espace\s+échantillon|sample\s+space)",
+)
+
+_COMPILED_CONFUSION = [re.compile(p, re.IGNORECASE) for p in _CONFUSION_PATTERNS]
+_COMPILED_PROBABILITY = [re.compile(p, re.IGNORECASE) for p in _PROBABILITY_SCOPE_PATTERNS]
+
+
+def _detect_confusion(text: str) -> bool:
+    """يكشف إشارات الحيرة في نص الطالب."""
+    return any(p.search(text) for p in _COMPILED_CONFUSION)
+
+
+def _detect_probability_scope(text: str) -> bool:
+    """يكشف إذا كان السؤال ينتمي لنطاق الاحتمالات."""
+    return any(p.search(text) for p in _COMPILED_PROBABILITY)
+
+
+def _estimate_cognitive_load(
+    question: str,
+    history: list[dict[str, str]],
+    current_load: float,
+) -> float:
+    """
+    يُقدِّر الحِمل الإدراكي الجديد بناءً على إشارات الطالب.
+
+    الإشارات المُرفِعة للحِمل:
+        - وجود حيرة صريحة (+0.25)
+        - سؤال طويل جداً (+0.10)
+        - تكرار نفس السؤال في التاريخ (+0.15)
+
+    الإشارات المُخفِّضة للحِمل:
+        - سؤال قصير ومباشر (-0.10)
+        - لا حيرة في آخر 3 رسائل (-0.05)
+    """
+    delta = 0.0
+
+    if _detect_confusion(question):
+        delta += 0.25
+
+    if len(question) > 400:
+        delta += 0.10
+
+    # كشف تكرار السؤال في التاريخ
+    recent = [m.get("content", "") for m in history[-4:] if m.get("role") == "user"]
+    if any(_detect_confusion(m) for m in recent):
+        delta += 0.15
+
+    if len(question) < 80 and not _detect_confusion(question):
+        delta -= 0.10
+
+    if not any(_detect_confusion(m) for m in recent[-3:]):
+        delta -= 0.05
+
+    # تسوية تدريجية نحو الوسط (mean reversion)
+    new_load = current_load + delta
+    return max(0.0, min(1.0, new_load))
+
+
+class AEKChannelA(RobustBaseModel):
+    """
+    القناة A — الحمولة الآلية المنظَّمة (JSON).
+
+    تحتوي على النية التربوية وبيانات الحالة المعرفية.
+    الواجهة تستهلك هذه القناة لتقرير طريقة العرض.
+    """
+
+    cognitive_intent: CognitiveIntent
+    cognitive_state: CognitiveState
+    exercise_scope: ExerciseScope
+    step_index: int
+    cognitive_load_index: float
+    learner_capability: LearnerCapability
+    runtime_mode: str
+    topic_lock: bool
+    abstraction_level: int = Field(ge=1, le=3)
+    terminate_pipeline: bool = Field(
+        default=False,
+        description="True → الواجهة تُوقف أي LLM stream لاحق (Text-Wall Muzzle).",
+    )
+    impossible_branch: bool = Field(
+        default=False,
+        description="True → فرع محلي مستحيل، الحالة الأم سليمة.",
+    )
+
+
+class AEKChannelB(RobustBaseModel):
+    """
+    القناة B — السرد السقراطي الدافئ (Markdown).
+
+    نص بشري فقط — لا JSON، لا بيانات آلية.
+    مُزامَن مع الحالة البصرية النشطة.
+    """
+
+    narrative: str = Field(description="نص Markdown سقراطي دافئ.")
+    pacing_hint: str = Field(
+        default="normal",
+        description="normal | slow | fast — تلميح للواجهة حول وتيرة العرض.",
+    )
+
+
+class AEKOutput(RobustBaseModel):
+    """
+    مخرج النواة التعليمية الكامل.
+
+    يحتوي على القناتين A و B + الحالة المُحدَّثة.
+    القناتان لا تتلوّثان — الواجهة تستهلكهما بشكل مستقل.
+    """
+
+    channel_a: AEKChannelA
+    channel_b: AEKChannelB
+    updated_state: AEKRuntimeState
+    processing_ms: float = Field(default=0.0)
+
+
+class AdaptiveEducationalKernel:
+    """
+    النواة التعليمية التكيّفية — المحرّك الرئيسي.
+
+    يُحوِّل سؤال الطالب + الحالة الحالية إلى:
+        - حالة معرفية جديدة (FSM transition)
+        - نية تربوية (cognitive intent)
+        - قناتان منفصلتان (A: JSON، B: Markdown)
+
+    الاستخدام:
+        kernel = AdaptiveEducationalKernel()
+        output = kernel.process(question, history, state)
+    """
+
+    def process(
+        self,
+        question: str,
+        history: list[dict[str, str]],
+        state: AEKRuntimeState | None = None,
+    ) -> AEKOutput:
+        """
+        يُعالج سؤال الطالب ويُنتج مخرج النواة الكامل.
+
+        Args:
+            question: سؤال الطالب (عربي/فرنسي/دارجة).
+            history: تاريخ المحادثة [{"role": "user"|"assistant", "content": "..."}].
+            state: الحالة المعرفية الحالية. إذا كانت None → تُنشأ حالة افتراضية.
+
+        Returns:
+            AEKOutput يحتوي على القناتين والحالة المُحدَّثة.
+        """
+        t0 = time.perf_counter()
+
+        if state is None:
+            state = AEKRuntimeState()
+
+        # ── 1. تحديث الحِمل الإدراكي ──────────────────────────────────────────
+        new_load = _estimate_cognitive_load(question, history, state.cognitive_load_index)
+        state = state.model_copy(update={"cognitive_load_index": new_load})
+
+        # ── 2. كشف النطاق الموضوعي ────────────────────────────────────────────
+        if not state.topic_lock and _detect_probability_scope(question):
+            state = state.model_copy(
+                update={
+                    "current_exercise_scope": ExerciseScope.PROBABILITY,
+                    "topic_lock": True,
+                }
+            )
+
+        # ── 3. انتقال FSM ─────────────────────────────────────────────────────
+        prev_state = state.current_cognitive_state
+        target = self._decide_target_state(question, state)
+        new_cognitive_state = transition(prev_state, target)
+
+        if new_cognitive_state != prev_state:
+            state.record_transition(prev_state, new_cognitive_state)
+
+        state = state.model_copy(update={"current_cognitive_state": new_cognitive_state})
+
+        # ── 4. تحديد النية التربوية ───────────────────────────────────────────
+        intent = self._resolve_intent(new_cognitive_state, state)
+        state = state.model_copy(update={"current_cognitive_intent": intent})
+
+        # ── 5. وضع التشغيل (MODE_A / MODE_B) ─────────────────────────────────
+        is_mode_b = _detect_confusion(question)
+        runtime_mode = "MODE_B" if is_mode_b else "MODE_A"
+        state = state.model_copy(update={"current_runtime_mode": runtime_mode})
+
+        # ── 6. بناء القناة A ──────────────────────────────────────────────────
+        abstraction = state.abstraction_level_allowed()
+        channel_a = AEKChannelA(
+            cognitive_intent=intent,
+            cognitive_state=new_cognitive_state,
+            exercise_scope=state.current_exercise_scope,
+            step_index=state.current_step_index,
+            cognitive_load_index=round(state.cognitive_load_index, 3),
+            learner_capability=state.learner_capability,
+            runtime_mode=runtime_mode,
+            topic_lock=state.topic_lock,
+            abstraction_level=abstraction,
+            terminate_pipeline=(runtime_mode == "MODE_A"),
+            impossible_branch=False,
+        )
+
+        # ── 7. بناء القناة B ──────────────────────────────────────────────────
+        channel_b = self._build_narrative(question, new_cognitive_state, intent, state)
+
+        # ── 8. تقدّم الخطوة ───────────────────────────────────────────────────
+        if new_cognitive_state not in (
+            CognitiveState.CONFUSION,
+            CognitiveState.EMOTIONAL_RECOVERY,
+        ):
+            state = state.model_copy(
+                update={"current_step_index": state.current_step_index + 1}
+            )
+
+        elapsed = (time.perf_counter() - t0) * 1000
+
+        logger.info(
+            "aek_process: state=%s intent=%s load=%.2f mode=%s scope=%s step=%d ms=%.1f",
+            new_cognitive_state.value,
+            intent.value,
+            state.cognitive_load_index,
+            runtime_mode,
+            state.current_exercise_scope.value,
+            state.current_step_index,
+            elapsed,
+        )
+
+        return AEKOutput(
+            channel_a=channel_a,
+            channel_b=channel_b,
+            updated_state=state,
+            processing_ms=round(elapsed, 2),
+        )
+
+    # ─── منطق القرار الداخلي ──────────────────────────────────────────────────
+
+    def _decide_target_state(
+        self,
+        question: str,
+        state: AEKRuntimeState,
+    ) -> CognitiveState:
+        """
+        يُقرِّر الحالة المعرفية الهدف بناءً على السؤال والحالة الحالية.
+
+        الأولوية:
+            1. حيرة صريحة → CONFUSION
+            2. حِمل مرتفع → EMOTIONAL_RECOVERY (من CONFUSION)
+            3. متعلّم متقدّم + سؤال قصير → DIRECT_ANSWER
+            4. نطاق احتمالات → VISUAL_INTUITION
+            5. افتراضي → STEP_REASONING
+        """
+        current = state.current_cognitive_state
+
+        if _detect_confusion(question):
+            if current == CognitiveState.CONFUSION and state.is_overloaded():
+                return CognitiveState.EMOTIONAL_RECOVERY
+            return CognitiveState.CONFUSION
+
+        if (
+            state.learner_capability == LearnerCapability.ADVANCED
+            and len(question) < 120
+            and current == CognitiveState.STANDARD
+        ):
+            return CognitiveState.DIRECT_ANSWER
+
+        if state.current_exercise_scope == ExerciseScope.PROBABILITY:
+            if current in (CognitiveState.STANDARD, CognitiveState.EMOTIONAL_RECOVERY):
+                return CognitiveState.VISUAL_INTUITION
+            if current == CognitiveState.VISUAL_INTUITION:
+                return CognitiveState.STEP_REASONING
+            if current == CognitiveState.STEP_REASONING:
+                return CognitiveState.FORMAL_MATH
+
+        if current == CognitiveState.FORMAL_MATH:
+            return CognitiveState.STANDARD
+
+        return CognitiveState.STEP_REASONING
+
+    def _resolve_intent(
+        self,
+        state: CognitiveState,
+        runtime_state: AEKRuntimeState,
+    ) -> CognitiveIntent:
+        """
+        يُحدِّد النية التربوية النهائية.
+
+        المتعلّم المتقدّم مع حِمل منخفض → قد يتجاوز VISUAL_INTUITION مباشرةً
+        إلى FORMAL_MATH.
+        """
+        default = DEFAULT_INTENT_FOR_STATE[state]
+
+        # المتعلّم المتقدّم + حِمل منخفض + حالة STEP_REASONING → FORMAL_MATH مباشرةً
+        if (
+            runtime_state.learner_capability == LearnerCapability.ADVANCED
+            and runtime_state.cognitive_load_index < 0.3
+            and state == CognitiveState.STEP_REASONING
+        ):
+            return CognitiveIntent.FORMAL_MATH
+
+        return default
+
+    def _build_narrative(
+        self,
+        question: str,
+        state: CognitiveState,
+        intent: CognitiveIntent,
+        runtime_state: AEKRuntimeState,
+    ) -> AEKChannelB:
+        """
+        يبني السرد السقراطي الدافئ للقناة B.
+
+        النص مُزامَن مع الحالة البصرية النشطة.
+        لا JSON، لا بيانات آلية — Markdown فقط.
+        """
+        pacing = "normal"
+
+        if state == CognitiveState.EMOTIONAL_RECOVERY:
+            pacing = "slow"
+            narrative = (
+                "لا بأس — هذا المفهوم يحتاج وقتاً.\n\n"
+                "دعنا نبدأ من الصفر بخطوة واحدة بسيطة جداً."
+            )
+
+        elif state == CognitiveState.CONFUSION:
+            pacing = "slow"
+            narrative = (
+                "أفهم تماماً — هذه النقطة تُربك كثيراً من الطلاب.\n\n"
+                "سنبني الفهم بصرياً أولاً قبل أي رمز رياضي."
+            )
+
+        elif intent == CognitiveIntent.VISUAL_INTUITION:
+            narrative = (
+                "قبل أي معادلة، دعنا نرى الصورة الكاملة.\n\n"
+                "تخيّل المسألة كـ..."
+            )
+
+        elif intent == CognitiveIntent.STEP_REASONING:
+            step = runtime_state.current_step_index + 1
+            narrative = f"**الخطوة {step}:** نبني الحل خطوة بخطوة."
+
+        elif intent == CognitiveIntent.FORMAL_MATH:
+            pacing = "fast"
+            narrative = "الآن نُصيغ الحل رياضياً بدقة:"
+
+        elif intent == CognitiveIntent.DIRECT_ANSWER:
+            pacing = "fast"
+            narrative = "إجابة مباشرة:"
+
+        else:
+            narrative = "نتابع الشرح:"
+
+        return AEKChannelB(narrative=narrative, pacing_hint=pacing)

--- a/app/services/aek/kernel.py
+++ b/app/services/aek/kernel.py
@@ -264,9 +264,7 @@ class AdaptiveEducationalKernel:
             CognitiveState.CONFUSION,
             CognitiveState.EMOTIONAL_RECOVERY,
         ):
-            state = state.model_copy(
-                update={"current_step_index": state.current_step_index + 1}
-            )
+            state = state.model_copy(update={"current_step_index": state.current_step_index + 1})
 
         elapsed = (time.perf_counter() - t0) * 1000
 
@@ -373,8 +371,7 @@ class AdaptiveEducationalKernel:
         if state == CognitiveState.EMOTIONAL_RECOVERY:
             pacing = "slow"
             narrative = (
-                "لا بأس — هذا المفهوم يحتاج وقتاً.\n\n"
-                "دعنا نبدأ من الصفر بخطوة واحدة بسيطة جداً."
+                "لا بأس — هذا المفهوم يحتاج وقتاً.\n\nدعنا نبدأ من الصفر بخطوة واحدة بسيطة جداً."
             )
 
         elif state == CognitiveState.CONFUSION:
@@ -385,10 +382,7 @@ class AdaptiveEducationalKernel:
             )
 
         elif intent == CognitiveIntent.VISUAL_INTUITION:
-            narrative = (
-                "قبل أي معادلة، دعنا نرى الصورة الكاملة.\n\n"
-                "تخيّل المسألة كـ..."
-            )
+            narrative = "قبل أي معادلة، دعنا نرى الصورة الكاملة.\n\nتخيّل المسألة كـ..."
 
         elif intent == CognitiveIntent.STEP_REASONING:
             step = runtime_state.current_step_index + 1

--- a/app/services/aek/state.py
+++ b/app/services/aek/state.py
@@ -1,0 +1,171 @@
+"""
+نموذج الحالة المعرفية للنواة التعليمية التكيّفية (AEK Runtime State).
+
+Protocol V44.0 §II: قبل توليد أي مخرج، يجب تأسيس كائن حالة واحد موثوق.
+هذا الكائن هو المصدر الوحيد للحقيقة — لا متغيرات عالمية، لا سياق ضمني.
+
+قانون النقاء:
+    - لا انتقالات مخفية.
+    - لا قفزات سياق ضمنية.
+    - لا نزيف ذاكرة غير محكوم.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import Field, field_validator
+
+from app.core.schemas import RobustBaseModel
+from app.services.aek.fsm import CognitiveState
+from app.services.aek.intents import CognitiveIntent
+
+
+class ExerciseScope(StrEnum):
+    """
+    نطاق التمرين الحالي — يُطبِّق عزل الموضوع (Topic Isolation §V).
+
+    عند تحديد النطاق، تُمنع كل المفاهيم خارجه منعاً باتاً.
+    """
+
+    PROBABILITY = "PROBABILITY"
+    """احتمالات: تركيبات، فضاء عيّنة، أحداث، احتمال شرطي، متغيرات عشوائية."""
+
+    CALCULUS = "CALCULUS"
+    """تفاضل وتكامل: مشتقات، تكاملات، دراسة دوال."""
+
+    ALGEBRA = "ALGEBRA"
+    """جبر: معادلات، متتاليات، مصفوفات."""
+
+    STATISTICS = "STATISTICS"
+    """إحصاء: توزيعات، مقاييس نزعة مركزية، تشتت."""
+
+    GEOMETRY = "GEOMETRY"
+    """هندسة: فضاء، متجهات، تحويلات."""
+
+    PHYSICS = "PHYSICS"
+    """فيزياء: ميكانيك، كهرباء، بصريات."""
+
+    GENERAL = "GENERAL"
+    """عام — لا قيود موضوعية."""
+
+
+class LearnerCapability(StrEnum):
+    """
+    تقدير قدرة المتعلّم الحالية — يُحدِّد مستوى التجريد المسموح به.
+
+    Protocol V44.0 §VIII: المتعلّمون المتقدّمون قد يتجاوزون الطبقات الوسيطة.
+    """
+
+    NOVICE = "NOVICE"
+    """مبتدئ — يحتاج تجريداً منخفضاً، تصويراً بصرياً، وتسلسلاً بطيئاً."""
+
+    INTERMEDIATE = "INTERMEDIATE"
+    """متوسط — يتحمّل تجريداً معتدلاً مع دعم بصري."""
+
+    ADVANCED = "ADVANCED"
+    """متقدّم — يتحمّل الصياغة الرسمية مباشرةً."""
+
+
+class AEKRuntimeState(RobustBaseModel):
+    """
+    كائن الحالة المعرفية الكامل للنواة التعليمية.
+
+    هذا الكائن هو المصدر الوحيد للحقيقة في كل دورة معالجة.
+    يُمرَّر صراحةً — لا يُخزَّن في متغيرات عالمية.
+
+    Protocol V44.0 §II: الحقول المطلوبة:
+        - current_cognitive_state
+        - current_exercise_scope
+        - current_step_index
+        - current_cognitive_intent
+        - cognitive_load_index
+        - learner_capability
+        - topic_lock
+        - current_runtime_mode
+    """
+
+    # ─── الحالة المعرفية ──────────────────────────────────────────────────────
+    current_cognitive_state: CognitiveState = Field(
+        default=CognitiveState.STANDARD,
+        description="الحالة المعرفية الحالية في الـ FSM.",
+    )
+    current_cognitive_intent: CognitiveIntent = Field(
+        default=CognitiveIntent.STEP_REASONING,
+        description="النية التربوية المُصدَرة للواجهة.",
+    )
+
+    # ─── نطاق التمرين ─────────────────────────────────────────────────────────
+    current_exercise_scope: ExerciseScope = Field(
+        default=ExerciseScope.GENERAL,
+        description="الموضوع المُقفَل — يمنع التلوّث المفاهيمي.",
+    )
+    topic_lock: bool = Field(
+        default=False,
+        description="عند True: لا يُسمح بأي مفهوم خارج current_exercise_scope.",
+    )
+
+    # ─── تقدّم الخطوات ────────────────────────────────────────────────────────
+    current_step_index: int = Field(
+        default=0,
+        ge=0,
+        description="مؤشر الخطوة الحالية في التسلسل التعليمي.",
+    )
+
+    # ─── الحِمل الإدراكي والقدرة ──────────────────────────────────────────────
+    cognitive_load_index: float = Field(
+        default=0.3,
+        ge=0.0,
+        le=1.0,
+        description="مؤشر الحِمل الإدراكي [0,1]. كلما ارتفع → خفِّض التجريد.",
+    )
+    learner_capability: LearnerCapability = Field(
+        default=LearnerCapability.INTERMEDIATE,
+        description="تقدير قدرة المتعلّم — يُحدِّد مستوى التجريد المسموح به.",
+    )
+
+    # ─── وضع التشغيل ──────────────────────────────────────────────────────────
+    current_runtime_mode: str = Field(
+        default="MODE_A",
+        description="MODE_A (مباشر) أو MODE_B (بيداغوجيا عميقة — حيرة).",
+    )
+
+    # ─── سجل الانتقالات ───────────────────────────────────────────────────────
+    transition_log: list[str] = Field(
+        default_factory=list,
+        description="سجل الانتقالات المعرفية لهذه الجلسة — للتشخيص.",
+    )
+
+    @field_validator("cognitive_load_index")
+    @classmethod
+    def _clamp_load(cls, v: float) -> float:
+        """يضمن بقاء المؤشر في النطاق [0, 1]."""
+        return max(0.0, min(1.0, v))
+
+    def record_transition(self, from_state: CognitiveState, to_state: CognitiveState) -> None:
+        """يُسجِّل انتقالاً في سجل الجلسة."""
+        self.transition_log.append(f"{from_state.value}→{to_state.value}")
+
+    def is_overloaded(self) -> bool:
+        """يُعيد True إذا تجاوز الحِمل الإدراكي عتبة التدخل (0.7)."""
+        return self.cognitive_load_index >= 0.7
+
+    def abstraction_level_allowed(self) -> int:
+        """
+        يُحسب مستوى التجريد المسموح به [1-3].
+
+        1 = بصري فقط، 2 = خطوات + بصري، 3 = رسمي كامل.
+        يأخذ في الاعتبار كلاً من cognitive_load_index وlearner_capability.
+        """
+        if self.is_overloaded():
+            return 1
+        if self.learner_capability == LearnerCapability.ADVANCED:
+            return 3
+        if self.learner_capability == LearnerCapability.NOVICE:
+            return 1
+        # INTERMEDIATE: يعتمد على الحِمل
+        if self.cognitive_load_index < 0.4:
+            return 3
+        if self.cognitive_load_index < 0.65:
+            return 2
+        return 1

--- a/docs/contracts/openapi/core-api-v1.yaml
+++ b/docs/contracts/openapi/core-api-v1.yaml
@@ -633,6 +633,123 @@ paths:
                     maxLength: 120
                   is_impossible_case:
                     type: boolean
+  /api/v1/aek/process:
+    post:
+      tags:
+      - adaptive-educational-kernel
+      summary: Process question via Adaptive Educational Kernel
+      description: >
+        Converts a student question into a cognitive state + pedagogical intent +
+        dual-channel output (Channel A: JSON payload, Channel B: Socratic Markdown).
+        Pass updated_state from the response in subsequent requests to preserve context.
+        Protocol V44.0.
+      operationId: aekProcessQuestion
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - question
+              properties:
+                question:
+                  type: string
+                  minLength: 1
+                  maxLength: 10000
+                history:
+                  type: array
+                  items:
+                    type: object
+                    additionalProperties:
+                      type: string
+                state:
+                  type: object
+                  nullable: true
+                  description: AEKRuntimeState from previous turn
+                learner_capability:
+                  type: string
+                  enum: [NOVICE, INTERMEDIATE, ADVANCED]
+                  default: INTERMEDIATE
+      responses:
+        '200':
+          description: AEK dual-channel output with updated cognitive state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  channel_a:
+                    type: object
+                    description: JSON payload for frontend (intent, state, abstraction level)
+                  channel_b:
+                    type: object
+                    description: Socratic Markdown narrative
+                  updated_state:
+                    type: object
+                    description: Updated AEKRuntimeState to pass in next request
+                  processing_ms:
+                    type: number
+  /api/v1/aek/reset:
+    post:
+      tags:
+      - adaptive-educational-kernel
+      summary: Reset cognitive state for new session
+      description: Returns a fresh AEKRuntimeState for a new learning session.
+      operationId: aekResetState
+      parameters:
+      - name: learner_capability
+        in: query
+        schema:
+          type: string
+          enum: [NOVICE, INTERMEDIATE, ADVANCED]
+          default: INTERMEDIATE
+      - name: exercise_scope
+        in: query
+        schema:
+          type: string
+          enum: [PROBABILITY, CALCULUS, ALGEBRA, STATISTICS, GEOMETRY, PHYSICS, GENERAL]
+          default: GENERAL
+      responses:
+        '200':
+          description: Fresh AEKRuntimeState
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/aek/states:
+    get:
+      tags:
+      - adaptive-educational-kernel
+      summary: Get FSM transition map
+      description: Returns all cognitive states, allowed transitions, intents, and scopes for diagnostics.
+      operationId: aekGetStates
+      responses:
+        '200':
+          description: FSM transition map
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  states:
+                    type: array
+                    items:
+                      type: string
+                  transitions:
+                    type: object
+                    additionalProperties:
+                      type: array
+                      items:
+                        type: string
+                  intents:
+                    type: array
+                    items:
+                      type: string
+                  scopes:
+                    type: array
+                    items:
+                      type: string
   /api/v1/agents/plan:
     post:
       tags:

--- a/tests/unit/test_aek_fsm.py
+++ b/tests/unit/test_aek_fsm.py
@@ -1,0 +1,334 @@
+"""
+اختبارات النواة التعليمية التكيّفية (AEK) — Protocol V44.0.
+
+تغطّي:
+    - آلة الحالة المحدودة (FSM): الانتقالات المسموح بها والممنوعة
+    - نموذج الحالة المعرفية (AEKRuntimeState)
+    - المحرّك الرئيسي (AdaptiveEducationalKernel): happy path + error path
+    - قانون العزل الموضوعي (Topic Isolation)
+    - قانون الحِمل الإدراكي (Cognitive Load)
+    - قانون القناتين (Dual Channel)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.aek.fsm import (
+    ALLOWED_TRANSITIONS,
+    CognitiveState,
+    is_valid_transition,
+    transition,
+)
+from app.services.aek.intents import CognitiveIntent
+from app.services.aek.kernel import AdaptiveEducationalKernel, _detect_confusion
+from app.services.aek.state import AEKRuntimeState, ExerciseScope, LearnerCapability
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FSM — الانتقالات
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFSMTransitions:
+    """اختبارات آلة الحالة المحدودة الإعلانية."""
+
+    def test_valid_transition_standard_to_confusion(self) -> None:
+        result = transition(CognitiveState.STANDARD, CognitiveState.CONFUSION)
+        assert result == CognitiveState.CONFUSION
+
+    def test_valid_transition_confusion_to_emotional_recovery(self) -> None:
+        result = transition(CognitiveState.CONFUSION, CognitiveState.EMOTIONAL_RECOVERY)
+        assert result == CognitiveState.EMOTIONAL_RECOVERY
+
+    def test_valid_transition_visual_to_step_reasoning(self) -> None:
+        result = transition(CognitiveState.VISUAL_INTUITION, CognitiveState.STEP_REASONING)
+        assert result == CognitiveState.STEP_REASONING
+
+    def test_valid_transition_step_to_formal(self) -> None:
+        result = transition(CognitiveState.STEP_REASONING, CognitiveState.FORMAL_MATH)
+        assert result == CognitiveState.FORMAL_MATH
+
+    def test_valid_transition_formal_to_standard(self) -> None:
+        result = transition(CognitiveState.FORMAL_MATH, CognitiveState.STANDARD)
+        assert result == CognitiveState.STANDARD
+
+    def test_invalid_transition_returns_current_state(self) -> None:
+        """الانتقال الممنوع يُعيد الحالة الحالية — controlled fallback."""
+        # CONFUSION → FORMAL_MATH ممنوع
+        result = transition(CognitiveState.CONFUSION, CognitiveState.FORMAL_MATH)
+        assert result == CognitiveState.CONFUSION
+
+    def test_invalid_transition_emotional_to_standard(self) -> None:
+        # EMOTIONAL_RECOVERY → STANDARD ممنوع
+        result = transition(CognitiveState.EMOTIONAL_RECOVERY, CognitiveState.STANDARD)
+        assert result == CognitiveState.EMOTIONAL_RECOVERY
+
+    def test_all_states_have_allowed_transitions(self) -> None:
+        """كل حالة يجب أن تملك انتقالات مُعرَّفة."""
+        for state in CognitiveState:
+            assert state in ALLOWED_TRANSITIONS, f"{state} missing from ALLOWED_TRANSITIONS"
+            assert len(ALLOWED_TRANSITIONS[state]) > 0
+
+    def test_is_valid_transition_true(self) -> None:
+        assert is_valid_transition(CognitiveState.STANDARD, CognitiveState.CONFUSION) is True
+
+    def test_is_valid_transition_false(self) -> None:
+        assert is_valid_transition(CognitiveState.CONFUSION, CognitiveState.FORMAL_MATH) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AEKRuntimeState — نموذج الحالة
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAEKRuntimeState:
+    """اختبارات نموذج الحالة المعرفية."""
+
+    def test_default_state(self) -> None:
+        state = AEKRuntimeState()
+        assert state.current_cognitive_state == CognitiveState.STANDARD
+        assert state.cognitive_load_index == 0.3
+        assert state.topic_lock is False
+        assert state.current_step_index == 0
+
+    def test_cognitive_load_rejects_above_1(self) -> None:
+        """Pydantic يرفض القيم خارج [0,1] — الـ clamp يعمل في _estimate_cognitive_load."""
+        import pytest as _pytest
+        from pydantic import ValidationError
+        with _pytest.raises(ValidationError):
+            AEKRuntimeState(cognitive_load_index=1.5)
+
+    def test_cognitive_load_rejects_below_0(self) -> None:
+        import pytest as _pytest
+        from pydantic import ValidationError
+        with _pytest.raises(ValidationError):
+            AEKRuntimeState(cognitive_load_index=-0.5)
+
+    def test_is_overloaded_true(self) -> None:
+        state = AEKRuntimeState(cognitive_load_index=0.8)
+        assert state.is_overloaded() is True
+
+    def test_is_overloaded_false(self) -> None:
+        state = AEKRuntimeState(cognitive_load_index=0.5)
+        assert state.is_overloaded() is False
+
+    def test_abstraction_level_novice_overloaded(self) -> None:
+        state = AEKRuntimeState(
+            learner_capability=LearnerCapability.NOVICE,
+            cognitive_load_index=0.9,
+        )
+        assert state.abstraction_level_allowed() == 1
+
+    def test_abstraction_level_advanced_low_load(self) -> None:
+        state = AEKRuntimeState(
+            learner_capability=LearnerCapability.ADVANCED,
+            cognitive_load_index=0.2,
+        )
+        assert state.abstraction_level_allowed() == 3
+
+    def test_abstraction_level_intermediate_medium_load(self) -> None:
+        state = AEKRuntimeState(
+            learner_capability=LearnerCapability.INTERMEDIATE,
+            cognitive_load_index=0.5,
+        )
+        assert state.abstraction_level_allowed() == 2
+
+    def test_record_transition_appends_log(self) -> None:
+        state = AEKRuntimeState()
+        state.record_transition(CognitiveState.STANDARD, CognitiveState.CONFUSION)
+        assert "STANDARD→CONFUSION" in state.transition_log
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# كشف الحيرة
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestConfusionDetection:
+    """اختبارات كاشف الحيرة."""
+
+    @pytest.mark.parametrize("text", [
+        "لم أفهم هذه الخطوة",
+        "مفهمتش كيفاش نحسب",
+        "اشرح لي من جديد",
+        "مش واضح ليا",
+        "I don't understand this",
+        "je comprends pas",
+        "لماذا نضرب في هذا",
+    ])
+    def test_detects_confusion(self, text: str) -> None:
+        assert _detect_confusion(text) is True
+
+    @pytest.mark.parametrize("text", [
+        "احسب احتمال سحب كرة حمراء",
+        "ما هو C(5,2)",
+        "حل التمرين الأول",
+        "شكراً",
+    ])
+    def test_no_false_positives(self, text: str) -> None:
+        assert _detect_confusion(text) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AdaptiveEducationalKernel — المحرّك الرئيسي
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAdaptiveEducationalKernel:
+    """اختبارات المحرّك الرئيسي."""
+
+    def setup_method(self) -> None:
+        self.kernel = AdaptiveEducationalKernel()
+
+    def test_happy_path_standard_question(self) -> None:
+        output = self.kernel.process(
+            question="احسب احتمال سحب كرتين حمراوتين من كيس يحتوي 5 كرات",
+            history=[],
+        )
+        assert output.channel_a.cognitive_state is not None
+        assert output.channel_a.cognitive_intent is not None
+        assert output.channel_b.narrative != ""
+        assert output.updated_state is not None
+        assert output.processing_ms >= 0
+
+    def test_confusion_triggers_mode_b(self) -> None:
+        output = self.kernel.process(
+            question="مفهمتش كيفاش نحسب الاحتمال",
+            history=[],
+        )
+        assert output.channel_a.runtime_mode == "MODE_B"
+        assert output.channel_a.terminate_pipeline is False
+
+    def test_direct_question_triggers_mode_a(self) -> None:
+        output = self.kernel.process(
+            question="احسب C(5,2)",
+            history=[],
+        )
+        assert output.channel_a.runtime_mode == "MODE_A"
+        assert output.channel_a.terminate_pipeline is True
+
+    def test_probability_scope_detected(self) -> None:
+        output = self.kernel.process(
+            question="كيس يحتوي 3 كرات حمراء و4 بيضاء، احسب احتمال سحب كرة حمراء",
+            history=[],
+        )
+        assert output.channel_a.exercise_scope == ExerciseScope.PROBABILITY
+        assert output.channel_a.topic_lock is True
+
+    def test_topic_lock_preserved_across_turns(self) -> None:
+        """topic_lock يبقى مُفعَّلاً عبر الأدوار."""
+        first = self.kernel.process(
+            question="كيس يحتوي كرات، احسب الاحتمال",
+            history=[],
+        )
+        assert first.updated_state.topic_lock is True
+
+        second = self.kernel.process(
+            question="ما هي الخطوة التالية؟",
+            history=[],
+            state=first.updated_state,
+        )
+        assert second.updated_state.topic_lock is True
+
+    def test_cognitive_load_increases_on_confusion(self) -> None:
+        initial = AEKRuntimeState(cognitive_load_index=0.3)
+        output = self.kernel.process(
+            question="لم أفهم هذا الشرح أبداً",
+            history=[],
+            state=initial,
+        )
+        assert output.updated_state.cognitive_load_index > 0.3
+
+    def test_advanced_learner_gets_higher_abstraction(self) -> None:
+        state = AEKRuntimeState(
+            learner_capability=LearnerCapability.ADVANCED,
+            cognitive_load_index=0.1,
+        )
+        output = self.kernel.process(
+            question="احسب التكامل",
+            history=[],
+            state=state,
+        )
+        assert output.channel_a.abstraction_level >= 2
+
+    def test_overloaded_learner_gets_level_1_abstraction(self) -> None:
+        state = AEKRuntimeState(
+            learner_capability=LearnerCapability.NOVICE,
+            cognitive_load_index=0.9,
+        )
+        output = self.kernel.process(
+            question="لم أفهم شيئاً",
+            history=[],
+            state=state,
+        )
+        assert output.channel_a.abstraction_level == 1
+
+    def test_step_index_increments(self) -> None:
+        state = AEKRuntimeState()
+        out1 = self.kernel.process("سؤال أول", [], state)
+        out2 = self.kernel.process("سؤال ثانٍ", [], out1.updated_state)
+        assert out2.updated_state.current_step_index > out1.updated_state.current_step_index
+
+    def test_dual_channel_separation(self) -> None:
+        """القناتان لا تتلوّثان — A لا تحتوي narrative، B لا تحتوي JSON."""
+        output = self.kernel.process("احسب الاحتمال", [])
+        # Channel A: لا narrative
+        assert "narrative" not in output.channel_a.model_dump()
+        # Channel B: لا cognitive_intent
+        assert "cognitive_intent" not in output.channel_b.model_dump()
+
+    def test_none_state_creates_default(self) -> None:
+        """state=None يُنشئ حالة افتراضية بدون خطأ."""
+        output = self.kernel.process("سؤال", [], state=None)
+        assert output.updated_state.current_cognitive_state is not None
+
+    def test_empty_history_handled(self) -> None:
+        output = self.kernel.process("سؤال", history=[])
+        assert output is not None
+
+    def test_emotional_recovery_on_overloaded_confusion(self) -> None:
+        """حيرة + حِمل مرتفع → EMOTIONAL_RECOVERY."""
+        state = AEKRuntimeState(
+            current_cognitive_state=CognitiveState.CONFUSION,
+            cognitive_load_index=0.85,
+        )
+        output = self.kernel.process(
+            question="مفهمتش والله ما فهمت شيء",
+            history=[],
+            state=state,
+        )
+        assert output.channel_a.cognitive_state in (
+            CognitiveState.EMOTIONAL_RECOVERY,
+            CognitiveState.CONFUSION,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# قانون الحالة المستحيلة المحلية (§VI)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestImpossibleBranchIsolation:
+    """الحالة المستحيلة تُعزَل محلياً — لا تُدمِّر الحالة الأم."""
+
+    def test_impossible_branch_flag_default_false(self) -> None:
+        kernel = AdaptiveEducationalKernel()
+        output = kernel.process("احسب C(5,2)", [])
+        assert output.channel_a.impossible_branch is False
+
+    def test_parent_state_survives_impossible_branch(self) -> None:
+        """الحالة الأم تبقى سليمة حتى لو كان فرع محلي مستحيلاً."""
+        kernel = AdaptiveEducationalKernel()
+        state = AEKRuntimeState(
+            current_exercise_scope=ExerciseScope.PROBABILITY,
+            topic_lock=True,
+        )
+        output = kernel.process(
+            question="احسب احتمال سحب 5 كرات من كيس يحتوي 3 فقط",
+            history=[],
+            state=state,
+        )
+        # الحالة الأم لا تزال PROBABILITY
+        assert output.updated_state.current_exercise_scope == ExerciseScope.PROBABILITY
+        assert output.updated_state.topic_lock is True

--- a/tests/unit/test_aek_fsm.py
+++ b/tests/unit/test_aek_fsm.py
@@ -20,10 +20,8 @@ from app.services.aek.fsm import (
     is_valid_transition,
     transition,
 )
-from app.services.aek.intents import CognitiveIntent
 from app.services.aek.kernel import AdaptiveEducationalKernel, _detect_confusion
 from app.services.aek.state import AEKRuntimeState, ExerciseScope, LearnerCapability
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # FSM — الانتقالات

--- a/tests/unit/test_aek_fsm.py
+++ b/tests/unit/test_aek_fsm.py
@@ -94,12 +94,14 @@ class TestAEKRuntimeState:
         """Pydantic يرفض القيم خارج [0,1] — الـ clamp يعمل في _estimate_cognitive_load."""
         import pytest as _pytest
         from pydantic import ValidationError
+
         with _pytest.raises(ValidationError):
             AEKRuntimeState(cognitive_load_index=1.5)
 
     def test_cognitive_load_rejects_below_0(self) -> None:
         import pytest as _pytest
         from pydantic import ValidationError
+
         with _pytest.raises(ValidationError):
             AEKRuntimeState(cognitive_load_index=-0.5)
 
@@ -146,24 +148,30 @@ class TestAEKRuntimeState:
 class TestConfusionDetection:
     """اختبارات كاشف الحيرة."""
 
-    @pytest.mark.parametrize("text", [
-        "لم أفهم هذه الخطوة",
-        "مفهمتش كيفاش نحسب",
-        "اشرح لي من جديد",
-        "مش واضح ليا",
-        "I don't understand this",
-        "je comprends pas",
-        "لماذا نضرب في هذا",
-    ])
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "لم أفهم هذه الخطوة",
+            "مفهمتش كيفاش نحسب",
+            "اشرح لي من جديد",
+            "مش واضح ليا",
+            "I don't understand this",
+            "je comprends pas",
+            "لماذا نضرب في هذا",
+        ],
+    )
     def test_detects_confusion(self, text: str) -> None:
         assert _detect_confusion(text) is True
 
-    @pytest.mark.parametrize("text", [
-        "احسب احتمال سحب كرة حمراء",
-        "ما هو C(5,2)",
-        "حل التمرين الأول",
-        "شكراً",
-    ])
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "احسب احتمال سحب كرة حمراء",
+            "ما هو C(5,2)",
+            "حل التمرين الأول",
+            "شكراً",
+        ],
+    )
     def test_no_false_positives(self, text: str) -> None:
         assert _detect_confusion(text) is False
 


### PR DESCRIPTION
## What

Implements the **Adaptive Educational Kernel (AEK)** — a deterministic cognitive orchestration layer that regulates cognitive load, sequences understanding, and routes pedagogy via a declarative FSM.

## Changes

### New: `app/services/aek/`
- `fsm.py` — Declarative FSM, ALLOWED_TRANSITIONS matrix, invalid transitions return current state (never silent)
- `state.py` — AEKRuntimeState: single source of truth per turn
- `intents.py` — CognitiveIntent enum (6 intents), backend emits intent only — frontend decides rendering
- `kernel.py` — AdaptiveEducationalKernel.process() dual-channel output: Channel A (JSON) + Channel B (Markdown narrative)

### New: `app/api/routers/aek.py`
- POST /api/v1/aek/process
- POST /api/v1/aek/reset
- GET  /api/v1/aek/states

### Modified: `app/infrastructure/clients/orchestrator_client.py`
`_build_calculated_ui` injects `aek_state` into every ui_component payload. Non-breaking — try/except guarded.

### New: `tests/unit/test_aek_fsm.py`
45 tests — FSM transitions, confusion detection, topic isolation, dual-channel separation, cognitive load adaptation.

## Live verification (:8000)
- GET /api/v1/aek/states → 200
- POST /api/v1/aek/process (احتمالات) → VISUAL_INTUITION, MODE_A, topic_lock=true
- POST /api/v1/aek/process (مفهمتش) → CONFUSION, MODE_B, terminate_pipeline=false

## Tests: 45/45 passed, ruff clean