### PR TITLE
fix(skills): refine exercise color sanitization precision

### DIFF
--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -2131,3 +2131,13 @@ connectivity confirmed. Supabase live row-insert deferred to Codespaces
 
 **تحقق حي**: `scripts/v30_live_test.py` — 3/3 mandates PASS (OpenRouter HTTP 200).
 **Doctrine**: D-079 + CLAUDE.md §6.56.
+
+## Open issue — External warning gate noise (LangGraph deprecation)
+
+- **الوصف**: بعض تشغيلات pytest تُعلَن كـ fail حسب tests-policy رغم نجاح الاختبارات، بسبب تحذير خارجي:
+  `LangChainPendingDeprecationWarning` من `langgraph.checkpoint.base`.
+- **النوع**: اعتماد خارجي/بيئي (ليس regression وظيفي في الشفرة المعدلة).
+- **الأثر**: تشويش على إشارة الجودة (false-negative policy signal).
+- **الإجراء المقترح**:
+  1. تثبيت/ترقية نسخة LangGraph المتوافقة، أو
+  2. إضافة إعداد موحّد في pytest لتصفية هذا التحذير المحدد فقط على مستوى المستودع.

--- a/.memory/progress.md
+++ b/.memory/progress.md
@@ -1917,3 +1917,50 @@ cogniforge_pipeline_invocations_total{mode="full"} 2.0
 - **الملفات**: `app/services/skills/output_firewall.py` (جديد) | `app/services/skills/topic_lock.py` (جديد) | `app/services/skills/__init__.py` | `app/services/chat/local_graph.py` | `app/api/routers/customer_chat.py` | `tests/test_output_firewall_v46.py` | `CLAUDE.md` | `.memory/decisions.md` | `.memory/progress.md`.
 
 
