### PR TITLE
fix(ws): never log out a valid session on WS 4401 — end the kick-to-login / "new conversation" catastrophe (ISS-097 / D-WS-KICK-001)

### DIFF
--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -3523,3 +3523,26 @@ Add `activeRequestIdRef.current = null` as the first statement in the
 
 ### Files Changed
 - `frontend/app/hooks/useAgentSocket.js` — reset in `assistant_final` handler
+
+---
+
+## D-WS-KICK-001 (2026-05-29) — WS 4401 must never log out a valid session
+
+**Decision:** `agent:auth_error` (→ logout) is dispatched ONLY when an HTTP `/me` probe
+definitively returns 401/403. A count of consecutive 4401 WS closes must NEVER trigger
+logout (the removed `MAX_FATAL_RETRIES` path was the cause of the idle kick). Transient
+WS-connect user-lookup failures close with retryable `1013`, not `4401`. `DashboardLayout`
+restores the latest conversation on mount (guarded by `didRestoreRef`).
+
+**Rules (permanent):**
+1. `/me` (Authorization header) is the sole arbiter of session validity — immune to a
+   proxy dropping the WS `?token=` query param.
+2. `4401` is reserved for missing/corrupt token or a genuinely inactive user; transient
+   server-side lookup failures → `1013`.
+3. No forced blank "new conversation": resume the last conversation on load.
+
+**Files Changed**
+- `frontend/app/hooks/useRealtimeConnection.js` (Fix A)
+- `frontend/app/components/CogniForgeApp.jsx` (Fix B)
+- `app/api/routers/customer_chat.py`, `app/api/routers/admin.py` (Fix C)
+- `tests/services/test_iss097_kick_to_login.py` (new — 7 regression checks)

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -3455,3 +3455,31 @@ const merged = deltaBuffer.splice(0).reduce(...);
 - `.devcontainer/secrets.env` — أُنشئ بالأسرار الحقيقية (git-ignored)
 - `frontend/app/hooks/useRealtimeConnection.js` — إصلاح `flushDeltaBuffer` baseEvent
 - `frontend/app/hooks/useAgentSocket.js` — إضافة `activeRequestIdRef.current = null` في `assistant_final`
+
+---
+
+## ISS-097 — The Idle Kick: 4401 logs out a VALID session (2026-05-29 / D-WS-KICK-001)
+
+**User report:** "حتى بدون طرح أي أسئلة" — kicked to login and dropped into a blank
+"new conversation" while idle (no question). Persisted through D-095 + D-096.
+
+**Root cause (two halves):**
+1. `useRealtimeConnection.js` fired `agent:auth_error` → `logout()` after a *count*
+   of consecutive 4401 closes (`MAX_FATAL_RETRIES=3`) WITHOUT confirming the token
+   was dead → kick in ~6-8s even with a valid token. Idle trigger: proxy intermittently
+   drops `?token=` on WS reconnect → server 4401 → repeat → kick.
+2. `DashboardLayout` always mounted with `conversationId=null` → blank chat on every login.
+
+**Fix (D-WS-KICK-001):**
+- A: auth_error fires ONLY when HTTP `/me` returns 401/403 (confirmed-invalid). Else
+  `retryTransientAuth()` reconnects. Removed `MAX_FATAL_RETRIES`/`FATAL_RETRY_DELAY_MS`.
+- B: restore latest conversation on mount via `/api/chat/latest` (guarded by `didRestoreRef`).
+- C: WS-connect transient `db.get` failure closes `1013` (`WS_BACKEND_TRANSIENT`), not 4401.
+
+**Live verification (node v22 + stdlib; sandbox blocks uvicorn boot):**
+- Frontend decision (faithful port + source-fidelity guard): idle 12× 4401 valid token →
+  0 logouts, 12 reconnects; 35× → offline (not auth_error); /me=invalid → 1 logout (correct). 4/4 ✅
+- Conversation restore: returning user resumes (cid=404); new user blank; explicit new-chat respected. 3/3 ✅
+- Auth premise (stdlib HS256 mirror of decode_user_id): valid never raises; expired/badsig/no-sub → 401. ✅
+- 7 regression assertions in `tests/services/test_iss097_kick_to_login.py` ✅; both routers compile.
+- Full browser + Supabase E2E runs on live Codespace/CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6828,3 +6828,85 @@ $ pytest tests/services/test_ws_heartbeat_skill.py tests/fitness/test_supervisor
 | `.memory/decisions.md` | إدخال D-096 |
 | `CLAUDE.md` §6.71 | هذا القسم |
 
