### PR TITLE
fix(ws): full-stack WebSocket recovery for Gitpod Flex/Ona (D-WS-GITPOD-002)

### DIFF
--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -215,13 +215,12 @@ ENVEOF
         changed=1
     fi
 
-    # ── BACKEND_CORS_ORIGINS (D-WS-002) ──────────────────────────────────────
-    # يضمن أن frontend على port 5000 مسموح له بـ CORS في جميع البيئات.
-    # يُعيَّن فقط إذا لم يكن موجوداً مسبقاً (يحترم التهيئة الصريحة).
-    if ! grep -q "^BACKEND_CORS_ORIGINS=" "$env_file" 2>/dev/null; then
-        _set_env_key "BACKEND_CORS_ORIGINS" "http://localhost:3000,http://localhost:5000,http://127.0.0.1:3000,http://127.0.0.1:5000"
-        changed=1
-    fi
+    # ── BACKEND_CORS_ORIGINS (D-WS-002 + D-WS-GITPOD-001) ───────────────────
+    # يُعيَّن دائماً لضمان تحديث القيمة عند إضافة نطاقات جديدة.
+    # D-WS-GITPOD-001: يشمل *.gitpod.dev (Gitpod Flex/Ona) و *.app.github.dev (Codespaces).
+    # ملاحظة: FastAPI CORSMiddleware يقبل wildcards فقط في subdomains (*.example.com).
+    _set_env_key "BACKEND_CORS_ORIGINS" "http://localhost:3000,http://localhost:5000,http://127.0.0.1:3000,http://127.0.0.1:5000,https://*.gitpod.io,https://*.gitpod.dev,https://*.eu-central-1-01.gitpod.dev,https://*.eu-central-1-02.gitpod.dev,https://*.us-east-1-01.gitpod.dev,https://*.app.github.dev,https://*.preview.app.github.dev,https://*.replit.dev,https://*.replit.app"
+    changed=1
 
     # ── ALLOWED_HOSTS (D-WS-002 + D-WS-GITPOD-001) ──────────────────────────
     # يضمن أن TrustedHostMiddleware يقبل Gitpod/Ona/Codespaces hosts.
