### PR TITLE
fix(ws): resolve WebSocket offline status in GitHub Codespaces

### DIFF
--- a/frontend/app/utils/wsUrl.js
+++ b/frontend/app/utils/wsUrl.js
@@ -16,6 +16,13 @@
  *   - ws:// في http، wss:// في https
  *   - دعم NEXT_PUBLIC_WS_URL للتهيئة الصريحة
  *
+ * ISS-WS-CODESPACES (2026-05-25):
+ *   في GitHub Codespaces، frontend/server.js يعمل على port 5000 ويُمرِّر
+ *   /api/chat/ws داخلياً إلى ws://127.0.0.1:8000.
+ *   الكود القديم كان يستبدل -5000. بـ -8000. في الـ URL → يتجاوز server.js →
+ *   يتصل بـ port 8000 مباشرة → يُخفق (CORS/auth/proxy مشاكل).
+ *   الحل: في Codespaces، أعِد window.location.host (port 5000) → server.js يُمرِّر.
+ *
  * ## قانون معماري (D-WS-001):
  *   ممنوع استخدام localhost داخل browser runtime.
  *   ممنوع hardcode أي port داخل browser runtime.
@@ -74,17 +81,19 @@ export const getCloudBackendHost = () => {
     const host = window.location.host; // مثل: 5000-abc123.ws-eu.gitpod.io
 
     // Gitpod / Ona: استبدل port prefix من 5000 إلى 8000
+    // كل port له subdomain مختلف → يجب الاتصال بـ 8000 subdomain مباشرة
     if (host.match(/^5000-/)) {
         return host.replace(/^5000-/, '8000-');
     }
-    // GitHub Codespaces: استبدل -5000. بـ -8000.
+
+    // GitHub Codespaces: أعِد null عمداً
+    // لا نستبدل -5000. بـ -8000. لأن frontend/server.js يعمل على port 5000
+    // ويُمرِّر /api/chat/ws داخلياً إلى ws://127.0.0.1:8000
+    // الاتصال المباشر بـ -8000. يتجاوز هذا الـ proxy ويُخفق في بعض بيئات Codespaces
     if (host.match(/-5000\./)) {
-        return host.replace(/-5000\./, '-8000.');
+        return null; // → يستخدم window.location.host (port 5000 + server.js proxy)
     }
-    // Replit: نفس النمط
-    if (host.match(/^5000-/)) {
-        return host.replace(/^5000-/, '8000-');
-    }
+
     return null;
 };
 


### PR DESCRIPTION
## المشكلة / Problem

في GitHub Codespaces، واجهة الدردشة تظهر **غير متصل** (offline) فوراً.

**السبب الجذري:** `wsUrl.js` كان يستبدل `-5000.` بـ `-8000.` في الـ URL ليتصل بالـ backend مباشرة، لكن هذا يتجاوز `frontend/server.js` الذي هو فعلاً WS proxy يعمل على port 5000.

## الحل / Fix

```
Browser (port 5000) → server.js proxy → ws://127.0.0.1:8000/api/chat/ws
```

`getCloudBackendHost()` تُعيد الآن `null` لمضيفي Codespaces (`-5000.app.github.dev`) بدلاً من استبدال الـ port، فيستخدم `getWsBase()` `window.location.host` وتتولى `server.js` التمرير الداخلي.

**Gitpod** (format: `5000-xxx.gitpod.io`) يحتفظ بالمنطق القديم لأن كل port له subdomain منفصل هناك.

## الملف المعدَّل / Changed file

- `frontend/app/utils/wsUrl.js` — `getCloudBackendHost()`

## كيفية الاختبار / How to test

1. افتح المستودع في Codespaces
2. شغّل الـ backend: `uvicorn app.main:app --host 0.0.0.0 --port 8000`
3. شغّل الـ frontend: `cd frontend && PORT=5000 npm run dev`
4. افتح port 5000 في المتصفح وسجّل دخولك
5. تحقق أن الـ chat يظهر **متصل** وليس **غير متصل**