+---
+
+## 6.72 The Idle Kick — 4401 Must Never Logout a Valid Session (2026-05-29, ISS-097 / D-WS-KICK-001)
+
+> **بلاغ المستخدم الحاسم**: «**حتى بدون طرح أي أسئلة** تحدث هذه الكارثة ... نخرج
+> ثم ندخل إلى صفحة دردشة جديدة». الطرد يحدث على اتصال خامل، بلا أي سؤال — مما
+> يُبرّئ D-096 (تزامن الإرسال يحدث أثناء البث فقط) و BKT تماماً، ويُثبت أن الكارثة
+> **على مستوى الاتصال** بحتاً.
+
+### الجذر (نصفان مستقلان، لم يُصلحهما D-095 ولا D-096)
+
+**النصف 1 — طرد كاذب**: `useRealtimeConnection.js` كان يُطلق `agent:auth_error`
+(→ `logout()` → "محادثة جديدة" فارغة) بعد *عدد* من إغلاقات `4401` المتتالية
+(`MAX_FATAL_RETRIES=3`) **دون تأكيد أن الـ token ميت فعلاً**. مع
+`FATAL_RETRY_DELAY_MS=2s` = طرد خلال ~6-8 ثوانٍ، حتى مع token صالح تماماً. على
+اتصال خامل، السبب الأرجح: بروكسي Codespaces/`server.js` يُسقط أحياناً
+`?token=` عند إعادة اتصال WS → الخادم يرى «لا token» → `4401` → تكرار → طرد.
+
+**النصف 2 — "محادثة جديدة" في كل دخول**: `DashboardLayout` كان يُحمَّل دائماً بـ
+`conversationId=null` + رسائل فارغة، فأي (إعادة) دخول يسقط في دردشة فارغة.
+
+### الإصلاح (3 طبقات على مستوى الجذر)
+
+- **A — Frontend (`useRealtimeConnection.js`)**: `agent:auth_error` (→ طرد) يُطلَق
+  **فقط** في فرع `result === "invalid"` — أي probe HTTP `/me` يُرجع 401/403 قطعياً
+  (الـ token ميت حقاً). نتيجة valid/unknown → `retryTransientAuth()` يُعيد الاتصال
+  بـ backoff تصاعدي (عبر عدّاد `retries` العام → "offline" أخيراً، لا "auth_error").
+  أُزيل `MAX_FATAL_RETRIES` و `FATAL_RETRY_DELAY_MS` (مسار العدّ الذي سبّب الطرد).
+- **B — Frontend (`CogniForgeApp.jsx`)**: عند التحميل، استعادة آخر محادثة عبر
+  `/api/chat/latest` (admin: `/admin/api/chat/latest`)، محروسة بـ `didRestoreRef`
+  أحادي الإطلاق فلا يكتب فوق "محادثة جديدة" صريحة أو فتح محادثة من القائمة.
+- **C — Backend (`customer_chat.py` + `admin.py`)**: جلب المستخدم عند الاتصال
+  `db.get(User, user_id)` مغلَّف بـ `try/except`؛ الفشل *العابر* (الـ token فُكَّ
+  بنجاح) يُغلق بـ `1013` القابل لإعادة المحاولة + كود `WS_BACKEND_TRANSIENT` بدل
+  `4401` فيُعيد العميل الاتصال بدل الطرد. المستخدم المفقود/الموقوف حقاً لا يزال
+  يُغلق `4401` (صحيح).
+
+### القواعد الـ 4 الدائمة (D-WS-KICK-001 — لا تُكسر بدون ADR)
+
+1. **المسار الوحيد إلى `agent:auth_error` هو probe `/me` يُؤكِّد 401/403**. لا عدّاد
+   إغلاقات يُترجَم إلى طرد. أي إعادة لمنطق العدّ = عودة فورية لكارثة الطرد الخامل.
+2. **`/me` هو الحكم الوحيد لصلاحية الجلسة** (token عبر Authorization header — مسار
+   موثوق منفصل عن WS؛ مناعة ضد إسقاط البروكسي لـ `?token=`).
+3. **الفشل العابر في جلب المستخدم بـ WS يُغلق `1013` لا `4401`** بعد فك الـ token
+   بنجاح. `4401` محجوز لـ token مفقود/تالف أو مستخدم موقوف فعلاً.
+4. **`DashboardLayout` يستعيد آخر محادثة عند التحميل** (محروس بـ `didRestoreRef`)
+   — لا "محادثة جديدة" فارغة قسرية.
+
+### التحقق الحي (2026-05-29 — sandbox يحجب egress فلا boot لـ uvicorn)
+
+الطرد على مستوى الاتصال، فهو قابل للتحقق محلياً بـ node v22 + stdlib:
+- **قرار الطرد (Frontend، Node — منقول بأمانة من المصدر + فحص بنيوي)**: السيناريو
+  الكارثي «خامل، 12× إغلاق 4401، token صالح» → **0 طرد، 12 إعادة اتصال**. 35×
+  4401 صالح → **offline لا auth_error**. 4401 + /me=invalid (انتهاء 8 ساعات حقيقي)
+  → طرد واحد (صحيح). 4/4 سيناريو ✅.
+- **استعادة المحادثة (Fix B، Node)**: عائد → يستأنف محادثته (404، رسالتان)؛ مستخدم
+  جديد → يبقى فارغاً؛ "محادثة جديدة" صريحة → لا تُمسح. 3/3 ✅.
+- **premise المصادقة (stdlib HS256 يُحاكي `decode_user_id`)**: token صالح لا يرفع
+  أبداً (لا 4401 عند الفك)؛ منتهٍ/توقيع خاطئ/بلا sub → 401 (طرد صحيح). ✅.
+- 7 اختبارات regression في `tests/services/test_iss097_kick_to_login.py` ✅ + كلا
+  الـ routers يُترجمان. **التحقق الكامل في المتصفح + Supabase يجري على Codespace حيّ/CI.**
+
+### الملفات (D-WS-KICK-001)
+
+| File | Change |
+|------|--------|
+| `frontend/app/hooks/useRealtimeConnection.js` | Fix A — auth_error فقط على /me invalid + retryTransientAuth |
+| `frontend/app/components/CogniForgeApp.jsx` | Fix B — استعادة آخر محادثة + didRestoreRef |
+| `app/api/routers/customer_chat.py` | Fix C — جلب عابر يُغلق 1013 لا 4401 (+contextlib) |
+| `app/api/routers/admin.py` | Fix C — نفس الإصلاح |
+| `tests/services/test_iss097_kick_to_login.py` | **جديد** — 7 regression checks |
+| `.memory/issues.md` / `.memory/decisions.md` | إدخالات ISS-097 / D-WS-KICK-001 |
+| `CLAUDE.md` §6.72 | هذا القسم |
+
+### السلسلة الكاملة (D-095 → D-WS-KICK-001)
+
+| Decision | المُصلَح |
+|----------|---------|
+| D-095 | ENVIRONMENT=testing → development (480-min JWT) |
+| D-096 | WS send concurrency lock (kick أثناء البث) |
+| **D-WS-KICK-001** | **idle 4401 لا يُسجِّل خروجاً إلا بتأكيد /me + استعادة المحادثة** |
+

--- a/app/api/routers/admin.py
+++ b/app/api/routers/admin.py
@@ -13,6 +13,7 @@
 """
 
 import asyncio
+import contextlib
 import inspect
 import uuid
 from datetime import UTC, datetime
@@ -373,7 +374,32 @@ async def chat_stream_ws(
         return
 
     async with async_session_factory() as db:
-        actor = await db.get(User, user_id)
+        # D-WS-KICK-001 (ISS-097): الـ token فُكَّ بنجاح. فشل جلب المستخدم هنا
+        # خلل خادم *عابر* لا فشل مصادقة — أغلق بـ 1013 القابل لإعادة المحاولة،
+        # لا 4401 (الذي تُترجمه الواجهة إلى تسجيل خروج).
+        try:
+            actor = await db.get(User, user_id)
+        except Exception as lookup_exc:
+            logger.warning(
+                "admin_chat.ws_user_lookup_transient: %s (closing 1013, not 4401)",
+                lookup_exc,
+            )
+            await websocket.accept(subprotocol=selected_protocol)
+            with contextlib.suppress(Exception):
+                await websocket.send_json(
+                    normalize_streaming_event(
+                        {
+                            "type": "error",
+                            "payload": {
+                                "details": "Service temporarily unavailable. Reconnecting.",
+                                "code": "WS_BACKEND_TRANSIENT",
+                                "status_code": 1013,
+                            },
+                        }
+                    )
+                )
+            await websocket.close(code=1013)
+            return
         if actor is None or not actor.is_active:
             await websocket.accept(subprotocol=selected_protocol)
             await websocket.send_json(

--- a/app/api/routers/customer_chat.py
+++ b/app/api/routers/customer_chat.py
@@ -13,6 +13,7 @@ D-086 (2026-05-23): تطبيق Protocol V46.0.
 """
 
 import asyncio
+import contextlib
 import uuid
 from datetime import UTC, datetime
 
@@ -174,7 +175,7 @@ async def _evaluate_and_emit_bkt(
                 },
                 conversation_id,
                 stream_request_id,
-            )
+            ),
         )
     except Exception as exc:
         # BKT must never break chat — log and continue.
@@ -479,7 +480,34 @@ async def chat_stream_ws(
         return
 
     async with async_session_factory() as db:
-        actor = await db.get(User, user_id)
+        # D-WS-KICK-001 (ISS-097): الـ token فُكَّ بنجاح (توقيع + صلاحية سليمان).
+        # أي فشل في جلب المستخدم هنا هو خلل خادم *عابر* (Supabase blip، انقطاع
+        # اتصال pool)، وليس فشل مصادقة. لا تُغلق بـ 4401 — فالواجهة تُترجم 4401
+        # المتكرر إلى تسجيل خروج. أغلق بـ 1013 (Try Again Later) القابل لإعادة
+        # المحاولة → الواجهة تُعيد الاتصال دون طرد المستخدم.
+        try:
+            actor = await db.get(User, user_id)
+        except Exception as lookup_exc:
+            logger.warning(
+                "customer_chat.ws_user_lookup_transient: %s (closing 1013, not 4401)",
+                lookup_exc,
+            )
+            await websocket.accept(subprotocol=selected_protocol)
+            with contextlib.suppress(Exception):
+                await websocket.send_json(
+                    normalize_streaming_event(
+                        {
+                            "type": "error",
+                            "payload": {
+                                "details": "Service temporarily unavailable. Reconnecting.",
+                                "code": "WS_BACKEND_TRANSIENT",
+                                "status_code": 1013,
+                            },
+                        }
+                    )
+                )
+            await websocket.close(code=1013)
+            return
         if actor is None or not actor.is_active:
             await websocket.accept(subprotocol=selected_protocol)
             await websocket.send_json(
@@ -581,7 +609,7 @@ async def chat_stream_ws(
                         ),
                         None,
                         stream_request_id,
-                    )
+                    ),
                 )
                 continue
 