@@ -473,6 +472,14 @@ launch_frontend() {
         elif lsof -ti :"$FRONTEND_PORT" >/dev/null 2>&1; then
             lifecycle_warn "Frontend Launcher: Port $FRONTEND_PORT already in use — skipping start"
         else
+            # D-WS-GITPOD-001: حذف stale lock قبل الإطلاق.
+            # عند تعطل Next.js أو إيقافه بشكل مفاجئ، يبقى ملف .next/dev/lock
+            # مقفلاً من العملية الميتة → يمنع إعادة التشغيل بخطأ "Unable to acquire lock".
+            local next_lock="frontend/.next/dev/lock"
+            if [ -f "$next_lock" ]; then
+                lifecycle_info "Frontend Launcher: Removing stale Next.js dev lock..."
+                rm -f "$next_lock" 2>/dev/null || true
+            fi
             lifecycle_info "Frontend Launcher: Starting Next.js dev server on port $FRONTEND_PORT..."
             # D-WS-001: custom server يُمرِّر WebSocket إلى Gateway (8000)
             # next dev لا يُمرِّر WebSocket upgrades — server.js يحل هذا
@@ -612,13 +619,14 @@ launch_orchestrator_service() {
 
     mkdir -p "$ORCH_LOG_DIR"
 
-    # ── التحقق من وجود OPENROUTER_API_KEY ────────────────────────────────────
+    # ── تحذير عند غياب OPENROUTER_API_KEY (لكن لا نوقف الإطلاق) ─────────────
+    # D-WS-GITPOD-001: الـ orchestrator يعمل في DEGRADED mode بدون LLM key.
+    # إيقاف الإطلاق كلياً يُسبب فشل /compose وانهيار Skills Pipeline.
     if [ -z "${OPENROUTER_API_KEY:-}" ]; then
-        lifecycle_warn "Orchestrator: OPENROUTER_API_KEY not set — skipping launch."
-        lifecycle_warn "             Set it in Gitpod Secrets or .devcontainer/secrets.env"
-        echo "[$(date -u +%FT%TZ)] OPENROUTER_API_KEY missing — orchestrator parked" \
+        lifecycle_warn "Orchestrator: OPENROUTER_API_KEY not set — launching in DEGRADED mode (no LLM)."
+        lifecycle_warn "             Set it in Gitpod Secrets or .devcontainer/secrets.env for full functionality."
+        echo "[$(date -u +%FT%TZ)] OPENROUTER_API_KEY missing — orchestrator starting in DEGRADED mode" \
             >> "$ORCH_LOG_DIR/orchestrator.log"
-        return 0
     fi
 
     # ── idempotent: هل الخدمة تعمل بالفعل؟ ──────────────────────────────────
@@ -710,10 +718,8 @@ launch_user_service() {
     # ── التحقق من وجود DATABASE_URL ──────────────────────────────────────────
     local user_db_url="${USER_DATABASE_URL:-${DATABASE_URL:-}}"
     if [ -z "$user_db_url" ]; then
-        lifecycle_warn "UserService: no DATABASE_URL available — skipping launch."
-        echo "[$(date -u +%FT%TZ)] DATABASE_URL missing — user-service parked" \
-            >> "$USER_LOG_DIR/user_service.log"
-        return 0
+        lifecycle_warn "UserService: no DATABASE_URL — launching with SQLite fallback (DEGRADED)."
+        user_db_url="sqlite+aiosqlite:///./user_service_dev.db"
     fi
 
     # ── idempotent: هل الخدمة تعمل بالفعل؟ ──────────────────────────────────
@@ -770,10 +776,8 @@ launch_planning_agent() {
     # ── التحقق من وجود DATABASE_URL ──────────────────────────────────────────
     local planning_db_url="${PLANNING_DATABASE_URL:-${DATABASE_URL:-}}"
     if [ -z "$planning_db_url" ]; then
-        lifecycle_warn "PlanningAgent: no DATABASE_URL available — skipping launch."
-        echo "[$(date -u +%FT%TZ)] DATABASE_URL missing — planning-agent parked" \
-            >> "$PLANNING_LOG_DIR/planning_agent.log"
-        return 0
+        lifecycle_warn "PlanningAgent: no DATABASE_URL — launching with SQLite fallback (DEGRADED)."
+        planning_db_url="sqlite+aiosqlite:///./planning_agent_dev.db"
     fi
 
     # ── تحويل URL إلى asyncpg (مطلوب لـ SQLAlchemy async) ────────────────────
@@ -840,10 +844,10 @@ launch_research_agent() {
 
     mkdir -p "$RESEARCH_LOG_DIR"
 
-    # ── التحقق من توفر DATABASE_URL ──────────────────────────────────────────
+    # ── تحذير عند غياب DATABASE_URL (لكن لا نوقف الإطلاق) ───────────────────
+    # Research Agent يعمل بدون DB — يستخدم Tavily فقط.
     if [ -z "${DATABASE_URL:-}" ]; then
-        lifecycle_warn "Research Agent: DATABASE_URL not set — skipping launch"
-        return 0
+        lifecycle_warn "Research Agent: DATABASE_URL not set — launching anyway (Tavily-only mode)."
     fi
 
     # ── idempotent: تجنب إطلاق نسخة ثانية ───────────────────────────────────
@@ -898,10 +902,10 @@ launch_reasoning_agent() {
 
     mkdir -p "$REASONING_LOG_DIR"
 
-    # ── التحقق من توفر DATABASE_URL ──────────────────────────────────────────
+    # ── تحذير عند غياب DATABASE_URL (لكن لا نوقف الإطلاق) ───────────────────
+    # Reasoning Agent يعمل بدون DB — يستخدم MCTS + LLM فقط.
     if [ -z "${DATABASE_URL:-}" ]; then
-        lifecycle_warn "Reasoning Agent: DATABASE_URL not set — skipping launch"
-        return 0
+        lifecycle_warn "Reasoning Agent: DATABASE_URL not set — launching anyway (MCTS-only mode)."
     fi
 
     # ── idempotent: تجنب إطلاق نسخة ثانية ───────────────────────────────────

--- a/app/api/routers/ws_proxy.py
+++ b/app/api/routers/ws_proxy.py
@@ -96,7 +96,7 @@ async def _proxy_websocket(
     # Determine auth transport mode for diagnostics (never log token value)
     has_token_qp = "token=" in upstream_url
     auth_mode = "query_param" if has_token_qp else ("subprotocol" if subprotocols else "none")
-    safe_upstream = upstream_url.split("?")[0] + ("?..." if "?" in upstream_url else "")
+    safe_upstream = upstream_url.split("?", maxsplit=1)[0] + ("?..." if "?" in upstream_url else "")
 
     logger.info(
         "ws_proxy.connecting upstream=%s auth_mode=%s protocols=%s",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -35,11 +35,17 @@ const nextConfig = {
         // GitHub Codespaces
         '*.app.github.dev',
         '*.preview.app.github.dev',
-        // Gitpod / Ona
+        // Gitpod Classic
         '*.gitpod.io',
         '*.ws-eu.gitpod.io',
         '*.ws-us.gitpod.io',
         '*.ws-eu2.gitpod.io',
+        // Gitpod Flex / Ona (D-WS-GITPOD-001)
+        // Pattern: <PORT>--<ENV_ID>.<cluster>.gitpod.dev
+        '*.gitpod.dev',
+        '*.eu-central-1-01.gitpod.dev',
+        '*.eu-central-1-02.gitpod.dev',
+        '*.us-east-1-01.gitpod.dev',
     ],
 };
 

--- a/tests/unit/core/test_settings.py
+++ b/tests/unit/core/test_settings.py
@@ -34,14 +34,30 @@ class TestCoreConfig:
         assert _normalize_csv_or_list('["foo", "bar"]') == ["foo", "bar"]
 
     def test_database_url_fallback(self):
-        """Verify DB URL fallback logic."""
-        # Clear both DATABASE_URL and APP_DATABASE_URL — base.py sets DATABASE_URL
-        # from APP_DATABASE_URL at import time, so both must be absent for fallback.
+        """Verify DB URL fallback logic.
+
+        Two sources can inject DATABASE_URL even when env vars are cleared:
+        1. base.py sets os.environ["DATABASE_URL"] from APP_DATABASE_URL at
+           module import time (before patch.dict runs).
+        2. pydantic-settings reads .env file directly via model_config env_file.
+
+        We bypass both by passing DATABASE_URL=None explicitly and overriding
+        model_config to skip .env loading for this test instance.
+        """
         clean_env = {
-            k: v for k, v in os.environ.items() if k not in ("DATABASE_URL", "APP_DATABASE_URL")
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "APP_DATABASE_URL")
         }
         with patch.dict(os.environ, clean_env, clear=True):
-            settings = AppSettings(ENVIRONMENT="testing", DATABASE_URL=None)
+            os.environ.pop("DATABASE_URL", None)
+            os.environ.pop("APP_DATABASE_URL", None)
+            # Bypass .env file loading by constructing with _env_file=None
+            settings = AppSettings(
+                ENVIRONMENT="testing",
+                DATABASE_URL=None,
+                _env_file=None,  # type: ignore[call-arg]
+            )
             assert "sqlite" in settings.DATABASE_URL
             assert ":memory:" in settings.DATABASE_URL
 


### PR DESCRIPTION
## المشكلة

WebSocket يُظهر "غير متصل" في Gitpod Flex/Ona رغم أن الـ backend يعمل على localhost. تحليل جذري كشف 8 أسباب متشابكة.

## التشخيص الجذري

### السبب الأول — `.env` يحتوي على SQLite بدلاً من Supabase
`supervisor.sh` يكتب `BACKEND_CORS_ORIGINS` **فقط إذا لم يكن موجوداً** (`if ! grep -q`). عند وجود قيمة قديمة (`localhost` فقط)، تبقى دون تحديث عبر إعادات التشغيل. النتيجة: FastAPI CORSMiddleware يرفض طلبات WebSocket من `*.gitpod.dev`.

### السبب الثاني — orchestrator-service لا يبدأ بدون `OPENROUTER_API_KEY`
الكود كان يُوقف الإطلاق كلياً (`return 0`) عند غياب المفتاح. هذا يُميت `/compose` وينهار Skills Pipeline حتى في DEGRADED mode.

### السبب الثالث — microservices تتوقف عند غياب `DATABASE_URL`
`user-service` و `planning-agent` كانا يُوقفان الإطلاق بدلاً من الـ SQLite fallback. `research-agent` و `reasoning-agent` لا يحتاجان DB أصلاً لكنهما كانا يتوقفان أيضاً.

### السبب الرابع — Next.js stale lock يمنع إعادة التشغيل
عند تعطل Next.js، يبقى `.next/dev/lock` مقفلاً من العملية الميتة → خطأ "Unable to acquire lock" عند إعادة التشغيل.

### السبب الخامس — `allowedDevOrigins` لا يشمل `*.gitpod.dev`
Next.js 15+ يرفض طلبات dev من origins غير مُدرجة. `*.gitpod.dev` و cluster subdomains كانت غائبة.

### السبب السادس — `ws_proxy.py` ruff lint error
`str.split()` بدون `maxsplit=1`.

### السبب السابع — `test_database_url_fallback` يفشل مع secrets حقيقية
`pydantic-settings` يقرأ `.env` مباشرة حتى بعد `patch.dict(os.environ)`. الاختبار لم يكن يُعطّل `.env` loading.

## الإصلاحات

| الملف | التغيير |
|-------|---------|
| `.devcontainer/supervisor.sh` | `BACKEND_CORS_ORIGINS` يُكتب دائماً (مثل `ALLOWED_HOSTS`) مع wildcard كامل لـ Gitpod/Codespaces/Replit |
| `.devcontainer/supervisor.sh` | orchestrator يبدأ في DEGRADED mode بدون `OPENROUTER_API_KEY` بدلاً من التوقف |
| `.devcontainer/supervisor.sh` | user-service/planning-agent: SQLite fallback بدلاً من `return 0` |
| `.devcontainer/supervisor.sh` | research-agent/reasoning-agent: تحذير فقط بدلاً من `return 0` |
| `.devcontainer/supervisor.sh` | حذف stale Next.js lock قبل إطلاق frontend |
| `frontend/next.config.js` | إضافة `*.gitpod.dev`, `*.eu-central-1-01.gitpod.dev`, `*.eu-central-1-02.gitpod.dev`, `*.us-east-1-01.gitpod.dev` إلى `allowedDevOrigins` |
| `app/api/routers/ws_proxy.py` | ruff PLC0207: `split("?", maxsplit=1)` |
| `tests/unit/core/test_settings.py` | `_env_file=None` لتجاوز `.env` loading في اختبار الـ fallback |

## التحقق الحي (Gitpod Flex 019e62a1)

```
Health Matrix:
  ✅ :8000 monolith      [ok]  db=ok
  ✅ :8001 user-service  [ok]
  ✅ :8002 planning-agent [ok] db=postgresql+asyncpg://...
  ✅ :8003 conversation-service [healthy] graph=true
  ✅ :8006 orchestrator  [ok]  graph=true
  ✅ :8007 research-agent [healthy] tavily=true
  ✅ :8008 reasoning-agent [healthy] llm=openrouter
  ✅ :8009 content-retrieval [healthy]

WebSocket E2E:
  ✅ Login → token acquired
  ✅ WS flow: conversation_init → assistant_delta → assistant_final

Skills Pipeline:
  ✅ mode=full | active=[planning, research, reasoning]

Gitpod host header:
  ✅ 8000--019e62a1-...eu-central-1-01.gitpod.dev accepted

Unit tests:
  ✅ 640/640 passed
```

## ملاحظة للمراجع

لا يتضمن هذا الـ PR تغييرات على `.devcontainer/secrets.env` (مُدرج في `.gitignore`). يجب تهيئة الأسرار عبر Gitpod Secrets أو نسخ `secrets.env.example` يدوياً.