### PR TITLE
Enable stable WebSocket mode and longer pings for Uvicorn to prevent mobile 'offline' flaps

### DIFF
--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -407,6 +407,9 @@ else
     python -m uvicorn app.main:app \
         --host 0.0.0.0 \
         --port "$APP_PORT" \
+        --ws websockets \
+        --ws-ping-interval 300 \
+        --ws-ping-timeout 300 \
         --reload \
         --log-level info &
 

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -2141,3 +2141,19 @@ connectivity confirmed. Supabase live row-insert deferred to Codespaces
 - **الإجراء المقترح**:
   1. تثبيت/ترقية نسخة LangGraph المتوافقة، أو
   2. إضافة إعداد موحّد في pytest لتصفية هذا التحذير المحدد فقط على مستوى المستودع.
+
+## ISS-WS-Offline-001 — WebSocket offline indicator on mobile (2026-05-24) [RESOLVED]
+
+**Symptom**: الواجهة كانت تُظهر `offline` بشكل متكرر خصوصاً على الهاتف أثناء جلسات الدردشة الحيّة.
+
+**Root cause**: تشغيل backend بدون stack WebSocket المناسب + مهلات ping قصيرة تؤدي لانقطاع heartbeat على الشبكات المحمولة.
+
+**Applied fix (exactly as validated live)**:
+1. تثبيت دعم WebSocket الكامل لـ Uvicorn:
+   - `pip install "uvicorn[standard]"`
+2. تشغيل الخادم بإعدادات WebSocket صريحة ومهلات ping ممتدة:
+   - `uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws websockets --ws-ping-interval 300 --ws-ping-timeout 300`
+
+**Live verification outcome**: اختفت حالة `offline` بعد تطبيق الخطوتين فقط، مع ثبات الاتصال أثناء الاستخدام الفعلي على الهاتف.
+
+**Operational note**: أي تشغيل بديل لا يمر بهذه الخيارات قد يعيد السلوك المتقطع نفسه على الشبكات غير المستقرة.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5753,3 +5753,25 @@ Codespaces/CI** (الـ sandbox يحجب تثبيت التبعيات + egress �
 - يمنع `prompt spaghetti` داخل orchestration layer.
 - يدعم فلسفة النظام: القدرات المعرفية يجب أن تعيش في skills قابلة للاختبار والاستبدال.
 - يفتح الطريق لمحاذاة أعمق (numbers/symbols/constraint clauses) داخل نفس skill دون تضخم `local_graph`.
+
+---
+
+## Session 2026-05-24 — ISS-WS-Offline-001 mobile connectivity stabilization
+
+### Problem
+ظهور `offline` في واجهة المحادثة الحية (خصوصاً الهاتف) رغم أن الخدمة تعمل.
+
+### Deep fix applied (and kept minimal)
+تم اعتماد خطوتين إلزاميتين فقط، بدون أي تعديل سلوكي إضافي:
+
+1. تثبيت دعم WebSocket الصحيح في بيئة التشغيل:
+   - `pip install "uvicorn[standard]"`
+2. تشغيل uvicorn بإعدادات websocket + ping الطويلة:
+   - `uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws websockets --ws-ping-interval 300 --ws-ping-timeout 300`
+
+### Why this works
+- `--ws websockets` يضمن استخدام backend websocket implementation المستقر.
+- زيادة `ping_interval` و`ping_timeout` إلى 300 ثانية تقلل قطع الاتصال الزائف على شبكات الهاتف المتذبذبة.
+
+### Live verification
+تم التحقق الحي بعد التطبيق مباشرة: اختفاء حالة `offline` واستمرار الاتصال بشكل مستقر.

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
 echo "🚀 Starting backend server..."
-uvicorn app.main:app --host 0.0.0.0 --port 8000
+uvicorn app.main:app \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --ws websockets \
+  --ws-ping-interval 300 \
+  --ws-ping-timeout 300

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -17,7 +17,13 @@ fi
 
 # 4) start backend
 echo "Starting uvicorn..."
-uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --reload > uvicorn.log 2>&1 &
+uvicorn app.main:app \
+  --host 0.0.0.0 \
+  --port ${PORT:-8000} \
+  --ws websockets \
+  --ws-ping-interval 300 \
+  --ws-ping-timeout 300 \
+  --reload > uvicorn.log 2>&1 &
 sleep 2
 
 # 5) show status


### PR DESCRIPTION
### Motivation
- Mobile clients observed frequent `offline` state during live chat because Uvicorn was not forced to use a stable WebSocket backend and ping timeouts were too short on mobile networks.
- The intent is to make the backend resilient to intermittent mobile network drops by selecting the `websockets` backend and extending heartbeat timing.

### Description
- Added explicit WebSocket backend and extended ping settings (`--ws websockets --ws-ping-interval 300 --ws-ping-timeout 300`) to Uvicorn invocations in `.devcontainer/supervisor.sh`, `scripts/start-backend.sh`, and `scripts/start_dev.sh`.
- Recorded the issue, root cause, applied fix, and operational notes in `/.memory/issues.md` under `ISS-WS-Offline-001` and added a matching session note to `CLAUDE.md` documenting the minimal fix and rationale.
- Documented the recommended runtime dependency (`pip install "uvicorn[standard]"`) in the notes to ensure the correct WebSocket implementation is available.

### Testing
- Ran live startup/connectivity verification using uvicorn with the new websocket flags and validated websocket endpoint reachability.