@@ -661,7 +689,7 @@ async def chat_stream_ws(
                         ),
                         local_conversation_id,
                         stream_request_id,
-                    )
+                    ),
                 )
                 turn_span.set_terminal("error")
                 close_ws_turn(turn_span, status="ERROR")

--- a/app/api/routers/customer_chat.py
+++ b/app/api/routers/customer_chat.py
@@ -841,24 +841,26 @@ async def chat_stream_ws(
             except Exception as exc:
                 stream_error = exc
                 logger.error(f"Error in compatibility facade stream: {exc}", exc_info=True)
-                if not isinstance(exc, WebSocketDisconnect):
-                    # D-096: locked send + state check
-                    if websocket.client_state == WebSocketState.CONNECTED:
-                        try:
-                            await _locked_send_json(
-                                websocket,
-                                send_lock,
-                                normalize_streaming_event(
-                                    {
-                                        "type": "error",
-                                        "payload": {"details": str(exc), "status_code": 500},
-                                    }
-                                ),
-                            )
-                        except (WebSocketDisconnect, RuntimeError) as _send_err:
-                            logger.debug(
-                                "customer_chat.error_send_failed: %s", type(_send_err).__name__
-                            )
+                # D-096: locked send + state check
+                if (
+                    not isinstance(exc, WebSocketDisconnect)
+                    and websocket.client_state == WebSocketState.CONNECTED
+                ):
+                    try:
+                        await _locked_send_json(
+                            websocket,
+                            send_lock,
+                            normalize_streaming_event(
+                                {
+                                    "type": "error",
+                                    "payload": {"details": str(exc), "status_code": 500},
+                                }
+                            ),
+                        )
+                    except (WebSocketDisconnect, RuntimeError) as _send_err:
+                        logger.debug(
+                            "customer_chat.error_send_failed: %s", type(_send_err).__name__
+                        )
             finally:
                 if stream_task is not None and not stream_task.done():
                     stream_task.cancel()

--- a/frontend/app/components/CogniForgeApp.jsx
+++ b/frontend/app/components/CogniForgeApp.jsx
@@ -144,6 +144,10 @@ const DashboardLayout = ({ user, token, onLogout }) => {
     const endpoint = user.is_admin ? '/admin/api/chat/ws' : '/api/chat/ws';
     const convEndpoint = user.is_admin ? '/admin/api/conversations' : '/api/chat/conversations';
     const historyEndpoint = user.is_admin ? (id) => `/admin/api/conversations/${id}` : (id) => `/api/chat/conversations/${id}`;
+    // ISS-097 (D-WS-KICK-001): نقطة استرجاع آخر محادثة — تُستخدم لاستعادة
+    // السياق عند التحميل بدل بدء "محادثة جديدة" فارغة في كل دخول.
+    const latestEndpoint = user.is_admin ? '/admin/api/chat/latest' : '/api/chat/latest';
+    const didRestoreRef = useRef(false);
 
     const fetchConversations = useCallback(async () => {
          try {
@@ -188,12 +192,48 @@ const DashboardLayout = ({ user, token, onLogout }) => {
     };
 
     const handleNewChat = () => {
+        // ISS-097: المستخدم اختار محادثة جديدة صراحةً — علِّم didRestoreRef
+        // حتى لا يُعيد effect الاسترجاع تحميل آخر محادثة فوق اختياره.
+        didRestoreRef.current = true;
         clearMessages();
         setConversationId(null);
         setConversations([]);
         setIsSidebarOpen(false);
         setIsMenuOpen(false);
     };
+
+    // ISS-097 (D-WS-KICK-001): استعادة آخر محادثة عند التحميل.
+    // الكارثة: DashboardLayout كان يبدأ دائماً بـ conversationId=null + رسائل
+    // فارغة، فبعد أي دخول (أول دخول أو إعادة دخول بعد طرد) يجد المستخدم نفسه
+    // في "محادثة جديدة" فارغة — وهو نصف شكوى المستخدم الحرفية.
+    // الحل: مرة واحدة عند التحميل، إن لم تكن هناك محادثة نشطة، نجلب آخر محادثة
+    // (/latest) ونحمِّلها. غير حرج: عند الفشل أو غياب محادثة سابقة نبقى في
+    // محادثة جديدة (مستخدم جديد). guard بـ didRestoreRef يمنع الكتابة فوق
+    // اختيار المستخدم (محادثة جديدة / فتح محادثة من القائمة).
+    useEffect(() => {
+        if (didRestoreRef.current) return;
+        didRestoreRef.current = true;
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch(apiUrl(latestEndpoint), {
+                    headers: { 'Authorization': `Bearer ${token}` },
+                });
+                if (!res.ok || cancelled) return;
+                const data = await res.json();
+                if (cancelled || !data || data.conversation_id === undefined || data.conversation_id === null) {
+                    return;
+                }
+                setMessages(data.messages || []);
+                setConversationId(data.conversation_id);
+            } catch (e) {
+                // non-fatal — نبقى في محادثة جديدة فارغة
+                errorTracker.reportError(e, { message: 'Failed to restore latest conversation' });
+            }
+        })();
+        return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [latestEndpoint, token]);
 
     // ISS-066: localStorage قُرئ في useState lazy initializer — لا حاجة لـ useEffect هنا.
 

--- a/frontend/app/hooks/useRealtimeConnection.js
+++ b/frontend/app/hooks/useRealtimeConnection.js
@@ -40,12 +40,11 @@ const MAX_BACKOFF = 30000; // أقصى تأخير بين المحاولات (30 
 // المبكر على شبكات الهاتف المتذبذبة (carrier-NAT يقطع الاتصال مؤقتاً).
 const MAX_RETRIES = 30;
 const FATAL_CODES = new Set([4401, 4403]);
-// D-WS-AUTH-001 (2026-05-26): bounded retry على 4401 قبل اعتباره fatal.
-// قبل: 4401 واحد → logout فوري → reload → cycle.
-// بعد: 4401 يُجرَّب N مرات مع backoff قبل اعتباره auth_error حقيقي.
-// نضيف فحص HTTP /me كـ probe لتمييز transient vs permanent.
-const MAX_FATAL_RETRIES = 3; // أقصى محاولات قبل اعتبار 4401 fatal
-const FATAL_RETRY_DELAY_MS = 2000; // backoff بين محاولات 4401
+// D-WS-AUTH-001 (2026-05-26) → D-WS-KICK-001 (ISS-097 — 2026-05-29):
+// 4401 لا يُسجِّل الخروج وحده أبداً. المسار الوحيد إلى auth_error هو probe
+// HTTP /me يُرجع 401/403 صراحةً (= الـ token ميت حقاً). عدّاد المحاولات
+// المنفصل (MAX_FATAL_RETRIES) أُزيل: لا حدّ يُترجَم إلى طرد — فقط نتيجة /me
+// القطعية. إعادة الاتصال على 4401-بـ-token-صالح تستخدم عدّاد retries العام.
 const REVALIDATION_TIMEOUT_MS = 5000; // مهلة /me probe
 // D-WS-FLAP-003: heartbeat كل 45s (كان 25s) — يعطي مساحة لـ proxies بدون إغراق.
 // uvicorn --ws-ping-interval 20 يفحص الـ TCP layer تلقائياً.
@@ -565,24 +564,19 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
             was_stable: wasStable,
           });
 
-          // D-WS-AUTH-001 (2026-05-26): 4401/4403 لم يَعُد fatal فوراً.
+          // D-WS-AUTH-001 (2026-05-26) → D-WS-KICK-001 (ISS-097): 4401/4403
           // ─────────────────────────────────────────────────────────────────
-          // قبل: 4401 → logout فوري → reload → cycle.
-          // بعد: 4401 يُجرَّب MAX_FATAL_RETRIES مع HTTP /me probe.
-          //
-          // الـ rationale: 4401 قد يكون transient في بيئات mobile/Codespaces:
-          //   - SECRET_KEY rotation race بين uvicorn instances
-          //   - DB lag → db.get(User) returns None
+          // 4401 قد يكون transient في بيئات mobile/Codespaces:
+          //   - DB lag → db.get(User) returns None / يرمي استثناء
           //   - clock skew بين client و server
-          //   - Codespaces proxy حذف auth header
+          //   - Codespaces proxy / carrier-NAT حذف auth header
+          //   - خلل WS من جهة الخادم (race، إغلاق مفاجئ)
           //
-          // الـ flow:
-          //   1. Increment fatalRetries.current
-          //   2. Try HTTP /me to probe token validity:
-          //      - 200 → token valid, 4401 transient → retry WS with backoff
-          //      - 401 → token truly invalid → fire auth_error (escalate)
-          //      - network error → can't tell → retry up to MAX_FATAL_RETRIES
-          //   3. After MAX_FATAL_RETRIES exhausted → fire auth_error
+          // الـ flow (D-WS-KICK-001 — لا حدّ يُترجَم إلى طرد):
+          //   1. probe HTTP /me لتأكيد صلاحية الـ token:
+          //      - 401/403 → الـ token ميت حقاً → fire auth_error (المسار الوحيد)
+          //      - 200 (valid) أو network/unknown → الـ token سليم → أعد الاتصال
+          //   2. لا تسجيل خروج أبداً ما دام /me لا يُؤكِّد البطلان.
           if (FATAL_CODES.has(e.code)) {
             fatalRetries.current += 1;
 
@@ -590,27 +584,28 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
               code: e.code,
               reason: e.reason,
               attempt: fatalRetries.current,
-              max: MAX_FATAL_RETRIES,
             });
 
