### PR TITLE
fix(boot): D-SQLITE-GUARD — prevent SQLite degraded-mode boot in Codespaces

### DIFF
--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -392,11 +392,23 @@ if ! lifecycle_acquire_lock "uvicorn_launch" 60; then
 fi
 
 # Check if already running AND actually listening (not just a zombie process)
+# D-SQLITE-GUARD: also verify the running process is NOT using SQLite.
+# If DATABASE_URL=sqlite in the process env, the backend is in degraded mode
+# and must be restarted with the real Supabase URL from secrets.env.
 _uvicorn_healthy() {
     local pid
     pid=$(lifecycle_get_state "uvicorn_pid" 2>/dev/null || true)
-    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && \
-        curl -sf --connect-timeout 2 "$HEALTH_ENDPOINT" >/dev/null 2>&1
+    [ -n "$pid" ] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    curl -sf --connect-timeout 2 "$HEALTH_ENDPOINT" >/dev/null 2>&1 || return 1
+    # Guard: reject if running with SQLite (degraded mode from a secrets-less boot)
+    local proc_db
+    proc_db=$(cat /proc/"$pid"/environ 2>/dev/null | tr '\0' '\n' | grep "^DATABASE_URL=" | cut -d= -f2- || true)
+    if echo "$proc_db" | grep -q "sqlite"; then
+        lifecycle_warn "D-SQLITE-GUARD: uvicorn PID $pid is running with SQLite — forcing restart with real DB"
+        return 1
+    fi
+    return 0
 }
 
 if _uvicorn_healthy; then


### PR DESCRIPTION
## Problem

When a Codespace starts without secrets configured in GitHub Codespaces Settings, `supervisor.sh` cannot find `APP_DATABASE_URL` and falls back to:

```
DATABASE_URL=sqlite+aiosqlite:///:memory:
TESTING=1
OPENROUTER_API_KEY=  (empty)
```

This caused three cascading failures:

1. **Login fails** — SQLite DB is empty (no users), every login returns "Invalid email or password"
2. **WebSocket returns empty responses** — `OPENROUTER_API_KEY` is missing, LLM produces no content, `assistant_delta` chunks have `content=""`
3. **Auth loop (kick → return)** — `/api/security/user/me` returns 401 (user not in SQLite), frontend fires `agent:auth_error`, logout triggers, page reloads, token is gone, user sees login screen, logs in again → same cycle

## Fix

Added **D-SQLITE-GUARD** to `_uvicorn_healthy()` in `supervisor.sh`.

The guard reads the running uvicorn process environment via `/proc/<pid>/environ`. If `DATABASE_URL` contains `sqlite`, the function returns false — causing supervisor to kill the degraded process and restart it with the real Supabase URL loaded from `.devcontainer/secrets.env`.

```bash
# Guard: reject if running with SQLite (degraded mode from a secrets-less boot)
local proc_db
proc_db=$(cat /proc/"$pid"/environ 2>/dev/null | tr '\0' '\n' | grep "^DATABASE_URL=" | cut -d= -f2- || true)
if echo "$proc_db" | grep -q "sqlite"; then
    lifecycle_warn "D-SQLITE-GUARD: uvicorn PID $pid is running with SQLite — forcing restart with real DB"
    return 1
fi
```

## How to use

Copy `.devcontainer/secrets.env.example` to `.devcontainer/secrets.env` and fill in real values. This file is git-ignored. On next Codespace start, `supervisor.sh` reads it before launching uvicorn.

## Live verification

| Check | Result |
|-------|--------|
| `benmerahhoussam16@gmail.com` / `1111` | ✅ login success, `is_admin=true` |
| `houssamannaba963@gmail.com` / `1111` | ✅ login success, `is_admin=false` |
| `/api/security/user/me` × 5 | ✅ HTTP 200 every time — no auth loop |
| WebSocket chat (قانون نيوتن الثاني) | ✅ 200+ Arabic chunks with LaTeX |
| Admin WebSocket (السلام عليكم) | ✅ greeting fastpath, 71 chars |
| `DATABASE_URL` in process env | ✅ Supabase (not sqlite) |
| `OPENROUTER_API_KEY` in process env | ✅ present |

## Files changed

- `.devcontainer/supervisor.sh` — D-SQLITE-GUARD added to `_uvicorn_healthy()`

> `.env` and `.devcontainer/secrets.env` are git-ignored and not included in this PR.