+
+## ✅ Session: 2026-05-24 — D-090/D-091: Full-path exercise alignment hardening
+
+- **المشكلة التشغيلية**: في أسئلة المتابعة القصيرة (مثل: "اشرح المطلوب") كان النظام يبني حارس الدقة من السؤال الأخير فقط، ما يسمح بانجراف جزئي عن معطيات التمرين الأصلية. كما ظهرت حالة اختلاق ألوان غير موجودة في السؤال ضمن شرح الاحتمالات.
+
+- **الإصلاحات المنفذة**:
+  1. **D-091**: ربط `_build_precision_guardrail` بالسياق المركّب الكامل (`history + السؤال الحالي`) داخل:
+     - `_chat_node`
+     - `run_local_graph_stream`
+  2. **D-090**: إضافة `_strip_unrequested_color_lines` في `local_graph.py` لإزالة أي سطر يذكر ألواناً غير موجودة في سؤال الاحتمالات.
+
+- **التحقق الحي (End-to-End)**:
+  - `python scripts/test_auto_ui_trigger.py` ✅
+    - confusion detector يعمل
+    - draw_mode = simultaneous عند "دفعة واحدة"
+    - التوجيه إلى `full_exercise_story` (وليس `probability_tree`)
+    - اتساق عددي: `C(11,3)=165` و `P=14/165`
+
+- **اختبارات الانحدار**:
+  - `TestPrecisionGuardrail` + `TestQuestionAlignmentSanitizer` + `TestCatastropheDeepScenarioRegression`
+  - جميع assertions تمر؛ التحذير الوحيد خارجي من تبعية LangGraph.
+
+- **الأثر**:
+  - تقليل drift في إجابات المتابعة
+  - منع اختلاق كيانات لونية في مسائل الاحتمالات
+  - الحفاظ على البنية التعليمية البصرية الصحيحة في السيناريو الحي
+
+## ✅ Session: 2026-05-24 — D-092: ExerciseAlignmentSkill extraction (deep skills architecture)
+
+- **الهدف**: نقل محاذاة معطيات التمرين من دالة محلية داخل `local_graph` إلى Skill رسمية مستقلة قابلة للقياس والتوسع.
+
+- **التنفيذ**:
+  - إنشاء `app/services/skills/exercise_alignment_skill.py` مع عقود Pydantic:
+    - `ExerciseAlignmentInput`
+    - `ExerciseAlignmentOutput`
+    - `ExerciseAlignmentSkill`
+  - ربط `local_graph._strip_unrequested_color_lines` بالـ Skill الجديدة بدل منطق inline.
+  - تحديث `app/services/skills/__init__.py` لتصدير skill الجديدة عبر public API.
+
+- **الفائدة المعمارية**:
+  - التزام أقوى بعقيدة: كل قدرة ذكاء = Skill مستقلة.
+  - قابلية اختبار أفضل (unit tests مستقلة للمهارة).
+  - قابلية توسعة: لاحقاً يمكن إضافة محاذاة أرقام/رموز/وحدات بنفس skill.
+
+- **التحقق**:
+  - اختبارات مهارة جديدة: `tests/services/test_exercise_alignment_skill.py`.
+  - اختبارات الانحدار السابقة لا تزال تعمل.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5700,3 +5700,56 @@ Codespaces/CI** (الـ sandbox يحجب تثبيت التبعيات + egress �
 - 25 اختباراً في `tests/test_output_firewall_v46.py` — جميعها تجتاز.
 - الـ backend يعمل على :8000 (`/health → ok`).
 
+
+---
+
+## Session 2026-05-24 — D-090/D-091 (LocalGraph full-path alignment)
+
+### Incident pattern
+في مسار المتابعة التعليمية، الطالب يرسل سؤالاً قصيراً بعد عرض تمرين كامل. إذا بُنِيَت guardrails من آخر سطر فقط، يضعف الالتصاق بمعطيات التمرين (year/colors/entities) ويزيد drift.
+
+### Implemented controls
+1. **D-091 — Context-bound Precision Guardrail**
+   - بناء `_build_precision_guardrail` من الرسالة المركّبة (history + current question) بدل السؤال الحالي وحده.
+   - مطبّق في: `_chat_node` و `run_local_graph_stream`.
+
+2. **D-090 — Probability Entity Alignment Sanitizer**
+   - إضافة `_strip_unrequested_color_lines(question, answer, intent)`.
+   - يمنع سطور الإجابة التي تُدخل ألواناً غير موجودة في معطيات سؤال الاحتمالات.
+   - يُطبّق مباشرة بعد توليد LLM وقبل بقية طبقات sanitation/quality/firewall.
+
+### Live verification (mandatory)
+- تم تنفيذ `scripts/test_auto_ui_trigger.py` بنجاح:
+  - confusion detected
+  - draw_mode=`simultaneous` عند "دفعة واحدة"
+  - route -> `full_exercise_story` (لا tree متتالية خاطئة)
+  - تحقق عددي: `C(11,3)=165` و `14/165`
+
+### Regression coverage
+- `tests/services/test_iss079_catastrophic_fixes.py`:
+  - `TestPrecisionGuardrail`
+  - `TestQuestionAlignmentSanitizer`
+  - `TestCatastropheDeepScenarioRegression`
+
+### Operational note
+إذا ظهر warning خارجي من LangGraph في pytest policy، يُسجَّل كاعتمادية خارجية ولا يُفسَّر كفشل وظيفي ما لم تفشل assertions نفسها.
+
+---
+
+## Session 2026-05-24 — D-092: Skillization of exercise alignment
+
+### Architectural upgrade
+تم استخراج منطق محاذاة معطيات تمرين الاحتمالات من `local_graph` إلى Skill رسمية:
+- `app/services/skills/exercise_alignment_skill.py`
+
+### Contracts
+- `ExerciseAlignmentInput(question, answer, intent)`
+- `ExerciseAlignmentOutput(aligned_answer, removed_lines, applied)`
+
+### Runtime integration
+`local_graph._strip_unrequested_color_lines` أصبح wrapper يستدعي skill الجديدة بشكل دفاعي.
+
+### Why this matters
+- يمنع `prompt spaghetti` داخل orchestration layer.
+- يدعم فلسفة النظام: القدرات المعرفية يجب أن تعيش في skills قابلة للاختبار والاستبدال.
+- يفتح الطريق لمحاذاة أعمق (numbers/symbols/constraint clauses) داخل نفس skill دون تضخم `local_graph`.

--- a/app/services/chat/local_graph.py
+++ b/app/services/chat/local_graph.py
@@ -69,6 +69,7 @@ def _is_textual_explain_request(question: str) -> bool:
     """يكشف طلب الشرح النصي الصريح — يُعطِّل LaTeX في system prompt."""
     return any(p.search(question) for p in _COMPILED_TEXTUAL)
 
+
 # ISS-075 (D-063): تطبيقات regex الـ greeting يجب أن تسمح بكلمات إضافية
 # قبل الإصلاح: `^(السلام)[\s\W]*$` يفشل عند "السلام عليكم" لأن "عليكم"
 # ليست في `[\s\W]`. نتيجة: التحية تُصنَّف كـ `general` → الـ LLM يُولد
@@ -131,7 +132,14 @@ _SYSTEM_PROMPTS = {
         "- استخدم التشبيهات والأمثلة الملموسة لتثبيت المفهوم\n"
         "- إذا كان السؤال غامضاً، اطرح توضيحاً قبل الإجابة\n"
         "- لا تختصر — الطالب يحتاج الفهم الكامل\n"
-        "- شجّع الطالب وأكد له أن الرياضيات ممتعة وليست صعبة"
+        "- شجّع الطالب وأكد له أن الرياضيات ممتعة وليست صعبة\n\n"
+        "## قواعد الجودة الإلزامية (مضاد الكوارث)\n"
+        "- التزم حرفياً بمعطيات التمرين ولا تُضِف لوناً أو رقماً غير موجود في النص.\n"
+        "- امنع التكرار: لا تعِد نفس الفقرة أو نفس القائمة بصياغات متشابهة.\n"
+        "- عند طلب «شجرة احتمالات»، ابنِ سحباً متتالياً بدون إرجاع مع فروع واضحة واحتمالات كل مستوى.\n"
+        "- ميّز بين «سحب دفعة واحدة» (توافيق) و«سحب متتالٍ» (شجرة/احتمالات شرطية).\n"
+        "- إذا ظهر تناقض في نصّ الطالب، اذكره بلطف ثم أكمل الحل على فرضية صريحة.\n"
+        "- اختم كل حل بـ «تحقّق سريع» عددي يثبت النتيجة (مثل: مجموع الاحتمالات = 1)."
     ),
     "general": (
         "أنت مساعد ذكي متخصص في خدمة الطلاب الجزائريين.\n"
@@ -231,6 +239,110 @@ _CHAT_META_PATTERNS = [
 ]
 
 
+def _normalize_for_dedup(text: str) -> str:
+    """يُطبّع الفقرة لأغراض كشف التكرار دون تغيير النص الأصلي."""
+    collapsed = _re_sanitize.sub(r"\s+", " ", text).strip()
+    # توحيد بسيط للترقيم العربي/اللاتيني لتقليل false negatives
+    return collapsed.replace("—", "-").replace("–", "-")
+
+
+def _token_signature(text: str) -> frozenset[str]:
+    """يبني بصمة كلمات مستقرة لكشف التكرار شبه المتطابق."""
+    return frozenset(tok for tok in _re_sanitize.findall(r"\w+", text.lower()) if len(tok) >= 2)
+
+
+def _is_long_educational_scaffold(norm: str, raw: str) -> bool:
+    """يحدد إن كانت الكتلة قالباً تعليمياً طويلاً قابلاً للتكرار الكارثي."""
+    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+    has_steps = bool(_re_sanitize.search(r"(^|\n)\s*(\d+[).]|[-*•])\s*", raw))
+    return len(norm) >= 140 and len(lines) >= 4 and has_steps
+
+
+def _is_near_duplicate(sig_a: frozenset[str], sig_b: frozenset[str], threshold: float = 0.82) -> bool:
+    """مقارنة تشابه Jaccard لكشف نسخة مكررة بصياغة سطحية مختلفة."""
+    if not sig_a or not sig_b:
+        return False
+    inter = len(sig_a & sig_b)
+    union = len(sig_a | sig_b)
+    if union == 0:
+        return False
+    return (inter / union) >= threshold
+
+
+def _build_precision_guardrail(question: str, intent: str) -> str:
+    """يبني حارس دقة موجزاً مرتبطاً بسؤال الطالب للحد من الانحراف/الهلوسة."""
+    if intent not in ("educational", "general"):
+        return ""
+    q = question.strip()
+    if not q:
+        return ""
+    numbers = _re_sanitize.findall(r"\b\d+\b", q)
+    arabic_colors = [c for c in ("بيضاء", "حمراء", "خضراء", "زرقاء", "سوداء", "صفراء") if c in q]
+    key_terms = [t for t in ("احتمالات", "شجرة", "بدون إرجاع", "احتمال شرطي", "تمرين") if t in q]
+    constraints: list[str] = [
+        "- لا تخترع معطيات جديدة غير موجودة في سؤال الطالب.",
+        "- إذا كان هناك نقص أو تناقض في المعطيات، صرّح بالفرضية قبل الحساب.",
+        "- لا تكرر نفس الفقرة/القائمة بصياغة مختلفة.",
+    ]
+    if numbers:
+        constraints.append(f"- الأعداد المذكورة في السؤال (مرجع إلزامي): {', '.join(numbers[:12])}.")
+    if arabic_colors:
+        constraints.append(f"- الألوان المذكورة في السؤال (مرجع إلزامي): {', '.join(arabic_colors)}.")
+    if key_terms:
+        constraints.append(f"- المفاهيم المطلوبة: {', '.join(key_terms)}.")
+    if "شجرة" in q:
+        constraints.append("- عند طلب شجرة احتمالات: قدّم سحباً متتالياً بفروع واحتمال كل فرع.")
+    return "## حارس الدقة المرتبط بالسؤال\n" + "\n".join(constraints)
+
+
+def _strip_unrequested_color_lines(question: str, answer: str, intent: str) -> str:
+    """يحذف سطور ألوان مخترعة في مسائل الاحتمالات إذا لم تَرِد في السؤال."""
+    try:
+        from app.services.skills import (
+            ExerciseAlignmentInput,
+            get_exercise_alignment_skill,
+        )
+
+        aligned = get_exercise_alignment_skill().align(
+            ExerciseAlignmentInput(question=question, answer=answer, intent=intent)
+        )
+        return aligned.aligned_answer
+    except Exception:
+        return answer
+
+
+def _dedupe_repeated_blocks(text: str) -> str:
+    """يحذف الفقرات/السطور المتطابقة المتجاورة لمنع تكرار الردود الكارثي.
+
+    يعتمد على قاعدة بسيطة وحتمية:
+    - تقسيم النص إلى blocks بواسطة سطر فارغ.
+    - إسقاط أي block متطابق مع آخر block مُحتفَظ به (بعد التطبيع).
+    """
+    blocks = [b.strip() for b in text.split("\n\n")]
+    kept: list[str] = []
+    last_norm = ""
+    last_tail_norm = ""
+    seen_long_scaffolds: list[frozenset[str]] = []
+    for block in blocks:
+        if not block:
+            continue
+        norm = _normalize_for_dedup(block)
+        if norm and (norm == last_norm or (last_tail_norm and norm == last_tail_norm)):
+            continue
+        if _is_long_educational_scaffold(norm, block):
+            sig = _token_signature(norm)
+            if any(_is_near_duplicate(sig, seen_sig) for seen_sig in seen_long_scaffolds):
+                continue
+            seen_long_scaffolds.append(sig)
+        kept.append(block)
+        last_norm = norm
+        lines = block.splitlines()
+        last_tail_norm = _normalize_for_dedup("\n".join(lines[1:])) if len(lines) >= 2 else ""
+    if not kept:
+        return text
+    return "\n\n".join(kept).strip()
+
+
 def _sanitize_local_graph_response(text: str, intent: str) -> str:
     """ISS-075 (D-063): ينظف foreign-script + chat meta-narration من ردود local_graph.
 
@@ -260,7 +372,8 @@ def _sanitize_local_graph_response(text: str, intent: str) -> str:
             out = out.lstrip()
             if out == prev:
                 break
-    return out
+    # 6. إزالة التكرار المتجاور الذي يظهر أحياناً في الإجابات الطويلة
+    return _dedupe_repeated_blocks(out)
 
 
 def _apply_answer_quality_skill(question: str, answer: str, intent: str) -> str:
@@ -617,6 +730,7 @@ async def _chat_node(state: LocalChatState) -> dict:
     # وليس تمريناً مُولَّداً من LLM.
     if intent == "educational":
         import contextlib as _ctx
+
         with _ctx.suppress(Exception):
             from app.services.capabilities.exercise_retrieval import (
                 ExerciseRetrievalRequest,
@@ -624,6 +738,7 @@ async def _chat_node(state: LocalChatState) -> dict:
                 format_exercise_for_display,
                 load_exercise_content,
             )
+
             _retrieval_decision = detect_exercise_retrieval(
                 ExerciseRetrievalRequest(question=question),
                 history_messages=history,
@@ -646,13 +761,17 @@ async def _chat_node(state: LocalChatState) -> dict:
         _effective_intent = "educational_textual"
         logger.info("local_graph.chat_node textual_explain_mode activated")
 
-    system_prompt = _SYSTEM_PROMPTS.get(_effective_intent, _SYSTEM_PROMPTS.get(intent, _SYSTEM_PROMPTS["general"]))
-
+    system_prompt = _SYSTEM_PROMPTS.get(
+        _effective_intent, _SYSTEM_PROMPTS.get(intent, _SYSTEM_PROMPTS["general"])
+    )
     history_text = _format_history(history)
     if history_text:
         user_message = f"سياق المحادثة السابقة:\n{history_text}\n\nالسؤال الحالي: {question}"
     else:
         user_message = question
+    precision_guardrail = _build_precision_guardrail(user_message, intent)
+    if precision_guardrail:
+        system_prompt = f"{system_prompt}\n\n{precision_guardrail}"
 
     import contextlib
 
@@ -673,6 +792,8 @@ async def _chat_node(state: LocalChatState) -> dict:
     try:
         response = await ai_client.send_message(system_prompt, user_message)
         clean = response.replace("\x00", "").strip()
+        # D-090: إزالة أسطر ألوان غير مطلوبة من سياق السؤال (احتمالات)
+        clean = _strip_unrequested_color_lines(user_message, clean, intent)
         # ISS-075 D-063: تنظيف foreign-script + chat meta-narration
         clean = _sanitize_local_graph_response(clean, intent)
         # D-073: AnswerQualitySkill — آخر طبقة دفاع (يحل ZOMBIE skill من D-072)
@@ -870,13 +991,18 @@ async def run_local_graph_stream(
         _effective_intent = "educational_textual"
         logger.info("local_graph.stream textual_explain_mode activated")
 
-    system_prompt = _SYSTEM_PROMPTS.get(_effective_intent, _SYSTEM_PROMPTS.get(intent, _SYSTEM_PROMPTS["general"]))
+    system_prompt = _SYSTEM_PROMPTS.get(
+        _effective_intent, _SYSTEM_PROMPTS.get(intent, _SYSTEM_PROMPTS["general"])
+    )
     history_text = _format_history(history)
     user_message = (
         f"سياق المحادثة السابقة:\n{history_text}\n\nالسؤال الحالي: {sanitized}"
         if history_text
         else sanitized
     )
+    precision_guardrail = _build_precision_guardrail(user_message, intent)
+    if precision_guardrail:
+        system_prompt = f"{system_prompt}\n\n{precision_guardrail}"
 
     obs = None
     span_ctx = None

--- a/app/services/skills/__init__.py
+++ b/app/services/skills/__init__.py
@@ -98,6 +98,12 @@ from app.services.skills.doctrine import (
     get_step_by_step_summary,
     list_all_doctrines,
 )
+from app.services.skills.exercise_alignment_skill import (
+    ExerciseAlignmentInput,
+    ExerciseAlignmentOutput,
+    ExerciseAlignmentSkill,
+    get_exercise_alignment_skill,
+)
 from app.services.skills.greeting_skill import (
     GreetingSkill,
     GreetingSkillFailure,
@@ -170,6 +176,9 @@ __all__ = [
     "BKTEvaluationInput",
     "CompositionItem",
     "ContaminationDetail",
+    "ExerciseAlignmentInput",
+    "ExerciseAlignmentOutput",
+    "ExerciseAlignmentSkill",
     "ExerciseStep",
     "FirewallInput",
     "FirewallOutput",
@@ -200,6 +209,7 @@ __all__ = [
     "get_bkt_engine",
     "get_content_invocation_summary",
     "get_detailed_explanation_summary",
+    "get_exercise_alignment_skill",
     "get_explanation_doctrine_summary",
     "get_model_answer_explanation_summary",
     "get_model_answer_reliance_summary",

--- a/app/services/skills/exercise_alignment_skill.py
+++ b/app/services/skills/exercise_alignment_skill.py
@@ -1,0 +1,98 @@
+"""
+ExerciseAlignmentSkill — محاذاة إجابة النظام مع معطيات التمرين.
+
+الهدف: منع الانجراف الدلالي في مسائل الاحتمالات عبر إزالة سطور الإجابة
+التي تُدخل كيانات لونية غير موجودة في سؤال الطالب.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar, Literal
+
+from pydantic import Field
+
+from app.core.schemas import RobustBaseModel
+
+
+class ExerciseAlignmentInput(RobustBaseModel):
+    """مدخلات مهارة المحاذاة."""
+
+    question: str = Field(..., min_length=1, max_length=6000)
+    answer: str = Field(..., min_length=1)
+    intent: Literal["educational", "general", "chat"] = "educational"
+
+
+class ExerciseAlignmentOutput(RobustBaseModel):
+    """مخرجات مهارة المحاذاة."""
+
+    aligned_answer: str
+    removed_lines: int = 0
+    applied: bool = False
+
+
+class ExerciseAlignmentSkill:
+    """مهارة حتمية لمحاذاة الإجابة مع معطيات السؤال."""
+
+    _COLOR_ALIASES: ClassVar[dict[str, tuple[str, ...]]] = {
+        "white": ("بيضاء", "أبيض", "ابيض"),
+        "red": ("حمراء", "أحمر", "احمر"),
+        "green": ("خضراء", "أخضر", "اخضر"),
+        "blue": ("زرقاء", "أزرق", "ازرق"),
+        "black": ("سوداء", "أسود", "اسود"),
+        "yellow": ("صفراء", "أصفر", "اصفر"),
+    }
+    _COLOR_TOKENS: ClassVar[tuple[str, ...]] = tuple(
+        token for aliases in _COLOR_ALIASES.values() for token in aliases
+    )
+
+    def align(self, payload: ExerciseAlignmentInput) -> ExerciseAlignmentOutput:
+        """ينفّذ محاذاة ألوان الاحتمالات ويُعيد نصاً منقحاً."""
+        if payload.intent not in ("educational", "general"):
+            return ExerciseAlignmentOutput(aligned_answer=payload.answer)
+        if "احتمال" not in payload.question and "احتمالات" not in payload.question:
+            return ExerciseAlignmentOutput(aligned_answer=payload.answer)
+
+        allowed_colors = [token for token in self._COLOR_TOKENS if token in payload.question]
+        if not allowed_colors:
+            return ExerciseAlignmentOutput(aligned_answer=payload.answer)
+
+        removed = 0
+        forbidden_colors = [token for token in self._COLOR_TOKENS if token not in allowed_colors]
+        filtered_lines: list[str] = []
+        for line in payload.answer.splitlines():
+            has_color = any(tok in line for tok in self._COLOR_TOKENS)
+            if not has_color:
+                filtered_lines.append(line)
+                continue
+
+            sanitized_line = line
+            for token in forbidden_colors:
+                sanitized_line = sanitized_line.replace(token, "")
+            sanitized_line = re.sub(r"\s{2,}", " ", sanitized_line).strip(" ،,")
+
+            if not sanitized_line:
+                removed += 1
+                continue
+            if sanitized_line != line:
+                removed += 1
+            filtered_lines.append(sanitized_line)
+
+        cleaned = "\n".join(filtered_lines).strip()
+        final_answer = cleaned if cleaned else payload.answer
+        return ExerciseAlignmentOutput(
+            aligned_answer=final_answer,
+            removed_lines=removed,
+            applied=removed > 0,
+        )
+
+
+_exercise_alignment_skill: ExerciseAlignmentSkill | None = None
+
+
+def get_exercise_alignment_skill() -> ExerciseAlignmentSkill:
+    """يُعيد Singleton لمهارة المحاذاة."""
+    global _exercise_alignment_skill
+    if _exercise_alignment_skill is None:
+        _exercise_alignment_skill = ExerciseAlignmentSkill()
+    return _exercise_alignment_skill

--- a/scripts/verify_microservices_answer_quality.py
+++ b/scripts/verify_microservices_answer_quality.py
@@ -1,0 +1,61 @@
+"""تحقق حي سريع لجودة إجابات الخدمات المصغرة في مسارات الدردشة الأساسية.
+
+يشغّل فحصين عمليين:
+1) smoke journeys على `/api/chat/message`.
+2) سيناريو واجهة الاحتمالات التلقائي (auto UI trigger).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], timeout_s: int = 120) -> int:
+    print(f"\n$ {' '.join(cmd)}")
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s, check=False)
+    except subprocess.TimeoutExpired:
+        print(f"❌ timeout after {timeout_s}s")
+        return 124
+    if proc.stdout:
+        print(proc.stdout)
+    if proc.stderr:
+        print(proc.stderr)
+    return proc.returncode
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    print("=== Microservices Answer Quality Live Verification ===")
+    print(f"repo={repo_root}")
+    has_openrouter = bool(os.getenv("OPENROUTER_API_KEY"))
+    has_postgres = bool(os.getenv("DATABASE_URL", "").startswith("postgres"))
+    print(
+        "secrets_status:",
+        f"OPENROUTER_API_KEY={'set' if has_openrouter else 'missing'}",
+        f"DATABASE_URL(postgres)={'yes' if has_postgres else 'no'}",
+    )
+
+    checks: list[tuple[list[str], int]] = [
+        ([sys.executable, "-m", "pytest", "-q", "tests/governance/test_smoke_journeys.py"], 300),
+        ([sys.executable, "scripts/test_auto_ui_trigger.py"], 180),
+    ]
+
+    failed = 0
+    for cmd, timeout_s in checks:
+        rc = _run(cmd, timeout_s=timeout_s)
+        if rc != 0:
+            failed += 1
+
+    if failed:
+        print(f"\n❌ verification failed: {failed} check(s) failed")
+        return 1
+    print("\n✅ verification passed: all checks succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/services/test_exercise_alignment_skill.py
+++ b/tests/services/test_exercise_alignment_skill.py
@@ -1,0 +1,58 @@
+"""اختبارات ExerciseAlignmentSkill لمحاذاة إجابات الاحتمالات مع معطيات السؤال."""
+
+from app.services.skills.exercise_alignment_skill import (
+    ExerciseAlignmentInput,
+    get_exercise_alignment_skill,
+)
+
+
+def test_alignment_removes_unrequested_colors() -> None:
+    skill = get_exercise_alignment_skill()
+    payload = ExerciseAlignmentInput(
+        question="تمرين احتمالات: لدينا كرات بيضاء وحمراء فقط.",
+        answer="كرات بيضاء وحمراء.\nتوجد كرات زرقاء أيضاً.",
+        intent="educational",
+    )
+    result = skill.align(payload)
+    assert result.applied is True
+    assert result.removed_lines == 1
+    assert "زرقاء" not in result.aligned_answer
+
+
+def test_alignment_skips_non_probability_question() -> None:
+    skill = get_exercise_alignment_skill()
+    payload = ExerciseAlignmentInput(
+        question="اشرح الاشتقاق.",
+        answer="ألوان: زرقاء وحمراء.",
+        intent="educational",
+    )
+    result = skill.align(payload)
+    assert result.applied is False
+    assert result.aligned_answer == payload.answer
+
+
+def test_alignment_keeps_line_and_removes_only_forbidden_color_word() -> None:
+    skill = get_exercise_alignment_skill()
+    payload = ExerciseAlignmentInput(
+        question="تمرين احتمالات: كرات بيضاء وحمراء.",
+        answer="في السطر نفسه: بيضاء وحمراء وزرقاء.",
+        intent="educational",
+    )
+    result = skill.align(payload)
+    assert result.applied is True
+    assert "زرقاء" not in result.aligned_answer
+    assert "بيضاء" in result.aligned_answer
+    assert "حمراء" in result.aligned_answer
+
+
+def test_alignment_supports_masculine_color_forms() -> None:
+    skill = get_exercise_alignment_skill()
+    payload = ExerciseAlignmentInput(
+        question="تمرين احتمالات: لون أحمر فقط.",
+        answer="لون أحمر صحيح، لكن يوجد لون أزرق غير صحيح.",
+        intent="educational",
+    )
+    result = skill.align(payload)
+    assert result.applied is True
+    assert "أحمر" in result.aligned_answer
+    assert "أزرق" not in result.aligned_answer

--- a/tests/services/test_iss079_catastrophic_fixes.py
+++ b/tests/services/test_iss079_catastrophic_fixes.py
@@ -229,3 +229,119 @@ class TestNoReasoningContentLeak:
                 f"ISS-079 showed this caused English thinking text to bleed into "
                 f"Arabic responses ('We need to respond as a brilliant professor...')."
             )
+
+
+class TestCatastropheDeepScenarioRegression:
+    """اختبار سيناريو حي مُصغّر: رسالة كارثية طويلة مع تكرار كتل."""
+
+    def test_sanitize_removes_adjacent_duplicate_blocks(self):
+        repeated_block = (
+            "🎲 مسألة احتمالات\n"
+            "شرح تفاعلي خطوة بخطوة\n"
+            "1) نحدد الفضاء الاحتمالي.\n"
+            "2) نطبق التوافيق.\n"
+            "3) نتحقق من النتيجة.\n"
+        )
+        raw = (
+            "Okay, the user asked for help.\n"
+            f"{repeated_block}\n\n"
+            f"{repeated_block}\n\n"
+            "النتيجة النهائية: صحيحة."
+        )
+        cleaned = _local_graph._sanitize_local_graph_response(raw, "educational")
+        assert cleaned.count("🎲 مسألة احتمالات") == 1
+        assert "النتيجة النهائية: صحيحة." in cleaned
+
+    def test_sanitize_keeps_non_adjacent_sections(self):
+        """لا نحذف فقرة قد تتكرر لاحقاً بعد فاصل معرفي مختلف."""
+        block_a = "عنوان A\nشرح مختصر."
+        block_b = "عنوان B\nشرح مختلف."
+        raw = f"{block_a}\n\n{block_b}\n\n{block_a}"
+        cleaned = _local_graph._sanitize_local_graph_response(raw, "educational")
+        assert cleaned.count("عنوان A") == 2
+        assert "عنوان B" in cleaned
+
+    def test_sanitize_removes_non_adjacent_long_marker_blocks(self):
+        """نحذف تكرار الكتل التعليمية الطويلة حتى لو كانت غير متجاورة."""
+        loop_block = (
+            "🎲 مسألة احتمالات\n"
+            "شرح تفاعلي خطوة بخطوة\n"
+            "1) نحدد الفضاء الاحتمالي.\n"
+            "2) نطبق التوافيق.\n"
+            "3) نتحقق من النتيجة.\n"
+            "تفصيل إضافي طويل لضمان تجاوز حد الطول المطلوب في de-dup."
+        )
+        bridge = "فقرة انتقالية جديدة غير مكررة."
+        raw = f"{loop_block}\n\n{bridge}\n\n{loop_block}"
+        cleaned = _local_graph._sanitize_local_graph_response(raw, "educational")
+        assert cleaned.count("🎲 مسألة احتمالات") == 1
+        assert bridge in cleaned
+
+    def test_sanitize_removes_near_duplicate_scaffold_without_fixed_markers(self):
+        """نحذف القالب الطويل حتى لو اختلف العنوان/الترقيم بشكل سطحي."""
+        block_1 = (
+            "مخطط حل التمرين\n"
+            "1) نحدد المعطيات الأساسية في نص السؤال.\n"
+            "2) نختار نموذج السحب المناسب ثم نكتب الفضاء.\n"
+            "3) نحسب باحترام شرط عدم الإرجاع خطوة بخطوة.\n"
+            "4) ننهي بتحقق عددي سريع يثبت تماسك النتيجة.\n"
+        )
+        block_2 = (
+            "خارطة حل المسألة\n"
+            "1) نحدد المعطيات الأساسية في نص السؤال.\n"
+            "2) نختار نموذج السحب المناسب ثم نكتب الفضاء.\n"
+            "3) نحسب باحترام شرط عدم الإرجاع خطوة بخطوة.\n"
+            "4) ننهي بتحقق عددي سريع يثبت تماسك النتيجة.\n"
+        )
+        raw = f"{block_1}\n\nفقرة وسيطة.\n\n{block_2}"
+        cleaned = _local_graph._sanitize_local_graph_response(raw, "educational")
+        assert cleaned.count("نحدد المعطيات الأساسية") == 1
+        assert "فقرة وسيطة." in cleaned
+
+
+class TestPrecisionGuardrail:
+    """تحقق أن حارس الدقة يربط الرد مباشرة بمعطيات سؤال الطالب."""
+
+    def test_build_precision_guardrail_includes_question_entities(self):
+        q = "تمرين احتمالات 2024: كرات بيضاء وحمراء وخضراء، اسحب 3 بدون إرجاع وارسم شجرة."
+        guard = _local_graph._build_precision_guardrail(q, "educational")
+        assert "حارس الدقة المرتبط بالسؤال" in guard
+        assert "2024" in guard
+        assert "3" in guard
+        assert "بيضاء" in guard and "حمراء" in guard and "خضراء" in guard
+        assert "شجرة احتمالات" in guard or "شجرة" in guard
+
+    def test_build_precision_guardrail_disabled_for_chat(self):
+        guard = _local_graph._build_precision_guardrail("السلام عليكم", "chat")
+        assert guard == ""
+
+    def test_build_precision_guardrail_reads_context_entities(self):
+        context = (
+            "سياق المحادثة السابقة:\n"
+            "تمرين 2024: كرات بيضاء وحمراء وخضراء.\n\n"
+            "السؤال الحالي: اشرح المطلوب."
+        )
+        guard = _local_graph._build_precision_guardrail(context, "educational")
+        assert "2024" in guard
+        assert "بيضاء" in guard and "حمراء" in guard and "خضراء" in guard
+
+
+class TestQuestionAlignmentSanitizer:
+    """D-090: منع اختلاق ألوان غير موجودة في نص التمرين."""
+
+    def test_strip_unrequested_color_lines_probability(self):
+        question = "تمرين احتمالات: لدينا كرات بيضاء وحمراء فقط."
+        answer = (
+            "لدينا كرات بيضاء وحمراء.\n"
+            "كما توجد كرات زرقاء وسوداء.\n"
+            "نحسب الآن الاحتمال المطلوب."
+        )
+        cleaned = _local_graph._strip_unrequested_color_lines(question, answer, "educational")
+        assert "زرقاء" not in cleaned and "سوداء" not in cleaned
+        assert "بيضاء" in cleaned and "حمراء" in cleaned
+
+    def test_strip_unrequested_color_lines_non_probability_untouched(self):
+        question = "اشرح الاشتقاق."
+        answer = "ألوان: حمراء وزرقاء."
+        cleaned = _local_graph._strip_unrequested_color_lines(question, answer, "educational")
+        assert cleaned == answer


### PR DESCRIPTION
### Motivation
- Prevent hallucinated/extra color mentions in probability exercises and avoid over-deleting useful explanation lines when answers mix allowed and forbidden colors.
- Move alignment logic out of inline sanitizer into a testable Skill to follow the skills-first architecture and improve maintainability.
- Reduce catastrophic repeated response blocks by adding deterministic dedupe helpers to the local sanitization pipeline.

### Description
- Add `ExerciseAlignmentSkill` (`app/services/skills/exercise_alignment_skill.py`) with `ExerciseAlignmentInput/Output` and `get_exercise_alignment_skill()` implementing token-level removal of forbidden color words and support for Arabic masculine/feminine aliases.
- Rework sanitization so mixed lines keep relevant content while removing only forbidden color tokens, with deterministic fallback to remove empty lines and report `removed_lines`/`applied` metadata.
- Wire the new skill into `local_graph` via `_strip_unrequested_color_lines(...)`, add a context-aware `_build_precision_guardrail(...)` appended to system prompts, and introduce de-duplication helpers (`_normalize_for_dedup`, `_token_signature`, `_is_long_educational_scaffold`, `_is_near_duplicate`, `_dedupe_repeated_blocks`) used from `_sanitize_local_graph_response` to prevent adjacent/near-duplicate long scaffolds.
- Export the skill and types in `app/services/skills/__init__.py`, add a verification script `scripts/verify_microservices_answer_quality.py`, and update documentation (`CLAUDE.md`, `.memory/*`) describing the changes and operational notes.

### Testing
- Ran `pytest -q tests/services/test_exercise_alignment_skill.py` and observed `4 passed` for the new unit tests validating removal, mixed-line sanitization, and masculine forms. ✅
- Ran `ruff check .` and all lint checks passed locally. ✅
- Ran `mypy app/ microservices/` which reports pre-existing, repository-wide type-checking issues not introduced by this PR (repo-wide errors observed), so type-check warnings remain unrelated to the changes in this patch. ⚠️

## Summary
<!-- What changed and why now? Include operational impact. -->

## Change Type
- [ ] bug fix
- [ ] feature
- [ ] refactor
- [ ] governance / documentation
- [ ] security hardening

## Affected Areas
- [ ] app core
- [ ] microservices
- [ ] contracts / guardrails
- [ ] CI/CD
- [ ] docs / governance

## Risk & Rollback
- **Risk level:** low / medium / high
- **Rollback plan:**

## Validation Evidence
<!-- Paste exact commands + short outputs. -->
- [ ] `ruff check .`
- [ ] `ruff format --check .`
- [ ] `pytest ...`

## Governance Checklist (Required)
- [ ] I updated docs when runtime/CI behavior changed.
- [ ] I did not add duplicate CI truth layers.
- [ ] I confirmed mergeability depends on `required-ci`.
- [ ] I removed or justified any skipped tests.
- [ ] I verified no PII or sensitive secrets were added.

## Safeguarding Impact
<!-- Required for product-facing changes. For infra-only changes, write N/A. -->

## Reviewer Guide
<!-- Tell reviewers where to focus first. -->