-            // فحص: هل تجاوزنا الحد؟
-            if (fatalRetries.current > MAX_FATAL_RETRIES) {
-              console.error(
-                `[WS] Exhausted ${MAX_FATAL_RETRIES} auth retries — escalating to auth_error.`
-              );
-              setState("auth_error");
-              if (typeof window !== "undefined") {
-                window.dispatchEvent(
-                  new CustomEvent("agent:auth_error", {
-                    detail: { code: e.code, reason: e.reason || "session_expired_confirmed" },
-                  })
-                );
-              }
-              return;
-            }
-
-            // محاولة probe HTTP /me لتمييز transient vs permanent
-            // نُلغي أي probe سابق
+            // ─────────────────────────────────────────────────────────────────
+            // D-WS-KICK-001 (ISS-097 — 2026-05-29): WS 4401 لا يُسجِّل الخروج وحده.
+            // ─────────────────────────────────────────────────────────────────
+            // الكارثة المُشخَّصة: الكود القديم كان يُطلق `agent:auth_error`
+            // (→ logout → "محادثة جديدة") بعد MAX_FATAL_RETRIES إغلاقات 4401
+            // *بدون* تأكيد أن الـ token فعلاً منتهٍ. مع FATAL_RETRY_DELAY_MS=2s،
+            // كان ذلك طرداً خلال ~6-8 ثوانٍ — حتى عندما يكون الـ token صالحاً
+            // تماماً. أي خلل WS من جهة الخادم (db.get transient، blip شبكي،
+            // race) كان يُترجَم إلى تسجيل خروج كارثي.
+            //
+            // القاعدة الجديدة (لا تُكسر بدون ADR): المسار **الوحيد** إلى
+            // `agent:auth_error` هو probe HTTP `/me` يُرجع 401/403 صراحةً
+            // (= الـ token ميت حقاً). أي نتيجة أخرى (200 = صالح، أو
+            // network/unknown = الخادم غير قابل للوصول) → نُبقي الجلسة
+            // ونُعيد الاتصال بـ exponential backoff. لا طرد أبداً ما دام
+            // الـ token صالحاً.
+            //
+            // إذا انتهى الـ token حقاً (بعد 8 ساعات) → /me يُرجع 401 → طرد
+            // نظيف (سلوك صحيح). وحتى حينها، FIX-B يستعيد آخر محادثة بعد
+            // إعادة الدخول فلا يفقد المستخدم سياقه.
             if (revalidateAbortRef.current) {
               revalidateAbortRef.current.abort();
             }
@@ -621,6 +616,35 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
               if (abortCtl) abortCtl.abort();
             }, REVALIDATION_TIMEOUT_MS);
 
+            // إعادة محاولة transient موحَّدة: backoff تصاعدي عبر عدّاد retries
+            // العام (لا عدّاد fatal منفصل) — فإن ظل الخادم 4401 إلى ما لا نهاية
+            // مع token صالح، نصل أخيراً إلى "offline" (الخادم معطّل) لا
+            // "auth_error" (الجلسة منتهية). هذان حدثان مختلفان تماماً.
+            const retryTransientAuth = (probe) => {
+              if (!mountedRef.current) return;
+              retries.current += 1;
+              if (retries.current >= MAX_RETRIES) {
+                console.error(
+                  `[WS] 4401 persisted ${MAX_RETRIES}× with valid/unknown token — ` +
+                    `server unreachable, declaring offline (NOT auth_error).`
+                );
+                setState("offline");
+                return;
+              }
+              setState(retries.current <= 1 ? "degraded" : "reconnecting");
+              if (typeof window !== "undefined") {
+                window.dispatchEvent(
+                  new CustomEvent("agent:transient_auth_warning", {
+                    detail: { code: e.code, attempt: retries.current, probe },
+                  })
+                );
+              }
+              const delay = Math.min(Math.pow(2, retries.current - 1) * 500, MAX_BACKOFF);
+              const jitter = Math.floor(Math.random() * 500);
+              clearTimeout(reconnectTimeoutRef.current);
+              reconnectTimeoutRef.current = setTimeout(connect, delay + jitter);
+            };
+
             revalidateTokenViaHttp(wsUrl, token, abortCtl?.signal)
               .then((result) => {
                 clearTimeout(timeoutId);
@@ -628,7 +652,7 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
                 console.info("[WS] Token revalidation result:", result);
 
                 if (result === "invalid") {
-                  // Token تأكد بطلانه عبر HTTP → escalate فوراً
+                  // المسار الوحيد للطرد: /me أكّد أن الـ token ميت حقاً.
                   console.error("[WS] Token confirmed invalid via /me — escalating to auth_error.");
                   setState("auth_error");
                   if (typeof window !== "undefined") {
@@ -641,40 +665,19 @@ export function useRealtimeConnection(wsUrl, token, eventNamespace = "default") 
                   return;
                 }
 
-                // result === "valid" أو "unknown" → transient، أعد المحاولة
+                // result === "valid" أو "unknown" → الـ token سليم، الخلل من
+                // الخادم → أعد الاتصال، لا تطرد.
                 console.info(
-                  `[WS] 4401 treated as transient (probe=${result}) — retrying in ${FATAL_RETRY_DELAY_MS}ms`
+                  `[WS] 4401 treated as transient (probe=${result}) — token NOT dead, reconnecting.`
                 );
-                // نُبقي state="connecting" أو نُحدِّثه — لكن لا "auth_error".
-                if (mountedRef.current) {
-                  setState(fatalRetries.current === 1 ? "degraded" : "reconnecting");
-                }
-                // أَطلق notification إعلامي (لا fatal)
-                if (typeof window !== "undefined") {
-                  window.dispatchEvent(
-                    new CustomEvent("agent:transient_auth_warning", {
-                      detail: {
-                        code: e.code,
-                        attempt: fatalRetries.current,
-                        max: MAX_FATAL_RETRIES,
-                        probe: result,
-                      },
-                    })
-                  );
-                }
-                clearTimeout(reconnectTimeoutRef.current);
-                reconnectTimeoutRef.current = setTimeout(connect, FATAL_RETRY_DELAY_MS);
+                retryTransientAuth(result);
               })
               .catch(() => {
                 clearTimeout(timeoutId);
                 if (!mountedRef.current) return;
-                // probe أُلغي أو فشل → اعتبره transient وأعد المحاولة
-                console.info("[WS] Token probe aborted/failed — treating as transient.");
-                if (mountedRef.current) {
-                  setState(fatalRetries.current === 1 ? "degraded" : "reconnecting");
-                }
-                clearTimeout(reconnectTimeoutRef.current);
-                reconnectTimeoutRef.current = setTimeout(connect, FATAL_RETRY_DELAY_MS);
+                // probe أُلغي أو فشل → unknown → أعد الاتصال (لا طرد).
+                console.info("[WS] Token probe aborted/failed — treating as transient (no logout).");
+                retryTransientAuth("unknown");
               });
 
             // مُهم: نُرجع هنا لأن probe + reconnect سيتمان async.

--- a/scripts/verify_iss097_live.py
+++ b/scripts/verify_iss097_live.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Live end-to-end verification for ISS-097 / D-WS-KICK-001 — run on a real Codespace.
+
+The "kick to login / new conversation" catastrophe is connection-level (it happens
+even without asking a question). This script boots nothing — it drives the *already
+running* stack (uvicorn :8000) the way the browser does, and proves:
+
+  1. /me returns 200 for a valid token (the probe Fix A relies on to keep the session).
+  2. An IDLE WebSocket with a valid token stays connected: session_ready arrives,
+     a heartbeat ping is answered with pong, and the socket is NOT closed / NOT 4401.
+  3. A reconnect STORM with the same valid token: every reconnect is accepted
+     (session_ready), never 4401 — so the client can never escalate to logout.
+  4. A token-stripped connect is correctly rejected with 4401 (genuine auth failure).
+  5. The latest-conversation restore endpoint (/api/chat/latest) responds (Fix B).
+
+Usage (on the Codespace, after the stack is up):
+    # provide a real JWT (from a login) or let the script log in:
+    TOKEN=<jwt> python scripts/verify_iss097_live.py
+    # or:
+    LOGIN_EMAIL=... LOGIN_PASSWORD=... python scripts/verify_iss097_live.py
+
+Exit code 0 = all checks passed.
+
+This file is intentionally dependency-light (httpx + websockets, both present on the
+Codespace). It is NOT part of pytest and never runs in the deps-less CI sandbox.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+BASE_HTTP = os.environ.get("VERIFY_BASE_HTTP", "http://localhost:8000")
+BASE_WS = os.environ.get("VERIFY_BASE_WS", "ws://localhost:8000")
+ME_PATH = "/api/security/user/me"
+WS_PATH = "/api/chat/ws"
+LATEST_PATH = "/api/chat/latest"
+
+PASS = "✅"
+FAIL = "❌"
+
+
+def _login_if_needed() -> str:
+    token = os.environ.get("TOKEN", "").strip()
+    if token:
+        return token
+    import httpx
+
+    email = os.environ.get("LOGIN_EMAIL")
+    password = os.environ.get("LOGIN_PASSWORD")
+    if not (email and password):
+        sys.exit("Provide TOKEN=<jwt> or LOGIN_EMAIL=.. LOGIN_PASSWORD=..")
+    r = httpx.post(
+        f"{BASE_HTTP}/api/security/login",
+        json={"email": email, "password": password},
+        timeout=20,
+    )
+    r.raise_for_status()
+    data = r.json()
+    return data.get("access_token") or data.get("token") or data["data"]["access_token"]
+
+
+async def _connect_once(token: str | None, *, idle_secs: float = 0.0) -> dict:
+    """Open the WS like the browser (?token=), optionally idle + heartbeat, then close.
+
+    Returns a dict describing what happened.
+    """
+    import websockets
+
+    url = f"{BASE_WS}{WS_PATH}"
+    if token is not None:
+        url += f"?token={token}"
+
+    result: dict = {"connected": False, "session_ready": False, "pong": False, "close_code": None}
+    try:
+        async with websockets.connect(url, ping_interval=None, open_timeout=15) as ws:
+            result["connected"] = True
+            # First server frame should be session_ready (D-WS-FLAP-003 primer).
+            try:
+                first = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+                if first.get("type") == "session_ready":
+                    result["session_ready"] = True
+            except TimeoutError:
+                pass
+
+            if idle_secs:
+                await asyncio.sleep(idle_secs)
+                await ws.send(json.dumps({"type": "ping"}))
+                # drain a few frames looking for a pong
+                for _ in range(5):
+                    try:
+                        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=8))
+                    except TimeoutError:
+                        break
+                    if '"type":"pong"' in json.dumps(msg) or msg.get("type") == "pong":
+                        result["pong"] = True
+                        break
+    except Exception as exc:  # websockets raises with .code on close
+        result["close_code"] = getattr(exc, "code", None) or str(exc)
+    return result
+
+
+async def _main() -> int:
+    import httpx
+
+    token = _login_if_needed()
+    passed = failed = 0
+
+    def check(cond: bool, msg: str) -> None:
+        nonlocal passed, failed
+        print(f"{PASS if cond else FAIL} {msg}")
+        passed += int(cond)
+        failed += int(not cond)
+
+    # 1. /me returns 200 for a valid token
+    me = httpx.get(
+        f"{BASE_HTTP}{ME_PATH}", headers={"Authorization": f"Bearer {token}"}, timeout=20
+    )
+    check(me.status_code == 200, f"/me with valid token -> 200 (got {me.status_code})")
+
+    # 2. Idle WS stays alive + heartbeat answered
+    idle = await _connect_once(token, idle_secs=8.0)
+    check(idle["connected"] and idle["session_ready"], "idle WS connects + session_ready")
+    check(idle["pong"], "idle WS heartbeat ping -> pong (no spurious close)")
+    check(
+        idle["close_code"] in (None, 1000, 1001), f"idle WS not 4401 (close={idle['close_code']})"
+    )
+
+    # 3. Reconnect storm — same valid token, 5x, all accepted, never 4401
+    storm_ok = True
+    for i in range(5):
+        r = await _connect_once(token)
+        ok = r["connected"] and r["session_ready"]
+        storm_ok = storm_ok and ok
+        print(
+            f"   reconnect #{i + 1}: connected={r['connected']} session_ready={r['session_ready']} close={r['close_code']}"
+        )
+    check(storm_ok, "reconnect storm: every reconnect accepted, never 4401")
+
+    # 4. Token-stripped connect is rejected (genuine auth failure)
+    no_tok = await _connect_once(None)
+    check(
+        no_tok["close_code"] not in (None, 1000, 1001),
+        f"no-token connect rejected (close={no_tok['close_code']})",
+    )
+
+    # 5. Latest-conversation restore endpoint responds (Fix B)
+    latest = httpx.get(
+        f"{BASE_HTTP}{LATEST_PATH}", headers={"Authorization": f"Bearer {token}"}, timeout=20
+    )
+    check(
+        latest.status_code in (200, 204, 404), f"/api/chat/latest responds ({latest.status_code})"
+    )
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/services/test_iss097_kick_to_login.py
+++ b/tests/services/test_iss097_kick_to_login.py
@@ -1,0 +1,143 @@
+"""
+Regression test — WebSocket 4401 must never log out a valid session (ISS-097 / D-WS-KICK-001).
+
+USER REPORT (2026-05-29):
+> «انت تستهزئ بي قم بحل الكارثة ... مشكلة الدخول و الخروج إلى محادثة جديدة
+>  بشكل كارثي خطير» — kicked to login after a question or two, landing in a
+>  brand-new conversation. Persisted through D-095 and D-096.
+
+ROOT CAUSE (D-WS-KICK-001) — two independent halves:
+
+1. SPURIOUS LOGOUT: `useRealtimeConnection.js` fired `agent:auth_error`
+   (→ logout → blank "new conversation") after a *count* of consecutive 4401
+   closes (MAX_FATAL_RETRIES), WITHOUT confirming the token was actually dead.
+   With FATAL_RETRY_DELAY_MS=2s that was a kick in ~6-8s — even when the token
+   was perfectly valid. Any server-side WS hiccup (transient db.get, blip,
+   race) was mistranslated into a catastrophic logout.
+
+2. "NEW CONVERSATION" ON EVERY LOGIN: `DashboardLayout` always mounted with
+   conversationId=null + empty messages, so any (re)login dropped the user
+   into a blank chat.
+
+INVARIANTS (enforced by these tests):
+A. Frontend: `agent:auth_error` is dispatched ONLY inside the `result === "invalid"`
+   branch (HTTP /me definitively 401/403). The count-based escalation
+   (MAX_FATAL_RETRIES) is removed.
+B. Frontend: `CogniForgeApp.jsx` restores the latest conversation on mount,
+   guarded by `didRestoreRef`.
+C. Backend: customer_chat.py + admin.py close a transient user-lookup failure
+   with retryable 1013 (NOT 4401) so the client reconnects instead of logging out.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "frontend" / "app" / "hooks" / "useRealtimeConnection.js"
+APP = REPO_ROOT / "frontend" / "app" / "components" / "CogniForgeApp.jsx"
+CUSTOMER = REPO_ROOT / "app" / "api" / "routers" / "customer_chat.py"
+ADMIN = REPO_ROOT / "app" / "api" / "routers" / "admin.py"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ─────────────────────────── Invariant A (frontend logout) ───────────────────────────
+
+
+def test_no_count_based_fatal_escalation() -> None:
+    """The count-based 4401 escalation constant must be gone (it caused the kick)."""
+    src = _read(HOOK)
+    assert "const MAX_FATAL_RETRIES" not in src, (
+        "D-WS-KICK-001: MAX_FATAL_RETRIES constant must be removed. A *count* of "
+        "4401 closes must never trigger logout — only a confirmed-invalid /me probe."
+    )
+    assert "const FATAL_RETRY_DELAY_MS" not in src, (
+        "D-WS-KICK-001: FATAL_RETRY_DELAY_MS constant must be removed (count-based path gone)."
+    )
+
+
+def test_auth_error_only_dispatched_after_invalid_probe() -> None:
+    """`agent:auth_error` must be dispatched ONLY in the `result === "invalid"` branch."""
+    src = _read(HOOK)
+    # Every dispatch of agent:auth_error must be preceded (within the same close
+    # handler) by a confirmed-invalid check. We assert the unique reason string
+    # introduced by the fix is the sole escalation path.
+    auth_error_dispatches = src.count('"agent:auth_error"')
+    assert auth_error_dispatches >= 1, "auth_error dispatch missing entirely."
+    assert auth_error_dispatches == 1, (
+        f"D-WS-KICK-001: expected exactly ONE agent:auth_error dispatch site "
+        f"(the confirmed-invalid /me branch), found {auth_error_dispatches}."
+    )
+    assert "token_invalid_confirmed_via_http" in src, (
+        "D-WS-KICK-001: the single auth_error path must be the HTTP-confirmed-invalid branch."
+    )
+    # The decision marker for the fix must be present.
+    assert "D-WS-KICK-001" in src
+
+
+def test_transient_4401_reconnects_not_logout() -> None:
+    """A valid/unknown /me result must reconnect, never logout."""
+    src = _read(HOOK)
+    assert "retryTransientAuth" in src, (
+        "D-WS-KICK-001: transient 4401 (valid/unknown token) must reconnect via "
+        "retryTransientAuth(), not escalate to auth_error."
+    )
+
+
+# ─────────────────────────── Invariant B (conversation restore) ───────────────────────────
+
+
+def test_latest_conversation_restore_on_mount() -> None:
+    src = _read(APP)
+    assert "/api/chat/latest" in src and "/admin/api/chat/latest" in src, (
+        "D-WS-KICK-001: DashboardLayout must restore the latest conversation on mount "
+        "(customer + admin /latest endpoints)."
+    )
+    assert "didRestoreRef" in src, (
+        "D-WS-KICK-001: a didRestoreRef guard must prevent overwriting the user's "
+        "explicit choice (new chat / opening a conversation)."
+    )
+    # handleNewChat must set the guard so restore does not clobber a deliberate new chat.
+    assert re.search(r"handleNewChat[\s\S]{0,200}didRestoreRef\.current = true", src), (
+        "D-WS-KICK-001: handleNewChat must set didRestoreRef so restore is suppressed."
+    )
+
+
+# ─────────────────────────── Invariant C (backend 1013 not 4401) ───────────────────────────
+
+
+def test_customer_ws_transient_lookup_closes_1013() -> None:
+    src = _read(CUSTOMER)
+    assert "WS_BACKEND_TRANSIENT" in src and "close(code=1013)" in src, (
+        "D-WS-KICK-001: customer_chat WS must close a transient user-lookup failure "
+        "with retryable 1013, not 4401."
+    )
+    # The guard must wrap db.get(User, user_id) in try/except.
+    assert re.search(
+        r"try:\s*\n\s*actor = await db\.get\(User, user_id\)\s*\n\s*except Exception",
+        src,
+    ), "D-WS-KICK-001: customer_chat WS user lookup must be wrapped in try/except."
+
+
+def test_admin_ws_transient_lookup_closes_1013() -> None:
+    src = _read(ADMIN)
+    assert "WS_BACKEND_TRANSIENT" in src and "close(code=1013)" in src, (
+        "D-WS-KICK-001: admin WS must close a transient user-lookup failure with 1013, not 4401."
+    )
+    assert re.search(
+        r"try:\s*\n\s*actor = await db\.get\(User, user_id\)\s*\n\s*except Exception",
+        src,
+    ), "D-WS-KICK-001: admin WS user lookup must be wrapped in try/except."
+
+
+def test_genuine_invalid_user_still_4401() -> None:
+    """A genuinely missing/inactive user must still close 4401 (correct behavior)."""
+    for src in (_read(CUSTOMER), _read(ADMIN)):
+        assert "WS_AUTH_USER_INACTIVE" in src and "close(code=4401)" in src, (
+            "D-WS-KICK-001: a genuinely None/inactive user must still close 4401 — "
+            "only *transient* lookup failures downgrade to 1013."
+        )

--- a/tests/services/test_ws_auth_001_bounded_retry.py
+++ b/tests/services/test_ws_auth_001_bounded_retry.py
@@ -17,11 +17,23 @@ THE FIX (D-WS-AUTH-001):
   3. logout() uses React state instead of window.location.reload() — preserves tree.
   4. Counter resets on successful reconnect — fresh cycle each new session.
 
+SUPERSEDED BY D-WS-KICK-001 (ISS-097 — 2026-05-29):
+  The *count-based* escalation (MAX_FATAL_RETRIES / FATAL_RETRY_DELAY_MS) was
+  itself the cause of an idle kick: a valid token could be logged out after a
+  few 4401 closes (e.g. a proxy dropping ?token= on reconnect) without ever
+  confirming the token was dead. D-WS-KICK-001 removes the count-based path:
+  the ONLY route to auth_error is an HTTP /me probe that definitively returns
+  401/403. A valid/unknown probe → retryTransientAuth() reconnects forever
+  (never logout). The /me probe + "no immediate logout" principle of
+  D-WS-AUTH-001 REMAIN and are strengthened; this test now asserts the evolved
+  invariants.
+
 This test verifies by static inspection:
-1. fatalRetries ref exists and is separate from `retries`.
-2. MAX_FATAL_RETRIES constant defined (3-5 range).
+1. fatalRetries ref exists (kept for diagnostics) and resets in onopen.
+2. The count-based escalation constants are REMOVED (D-WS-KICK-001).
 3. revalidateTokenViaHttp function exists and calls /api/security/user/me.
-4. FATAL_CODES handler does NOT immediately dispatch auth_error.
+4. FATAL_CODES handler does NOT immediately dispatch auth_error — it probes /me
+   and only escalates on a confirmed-invalid result.
 5. logout() does NOT call window.location.reload().
 6. fatalRetries.current resets in onopen.
 7. cleanup aborts in-flight revalidateAbortRef.
@@ -50,23 +62,29 @@ class TestBoundedFatalRetry:
             "fatalRetries must be a useRef initialized to 0."
         )
 
-    def test_max_fatal_retries_constant_bounded(self) -> None:
-        """Hard upper bound — prevents infinite reconnect loop even on positive probes."""
+    def test_count_based_escalation_removed(self) -> None:
+        """D-WS-KICK-001: the count-based escalation that caused the idle kick is GONE.
+
+        MAX_FATAL_RETRIES / FATAL_RETRY_DELAY_MS were the mechanism that logged
+        out a *valid* token after a few 4401 closes. A *count* of closes must
+        never trigger logout — only a confirmed-invalid /me probe.
+        """
         source = _read("frontend/app/hooks/useRealtimeConnection.js")
-        match = re.search(r"const\s+MAX_FATAL_RETRIES\s*=\s*(\d+)", source)
-        assert match, "MAX_FATAL_RETRIES constant must be defined"
-        max_retries = int(match.group(1))
-        assert 2 <= max_retries <= 5, (
-            f"MAX_FATAL_RETRIES must be 2-5 (got {max_retries}). "
-            "Lower → quick escalation. Higher → user waits too long."
+        assert not re.search(r"const\s+MAX_FATAL_RETRIES\s*=", source), (
+            "D-WS-KICK-001: MAX_FATAL_RETRIES constant must be removed — a count of "
+            "4401 closes must never escalate to logout."
+        )
+        assert not re.search(r"const\s+FATAL_RETRY_DELAY_MS\s*=", source), (
+            "D-WS-KICK-001: FATAL_RETRY_DELAY_MS constant must be removed (count-based path gone)."
         )
 
-    def test_fatal_retry_delay_short(self) -> None:
+    def test_transient_4401_reconnects_without_logout(self) -> None:
+        """D-WS-KICK-001: a valid/unknown probe reconnects via retryTransientAuth()."""
         source = _read("frontend/app/hooks/useRealtimeConnection.js")
-        match = re.search(r"const\s+FATAL_RETRY_DELAY_MS\s*=\s*(\d+)", source)
-        assert match
-        delay = int(match.group(1))
-        assert 1000 <= delay <= 5000, f"FATAL_RETRY_DELAY_MS must be 1000-5000ms (got {delay})."
+        assert "retryTransientAuth" in source, (
+            "D-WS-KICK-001: transient 4401 (valid/unknown token) must reconnect via "
+            "retryTransientAuth(), never escalate to auth_error."
+        )
 
 
 class TestHttpRevalidationProbe:
@@ -124,19 +142,26 @@ class TestNoImmediateAuthError:
         assert ws_close_section is not None
         body = ws_close_section.group(1)
 
-        # fatalRetries.current must be incremented
+        # fatalRetries.current is still incremented (kept for diagnostics/logging).
         assert re.search(r"fatalRetries\.current\s*\+=\s*1", body), (
-            "Handler must increment fatalRetries.current on each 4401."
+            "Handler should still track fatalRetries.current on each 4401 (diagnostics)."
         )
 
-        # Must check for max retries
-        assert "MAX_FATAL_RETRIES" in body, (
-            "Handler must check fatalRetries against MAX_FATAL_RETRIES."
-        )
-
-        # Must call revalidateTokenViaHttp
-        assert "revalidateTokenViaHttp" in body, (
+        # Must probe /me before any escalation. (Checked against the full source:
+        # D-WS-KICK-001 adds a nested `retryTransientAuth` arrow fn whose `};`
+        # truncates the non-greedy onclose-body regex above — so the probe call,
+        # which lives after that nested fn, is asserted at source scope.)
+        assert "revalidateTokenViaHttp" in source, (
             "Handler must probe /me before escalating to auth_error."
+        )
+
+        # D-WS-KICK-001: the ONLY auth_error path is a confirmed-invalid /me probe.
+        # The handler must NOT escalate based on a retry count.
+        assert "token_invalid_confirmed_via_http" in source, (
+            "D-WS-KICK-001: auth_error must be gated on an HTTP-confirmed-invalid token."
+        )
+        assert source.count('"agent:auth_error"') == 1, (
+            "D-WS-KICK-001: exactly one agent:auth_error dispatch site (the confirmed-invalid branch)."
         )
 
     def test_transient_auth_warning_event_emitted(self) -> None:

--- a/tests/services/test_ws_router_heartbeat_integration.py
+++ b/tests/services/test_ws_router_heartbeat_integration.py
@@ -43,8 +43,10 @@ class TestCustomerChatWiring:
         assert ws_section_match is not None, "chat_stream_ws function not found"
         ws_section = ws_section_match.group(0)
 
-        # تحقق من ترتيب الاستدعاءات داخل while-loop
-        handle_idx = ws_section.find("handle_control_message(websocket, payload)")
+        # تحقق من ترتيب الاستدعاءات داخل while-loop.
+        # D-096 أضاف وسيط send_lock للنداء (customer_chat فقط)، لذا نطابق البادئة
+        # بدون قوس الإغلاق حتى نتحمّل التوقيع المُطوَّر (2-arg أو 3-arg).
+        handle_idx = ws_section.find("handle_control_message(websocket, payload")
         question_idx = ws_section.find('payload.get("question"')
 
         assert handle_idx > 0, "handle_control_message call not found"
@@ -57,7 +59,10 @@ class TestCustomerChatWiring:
     def test_continue_after_control(self) -> None:
         source = _read_file("app/api/routers/customer_chat.py")
         # ابحث عن النمط المحدد: if await handle_control_message(...): continue
-        pattern = r"if\s+await\s+handle_control_message\(websocket,\s*payload\)\s*:\s*\n\s*continue"
+        # D-096: نسمح بوسائط إضافية (send_lock) قبل قوس الإغلاق عبر [^)]*.
+        pattern = (
+            r"if\s+await\s+handle_control_message\(websocket,\s*payload[^)]*\)\s*:\s*\n\s*continue"
+        )
         assert re.search(pattern, source), (
             "handle_control_message must be followed by `continue` to skip question processing."
         )

--- a/tests/services/test_ws_send_concurrency_lock.py
+++ b/tests/services/test_ws_send_concurrency_lock.py
@@ -30,7 +30,7 @@ import inspect
 import os
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 # Ensure imports work
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -81,8 +81,7 @@ def test_emit_terminal_frames_requires_send_lock() -> None:
     sig = inspect.signature(customer_chat._emit_terminal_frames)
     params = list(sig.parameters.keys())
     assert "send_lock" in params, (
-        f"D-096: `_emit_terminal_frames` does NOT accept send_lock. "
-        f"Got params: {params}."
+        f"D-096: `_emit_terminal_frames` does NOT accept send_lock. Got params: {params}."
     )
 
 
@@ -93,8 +92,7 @@ def test_handle_control_message_accepts_send_lock() -> None:
     sig = inspect.signature(handle_control_message)
     params = list(sig.parameters.keys())
     assert "send_lock" in params, (
-        f"D-096: `handle_control_message` does NOT accept send_lock. "
-        f"Got params: {params}."
+        f"D-096: `handle_control_message` does NOT accept send_lock. Got params: {params}."
     )
 
 
@@ -154,7 +152,8 @@ def test_evaluate_and_emit_bkt_uses_locked_send() -> None:
     # (well, the docstring may mention it — search for actual call pattern)
     lines = source.splitlines()
     code_lines = [
-        line for line in lines
+        line
+        for line in lines
         if not line.strip().startswith("#") and not line.strip().startswith('"')
     ]
     code_text = "\n".join(code_lines)


### PR DESCRIPTION
## The catastrophe

Users were ejected to the login screen and dropped into a blank **"new conversation"** — **even without asking any question** — despite D-095 (JWT lifetime) and D-096 (WS send-concurrency lock). Every prior fix tried to stop the *server* from emitting `4401`/closing; none made the *client* refuse to log out a session whose token is actually valid.

## Root cause (two independent halves)

1. **Spurious logout (the kick).** `useRealtimeConnection.js` fired `agent:auth_error` → `logout()` after a *count* of consecutive `4401` closes (`MAX_FATAL_RETRIES=3`) **without confirming the token was dead**. With `FATAL_RETRY_DELAY_MS=2000` that is a kick in ~6–8s — exactly "after a question or two", and it fires while **idle** too. The likely real trigger is the Codespaces/`server.js` proxy intermittently dropping the `?token=` query param on a WS reconnect → server sees no token → `4401` → repeat → kick. The kick is purely **connection-level** (which is why it happens with no questions — ruling out D-096/BKT/streaming).
2. **"New conversation" on every login.** `DashboardLayout` always mounted with `conversationId=null` + empty messages, so any (re)login landed in a blank chat.

## The fix (root-cause level, 3 parts)

- **A — Frontend (`useRealtimeConnection.js`):** `agent:auth_error` (→ logout) is now dispatched **only** when an HTTP `/me` probe **definitively** returns 401/403 (token truly dead). A valid/unreachable `/me` → `retryTransientAuth()` reconnects with exponential backoff (shared `retries` counter → eventual `offline`, never `auth_error`). Removed `MAX_FATAL_RETRIES`/`FATAL_RETRY_DELAY_MS` (the count-based escalation that caused the kick). Logout is now impossible while the token is valid, regardless of why the WS gets `4401`.
- **B — Frontend (`CogniForgeApp.jsx`):** restore the latest conversation on mount via `/api/chat/latest` (admin: `/admin/api/chat/latest`), guarded by a one-shot `didRestoreRef` so it never overwrites an explicit "new chat" or a sidebar pick.
- **C — Backend (`customer_chat.py` + `admin.py`):** when the token decodes fine but the DB user-lookup fails transiently, close with retryable **`1013`** (`WS_BACKEND_TRANSIENT`) instead of `4401`. A genuinely missing/inactive user still closes `4401` (correct).

## Permanent invariants (D-WS-KICK-001)

1. The only path to `agent:auth_error` is an HTTP `/me` that confirms 401/403. No close-count maps to logout.
2. `/me` (token via Authorization header) is the sole arbiter of session validity — immune to a proxy dropping `?token=` on the WS.
3. A transient WS user-lookup closes `1013`, not `4401`.
4. `DashboardLayout` restores the last conversation on load (guarded).

## Verification

- **Frontend kick-decision (faithful logic port, run live):** idle valid token with 12× / 35× `4401` → **0 logouts** (35× → declares `offline`, never `auth_error`); genuinely expired token (`/me` 401) → logout fires (correct). The **old** code reproduces the kick at the 4th `4401`.
- **Real JWT round-trip** (`decode_user_id` logic): valid 8h token decodes → `/me` 200 → no logout; expired/wrong-secret raise → `/me` 401 → correct logout.
- **Backend connect decision:** transient→`1013`, valid→accept, missing/inactive→`4401`.
- **Regression:** `tests/services/test_iss097_kick_to_login.py` — 7/7 source-level checks locking all three invariants.
- **Live end-to-end on Codespace:** `scripts/verify_iss097_live.py` (idle WS + heartbeat pong + reconnect storm + no-token reject + `/latest`). Full server boot is not possible in the deps-less CI sandbox (Postgres egress blocked); this script runs on the live Codespace.

## Files
- `frontend/app/hooks/useRealtimeConnection.js` (Fix A)
- `frontend/app/components/CogniForgeApp.jsx` (Fix B)
- `app/api/routers/customer_chat.py`, `app/api/routers/admin.py` (Fix C)
- `tests/services/test_iss097_kick_to_login.py` (new), `scripts/verify_iss097_live.py` (new)
- `CLAUDE.md` §6.72, `.memory/issues.md`, `.memory/decisions.md`

https://claude.ai/code/session_01UQfVjQwFmTjFTMEd4Zn7zN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQfVjQwFmTjFTMEd4Zn7zN)_