### PR TITLE
fix(ISS-107): Arabic stream guard + model-chain hygiene — end English/garbage answers

### DIFF
--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -3932,3 +3932,28 @@ MANDATORY in Codespaces (Postgres egress firewalled in the build sandbox).
 **Files Changed**
 - frontend/app/hooks/useAgentSocket.js (error + assistant_error handlers finalize the bubble)
 - frontend/tests/iss104_error_finalizes_message.test.mjs (new — 11 static guards + 10 scenarios)
+
+---
+
+## D-LANG-GUARD-001 (ISS-107) — حارس اللغة العربية على البثّ + تنظيف سلسلة النماذج (2026-06-02)
+
+**القرار:** كل مسار بثّ يُولِّد إجابة للطالب **يجب** أن يمرّ عبر `guard_arabic_stream`
+(`app/services/skills/arabic_stream_guard.py`). يُحظر بثّ `ai_client.stream_chat` خاماً.
+
+**الآلية:** نافذة أولى (~200 حرف) → فحص النثر بعد إزالة LaTeX (يتجنّب false positive على
+العربية المثقلة بالرياضيات؛ gpt-oss الصحيح نسبته الخام 0.57) → عربي: بثّ + تنظيف الرموز
+الملتصقة | إنجليزي/غارباج: إعادة توليد بـ prompt عربي صارم ثم رسالة عربية نظيفة (لا silent
+failure، لا إنجليزية تصل للطالب).
+
+**القواعد الدائمة (لا تُكسر بدون ADR):**
+1. مسارا البثّ في `local_graph` ملفوفان بالحارس — لا تُزِل اللفّ.
+2. كشف الإنجليزية يعتمد **النثر** لا النسبة الخام (LaTeX يضخّم اللاتينية).
+3. `simple_client._stream_model` يرفع عند content_chunks==0 → تقدّم للنموذج التالي.
+4. سلسلة `ai_config` تقتصر على نماذج عربية مُتحقَّقة حياً أو محميّة بالحُرّاس.
+   nemotron-super (إنجليزي)/glm-4.5-air (فارغ)/trinity (404) **محظورة** كـ fallback.
+5. `detect_explanation_with_context` يربط المتابعات («لم افهم»/«اشرح بالعربية»/«وضّح») بتمرين
+   السياق عبر `_is_followup_explanation_request` (تأثيره صفر بلا تمرين في التاريخ).
+
+**التحقق الحي (real OpenRouter 2026-06-02):** فرض nemotron-super (مُنتِج الإنجليزية) كـ PRIMARY
+→ الحارس كشف وأعاد التوليد → عربي نظيف. المسار المُصلَح: عربي على الموضوع. 23/23 + 123 regression
+خضراء. التحقق الكامل (Supabase + WS + المتصفح) إلزامي في Codespaces.

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -3803,3 +3803,66 @@ build sandbox, run the live end-to-end there with the real secrets + logins
 
 **Files:** `frontend/app/hooks/useAgentSocket.js` (error + assistant_error handlers),
 `frontend/tests/iss104_error_finalizes_message.test.mjs` (new, 21 checks).
+
+---
+
+## ISS-107 — أسئلة المتابعة تنهار: إنجليزية + انحراف للكيمياء + فقدان سياق التمرين (2026-06-02)
+
+**بلاغ المستخدم (تجريب حي):** بعد استدعاء تمرين الدوال العددية BAC 2016:
+- «لم افهم التكامل» → رد **بالإنجليزية** (تعريف مجاميع ريمان).
+- «اشرح بالعربية» → **هلوسة كيمياء مشوّهة** (روابط تساهمية، رمز ملتصق «أستاذochemistry»)
+  + فقدان كامل لسياق التمرين + تأخّر شديد.
+
+**الأسباب الجذرية (مُتحقَّق منها بالكود + بنشمارك حي بالمفتاح الحقيقي 2026-06-02):**
+- **RC-1**: صفر حارس لغة/جودة على مسار البثّ الحي. `run_local_graph_stream` و
+  `run_local_graph_with_exercise_context` تبثّان قطع `ai_client.stream_chat` الخام
+  (فقط `\x00` removal). الحُرّاس القدامى يعملون في `_chat_node` غير الانسيابي (كود ميت).
+- **RC-2 (المسبّب المباشر للإنجليزية — مُثبت حياً)**: سلسلة النماذج تنحدر عند ضغط
+  gpt-oss إلى: `nemotron-3-super-120b` → **إنجليزي في content** ("We need to respond
+  in Arabic..."), `glm-4.5-air` → **content فارغ** (reasoning-only), `trinity` → **404**.
+  و `simple_client.stream_chat` كان يعتبر content_chunks==0 نجاحاً (إجابة فارغة بدل التقدّم).
+- **RC-3**: `detect_explanation_with_context` يتطلب نمطاً صارماً؛ «لم افهم»/«اشرح بالعربية»
+  لا يطابقان `_BAC_EXERCISE_EXPLANATION_PATTERNS` → يسقطان للـ LLM العام → هلوسة كيمياء
+  (الـ prompt التعليمي يسرد الكيمياء كمادة).
+- **RC-4**: بطء النموذج — `gpt-oss-120b` = 86-115s، `gpt-oss-20b` = 51s (يفسّر «يتأخر كثيرا»).
+
+**بنشمارك حي (2026-06-02، المفتاح الحقيقي + الـ prompt الإنتاجي):**
+| نموذج | النتيجة | الزمن |
+|------|---------|------|
+| gpt-oss-120b (PRIMARY) | ✅ عربي | 86-115s |
+| gpt-oss-20b | ✅ عربي (ar خام 0.57 بسبب LaTeX) | 51s |
+| nemotron-3-super-120b | ❌ إنجليزي في content | 28s |
+| glm-4.5-air | ⚠️ content فارغ | 16s |
+| nemotron-nano-30b | ✅ عربي مع prompt قصير / فارغ مع prompt طويل | 2-3s |
+| trinity-large-thinking | ❌ 404 | — |
+
+**الإصلاح (شامل دائم):**
+1. **Skill جديد** `app/services/skills/arabic_stream_guard.py` — يلفّ مساري البثّ:
+   يخزّن نافذة أولى (~200 حرف)، يفحص **النثر** (بعد إزالة LaTeX — لتجنّب false positive على
+   العربية+LaTeX)، يكشف الإنجليزية/تسريب التفكير، يعيد التوليد بـ prompt عربي صارم، ثم
+   رسالة عربية نظيفة عند الفشل النهائي. يُنظّف الرموز الملتصقة («أستاذochemistry» → «أستاذ»).
+2. **`simple_client._stream_model`**: يرفع `ValueError` عند content_chunks==0 → `stream_chat`
+   يتقدّم للنموذج التالي بدل إرجاع فراغ.
+3. **`ai_config`**: السلسلة نُظِّفت — حُذف nemotron-super (إنجليزي)/glm (فارغ)/trinity (404)؛
+   أُضيف gemma-4/qwen3-next/kimi (محميّة بالحُرّاس) + nemotron-nano.
+4. **`exercise_retrieval`**: وُسِّعت بوّابة Phase-2 بـ `_is_followup_explanation_request`
+   (علامات حيرة + «اشرح»/«اشرح بالعربية»/«وضّح») → المتابعات تبقى مربوطة بتمرين السياق.
+
+**التحقق الحي (2026-06-02، real OpenRouter):**
+- Scenario A (المسار المُصلَح): ✅ عربي، على الموضوع (تكامل g(x))، 86s.
+- **Scenario B (إثبات الكارثة)**: فُرِض `nemotron-3-super-120b` (مُنتِج الإنجليزية) كـ PRIMARY
+  → سجل الحارس «first attempt non-Arabic — regenerating» → المخرَج **عربي نظيف** («التكامل
+  هو العملية العكسية للاشتقاق...»). **بق المستخدم صار مستحيلاً بنيوياً.**
+- 23/23 اختبار ISS-107 + 117 اختبار regression (iss075/iss079/exercise_retrieval/ai_models) +
+  6 gateway — كلها خضراء. ruff نظيف.
+
+**egress الـ sandbox:** OpenRouter ✅ / Tavily ✅ / Supabase Postgres 6543 **محجوب فعلياً**
+(TCP timeout — حقيقة شبكية). الـ E2E الكامل لمسار الإجابة جرى بـ SQLite + OpenRouter الحقيقي
+(محتوى التمرين من `knowledge_base/` لا من DB). **التحقق الكامل عبر المتصفح + Supabase + WS
+إلزامي في Codespaces الحقيقي** بالدخولين (`houssamannaba963@gmail.com`/`1111`،
+أدمن `benmerahhoussam16@gmail.com`/`1111`).
+
+**الملفات:** `app/services/skills/arabic_stream_guard.py` (جديد)، `app/services/chat/local_graph.py`،
+`app/core/gateway/simple_client.py`، `app/core/ai_config.py`،
+`app/services/capabilities/exercise_retrieval.py`، `app/services/skills/__init__.py`،
+`tests/services/test_iss107_{arabic_stream_guard,context_binding,model_chain}.py` (جديدة).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7723,3 +7723,42 @@ node frontend/tests/iss105_orphaned_streaming_message.test.mjs   # 9 ضمانا�
 |----------|---------|
 | D-WS-ORPHAN-001 | يتيم البثّ + كنس نهائي + MathText للمكوّنات |
 | **D-WS-CARD-PERSIST-001** | **حفظ بطاقات Generative UI عبر عمود ui_component → تبقى بعد الخروج/الدخول** |
+
+---
+
+## 6.82 Arabic Stream Guard + Model-Chain Hygiene — End of English/Garbage Answers (2026-06-02, ISS-107 / D-LANG-GUARD-001)
+
+> **بلاغ المستخدم (تجريب حي):** بعد تمرين BAC 2016، «لم افهم التكامل» → رد **بالإنجليزية**
+> (مجاميع ريمان)؛ «اشرح بالعربية» → **هلوسة كيمياء مشوّهة** («أستاذochemistry») + فقدان سياق + بطء.
+
+### الجذور (مُثبتة ببنشمارك حي على OpenRouter بالمفتاح الحقيقي 2026-06-02)
+- **RC-1**: صفر حارس لغة على مسار البثّ الحي — `run_local_graph_stream` و
+  `run_local_graph_with_exercise_context` تبثّان قطع `ai_client.stream_chat` الخام.
+- **RC-2 (مباشر)**: سلسلة fallback تنحدر إلى `nemotron-3-super-120b` (**إنجليزي في content**:
+  "We need to respond in Arabic...")، `glm-4.5-air` (**content فارغ** reasoning-only)،
+  `trinity-large-thinking` (**404**). و `stream_chat` كان يعدّ content==0 نجاحاً.
+- **RC-3**: «لم افهم»/«اشرح بالعربية» لا يطابقان أنماط الشرح الصارمة → LLM عام → هلوسة كيمياء.
+- **RC-4**: بطء (gpt-oss-120b 86-115s، gpt-oss-20b 51s) — يفسّر «يتأخر كثيرا».
+
+### الإصلاح
+1. **`arabic_stream_guard.py` (Skill جديد)** — يلفّ مساري البثّ: نافذة أولى ~200 حرف → فحص
+   **النثر بعد إزالة LaTeX** (gpt-oss الصحيح نسبته الخام 0.57 — لا false positive) → عربي: بثّ
+   + تنظيف الرموز الملتصقة | إنجليزي: إعادة توليد بـ prompt عربي صارم → رسالة عربية نظيفة.
+2. **`simple_client._stream_model`** يرفع عند `content_chunks==0` → `stream_chat` يتقدّم.
+3. **`ai_config`** السلسلة نُظِّفت (حُذف nemotron-super/glm/trinity).
+4. **`exercise_retrieval`** ربط المتابعات بتمرين السياق (`_is_followup_explanation_request`).
+
+### القواعد الدائمة (لا تُكسر بدون ADR)
+1. **كل مسار بثّ للطالب يمرّ عبر `guard_arabic_stream`** — ممنوع بثّ `stream_chat` خاماً.
+2. كشف الإنجليزية يعتمد **النثر** لا النسبة الخام (LaTeX يضخّم اللاتينية).
+3. `content_chunks==0` = فشل → تقدّم للنموذج التالي (لا «إجابة فارغة»).
+4. fallback يقتصر على نماذج عربية مُتحقَّقة أو محميّة؛ nemotron-super/glm-4.5-air/trinity **محظورة**.
+5. المتابعات («لم افهم»/«اشرح بالعربية»/«وضّح») تبقى مربوطة بتمرين السياق.
+
+### التحقق الحي (real OpenRouter 2026-06-02)
+- **Scenario B (إثبات الكارثة):** فُرِض `nemotron-3-super-120b` كـ PRIMARY → سجل الحارس
+  «first attempt non-Arabic — regenerating» → مخرَج **عربي نظيف**. بق المستخدم صار مستحيلاً بنيوياً.
+- 23/23 ISS-107 + 123 regression + 6 gateway خضراء؛ ruff نظيف.
+- **egress:** OpenRouter ✅/Tavily ✅/**Supabase 6543 محجوب** في الـ sandbox → E2E مسار الإجابة
+  بـ SQLite + OpenRouter الحقيقي. **التحقق الكامل (Supabase + WS + المتصفح) إلزامي في Codespaces**
+  بالدخولين (`houssamannaba963@gmail.com`/`1111`، أدمن `benmerahhoussam16@gmail.com`/`1111`).

--- a/app/core/ai_config.py
+++ b/app/core/ai_config.py
@@ -135,11 +135,20 @@ class ActiveModels:
     PRIMARY = _resolve_primary_model("openai/gpt-oss-120b:free")
     LOW_COST = PRIMARY
     GATEWAY_PRIMARY = PRIMARY
-    GATEWAY_FALLBACK_1 = "openai/gpt-oss-20b:free"  # demoted from PRIMARY 2026-05-27 (ISS-082)
-    GATEWAY_FALLBACK_2 = "nvidia/nemotron-3-super-120b-a12b:free"  # verified live 2026-05-27
-    GATEWAY_FALLBACK_3 = "z-ai/glm-4.5-air:free"  # verified live 2026-05-27
-    GATEWAY_FALLBACK_4 = "nvidia/nemotron-3-nano-30b-a3b:free"  # works on short prompts
-    GATEWAY_FALLBACK_5 = "arcee-ai/trinity-large-thinking:free"
+    # ISS-107 (2026-06-02): بنشمارك حي بالمفتاح الحقيقي + الـ system prompt الإنتاجي
+    # كشف أن السلسلة القديمة تنحدر إلى نماذج كارثية عند ضغط gpt-oss:
+    #   ❌ nvidia/nemotron-3-super-120b → "We need to respond in Arabic..." (إنجليزي في content)
+    #   ❌ z-ai/glm-4.5-air → content فارغ (reasoning-only)
+    #   ❌ arcee-ai/trinity-large-thinking → HTTP 404 (غير موجود)
+    # ✅ verified Arabic content (full prompt): gpt-oss-120b، gpt-oss-20b.
+    # nemotron-nano: عربي سريع مع prompt قصير، لكن reasoning-only مع prompt طويل (D-067)
+    #   — آمن الآن بفضل guard "content_chunks==0 → advance" + Arabic stream guard (ISS-107).
+    # gemma-4/qwen3-next/kimi: نماذج instruct كبيرة (429 وقت البنشمارك)، محميّة بالحُرّاس.
+    GATEWAY_FALLBACK_1 = "openai/gpt-oss-20b:free"  # ✅ Arabic content (live 2026-06-02)
+    GATEWAY_FALLBACK_2 = "nvidia/nemotron-3-nano-30b-a3b:free"  # سريع؛ محميّ بـ content==0 guard
+    GATEWAY_FALLBACK_3 = "google/gemma-4-26b-a4b-it:free"  # Gemma — عربي قوي؛ محميّ بالحُرّاس
+    GATEWAY_FALLBACK_4 = "qwen/qwen3-next-80b-a3b-instruct:free"  # instruct كبير؛ محميّ بالحُرّاس
+    GATEWAY_FALLBACK_5 = "moonshotai/kimi-k2.6:free"  # احتياطي أخير كبير؛ محميّ بالحُرّاس
     TIER_NANO = PRIMARY
     TIER_FAST = PRIMARY
     TIER_SMART = PRIMARY

--- a/app/core/gateway/simple_client.py
+++ b/app/core/gateway/simple_client.py
@@ -209,6 +209,17 @@ class OpenRouterClient(LLMClient):
                         reasoning_chunks,
                     )
 
+                # ISS-107 (D-WS-LANG-GUARD): نموذج لم يُنتج أي content حقيقي
+                # (reasoning-only مثل glm-4.5-air، أو فراغ تام) يُعَدّ فشلاً —
+                # نرفع استثناءً ليتقدّم stream_chat للنموذج التالي بدل إرجاع
+                # إجابة فارغة («لا يجيب»). آمن: كل ما بُثّ كان content=None
+                # (المستهلك يتخطّاه)، فلا غارباج وصل للطالب.
+                if content_chunks == 0:
+                    raise ValueError(
+                        f"empty_completion model={model_id} "
+                        f"(content_chunks=0 reasoning_chunks={reasoning_chunks})"
+                    )
+
         except httpx.StreamError as e:
             raise httpx.ConnectError(f"Stream error: {e}") from e
 

--- a/app/services/capabilities/exercise_retrieval.py
+++ b/app/services/capabilities/exercise_retrieval.py
@@ -826,6 +826,44 @@ def _detect_entry_from_history(
     return _find_matching_entry(recent_text)
 
 
+# ISS-107: علامات متابعة قصيرة/حيرة تُبقي السؤال مربوطاً بتمرين السياق.
+# «لم افهم التكامل» و«اشرح بالعربية» لا يطابقان _BAC_EXERCISE_EXPLANATION_PATTERNS
+# (لا «اشرح» مجرّدة، ولا علامات الحيرة) → كانا يسقطان للـ LLM العام → هلوسة كيمياء.
+# هذه المجموعة تُفعِّل Phase-2 (المعتمد على التاريخ) فقط — تأثيرها صفر بلا تمرين
+# في السياق (`_detect_entry_from_history` يُرجع None فيسقط للمسار العام).
+_FOLLOWUP_EXPLANATION_MARKERS: tuple[str, ...] = (
+    "لم افهم",
+    "لم أفهم",
+    "ما فهمت",
+    "مافهمت",
+    "مفهمتش",
+    "ما فهمتش",
+    "كيفاش",
+    "وضّح",
+    "وضح",
+    "اشرح",
+    "إشرح",
+    "اشرحلي",
+    "فسّر",
+    "فسر",
+    "بسّط",
+    "بسط",
+    "بالعربية",
+    "اعد الشرح",
+    "أعد الشرح",
+    "اعد شرح",
+    "explain",
+    "i don't understand",
+    "didn't understand",
+    "in arabic",
+)
+
+
+def _is_followup_explanation_request(normalized: str) -> bool:
+    """يكشف متابعة شرح/حيرة قصيرة تستحق ربطها بتمرين السياق (ISS-107)."""
+    return any(m in normalized for m in _FOLLOWUP_EXPLANATION_MARKERS)
+
+
 def detect_explanation_with_context(
     request: ExerciseRetrievalRequest,
     history_messages: list[dict[str, str]] | None = None,
@@ -856,8 +894,11 @@ def detect_explanation_with_context(
         matched_entry = _find_matching_entry(normalized)
         reason_used = "bac_explanation_with_context"
 
-    # المرحلة 2 (ISS-058): استفسار مفاهيمي + سياق محادثة عن تمرين بكالوريا
-    if matched_entry is None and has_explanation_pattern:
+    # المرحلة 2 (ISS-058 + ISS-107): استفسار مفاهيمي/حيرة/متابعة قصيرة + سياق محادثة
+    # عن تمرين بكالوريا. وُسِّعت البوّابة لتشمل علامات المتابعة («لم افهم»، «اشرح
+    # بالعربية»، «وضّح») لأن «اشرح بالعربية» لا يطابق الأنماط الصارمة → كان يهلوس.
+    is_followup = has_explanation_pattern or _is_followup_explanation_request(normalized)
+    if matched_entry is None and is_followup:
         context_entry = _detect_entry_from_history(history_messages)
         if context_entry is not None:
             matched_entry = context_entry
@@ -867,7 +908,7 @@ def detect_explanation_with_context(
         return ExplanationWithContextDecision(
             recognized=False,
             reason="no_bac_explanation_pattern"
-            if not has_explanation_pattern
+            if not is_followup
             else "no_matching_entry_or_context",
         )
 

--- a/app/services/chat/local_graph.py
+++ b/app/services/chat/local_graph.py
@@ -1041,25 +1041,16 @@ async def run_local_graph_stream(
     chunk_count = 0
     total_chars = 0
     try:
-        async for raw_chunk in ai_client.stream_chat(messages):
-            # raw_chunk: OpenRouter SSE delta — نستخرج فقط محتوى المساعد
-            try:
-                choices = raw_chunk.get("choices") if isinstance(raw_chunk, dict) else None
-                if not choices:
-                    continue
-                delta = choices[0].get("delta", {}) or {}
-                content = delta.get("content")
-                if not content or not isinstance(content, str):
-                    continue
-                clean = content.replace("\x00", "")
-                if not clean:
-                    continue
-                chunk_count += 1
-                total_chars += len(clean)
-                yield clean
-            except Exception:
-                # قطعة واحدة سيئة لا تكسر التيار
+        # ISS-107: حارس اللغة العربية + إعادة توليد + تنظيف الرموز الملتصقة.
+        # لا نبثّ ai_client.stream_chat خاماً للطالب أبداً (الإنجليزية/الغارباج محظورة).
+        from app.services.skills.arabic_stream_guard import guard_arabic_stream
+
+        async for clean in guard_arabic_stream(ai_client, messages):
+            if not clean:
                 continue
+            chunk_count += 1
+            total_chars += len(clean)
+            yield clean
     except Exception:
         logger.warning("local_graph.stream_failed intent=%s", intent, exc_info=True)
         if obs is not None and span_ctx is not None:
@@ -1466,23 +1457,15 @@ async def run_local_graph_with_exercise_context(
     try:
         # ISS-059 (D-053): max_tokens ديناميكي حسب نوع السؤال
         # CONCEPT=350 | JUSTIFICATION=450 | METHOD=600 | DEFAULT=700 | FULL=900
-        async for raw_chunk in ai_client.stream_chat(messages, max_tokens=token_budget):
-            try:
-                choices = raw_chunk.get("choices") if isinstance(raw_chunk, dict) else None
-                if not choices:
-                    continue
-                delta = choices[0].get("delta", {}) or {}
-                content = delta.get("content")
-                if not content or not isinstance(content, str):
-                    continue
-                clean = content.replace("\x00", "")
-                if not clean:
-                    continue
-                chunk_count += 1
-                total_chars += len(clean)
-                yield clean
-            except Exception:
+        # ISS-107: حارس اللغة العربية على شرح التمرين أيضاً (لا إنجليزية/غارباج).
+        from app.services.skills.arabic_stream_guard import guard_arabic_stream
+
+        async for clean in guard_arabic_stream(ai_client, messages, max_tokens=token_budget):
+            if not clean:
                 continue
+            chunk_count += 1
+            total_chars += len(clean)
+            yield clean
     except Exception:
         logger.warning("local_graph.exercise_explanation_stream_failed", exc_info=True)
         if obs is not None and span_ctx is not None:

--- a/app/services/skills/__init__.py
+++ b/app/services/skills/__init__.py
@@ -48,6 +48,12 @@ from app.services.skills.answer_quality_skill import (
     QualityIssue,
     get_answer_quality_skill,
 )
+from app.services.skills.arabic_stream_guard import (
+    arabic_prose_ratio,
+    guard_arabic_stream,
+    is_probably_non_arabic,
+    sanitize_stream_chunk,
+)
 from app.services.skills.bac_exercise_skill import (
     BACExerciseSkill,
     BACSkillExplanationOutput,
@@ -203,6 +209,7 @@ __all__ = [
     "TopicLockInput",
     "TopicLockOutput",
     "apply_channel_b_firewall",
+    "arabic_prose_ratio",
     "build_exercise_explanation_prompt",
     "get_answer_quality_skill",
     "get_bkt_cognitive_summary",
@@ -219,5 +226,8 @@ __all__ = [
     "get_skill_invocation_protocol_summary",
     "get_step_by_step_summary",
     "get_topic_lock",
+    "guard_arabic_stream",
+    "is_probably_non_arabic",
     "list_all_doctrines",
+    "sanitize_stream_chunk",
 ]

--- a/app/services/skills/arabic_stream_guard.py
+++ b/app/services/skills/arabic_stream_guard.py
@@ -28,28 +28,53 @@ import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from prometheus_client import CollectorRegistry, Counter
-
 logger = logging.getLogger("cogniforge.skills.arabic_stream_guard")
 
-# ─── مقاييس Prometheus (registry مستقل لكل skill — §6 doctrine) ────────────────
-_REGISTRY = CollectorRegistry()
-_GUARD_CHECKS = Counter(
-    "cogniforge_skill_lang_guard_checks_total",
-    "عدد فحوصات نافذة اللغة على البثّ الحي",
-    ["result"],  # arabic | rejected
-    registry=_REGISTRY,
-)
-_GUARD_REGEN = Counter(
-    "cogniforge_skill_lang_guard_regenerations_total",
-    "عدد إعادات التوليد بعد رفض النافذة الأولى",
-    registry=_REGISTRY,
-)
-_GUARD_FALLBACK = Counter(
-    "cogniforge_skill_lang_guard_fallback_total",
-    "عدد مرّات إصدار الرسالة العربية النظيفة بعد فشل إعادة التوليد",
-    registry=_REGISTRY,
-)
+# ─── مقاييس Prometheus — استيراد دفاعي (registry مستقل لكل skill — §6 doctrine) ──
+# نمط الكود: لا يجوز أن يفشل استيراد الـ skill بسبب غياب prometheus_client
+# (بوّابات CI minimal-deps تستورد الحزمة عبر __init__ بدون prometheus).
+try:
+    from prometheus_client import CollectorRegistry, Counter
+
+    _REGISTRY = CollectorRegistry()
+    _GUARD_CHECKS = Counter(
+        "cogniforge_skill_lang_guard_checks_total",
+        "عدد فحوصات نافذة اللغة على البثّ الحي",
+        ["result"],  # arabic | rejected
+        registry=_REGISTRY,
+    )
+    _GUARD_REGEN = Counter(
+        "cogniforge_skill_lang_guard_regenerations_total",
+        "عدد إعادات التوليد بعد رفض النافذة الأولى",
+        registry=_REGISTRY,
+    )
+    _GUARD_FALLBACK = Counter(
+        "cogniforge_skill_lang_guard_fallback_total",
+        "عدد مرّات إصدار الرسالة العربية النظيفة بعد فشل إعادة التوليد",
+        registry=_REGISTRY,
+    )
+    _METRICS_AVAILABLE = True
+except ImportError:
+    _METRICS_AVAILABLE = False
+
+
+def _record_check(result: str) -> None:
+    """يُسجِّل نتيجة فحص نافذة اللغة (arabic | rejected)."""
+    if _METRICS_AVAILABLE:
+        _GUARD_CHECKS.labels(result=result).inc()
+
+
+def _record_regen() -> None:
+    """يُسجِّل إعادة توليد بعد رفض النافذة الأولى."""
+    if _METRICS_AVAILABLE:
+        _GUARD_REGEN.inc()
+
+
+def _record_fallback() -> None:
+    """يُسجِّل إصدار الرسالة العربية النظيفة بعد فشل كل المحاولات."""
+    if _METRICS_AVAILABLE:
+        _GUARD_FALLBACK.inc()
+
 
 # ─── ثوابت ────────────────────────────────────────────────────────────────────
 _WINDOW_CHARS = 200
@@ -216,10 +241,10 @@ async def _guarded_attempt(
             if buf_len >= _WINDOW_CHARS:
                 window = "".join(buf)
                 if is_probably_non_arabic(window):
-                    _GUARD_CHECKS.labels(result="rejected").inc()
+                    _record_check("rejected")
                     yield ("reject", "")
                     return
-                _GUARD_CHECKS.labels(result="arabic").inc()
+                _record_check("arabic")
                 decided = True
                 cleaned = sanitize_stream_chunk(window)
                 if cleaned:
@@ -233,10 +258,10 @@ async def _guarded_attempt(
     if not decided and buf:
         window = "".join(buf)
         if is_probably_non_arabic(window):
-            _GUARD_CHECKS.labels(result="rejected").inc()
+            _record_check("rejected")
             yield ("reject", "")
             return
-        _GUARD_CHECKS.labels(result="arabic").inc()
+        _record_check("arabic")
         cleaned = sanitize_stream_chunk(window)
         if cleaned:
             yield ("chunk", cleaned)
@@ -268,7 +293,7 @@ async def guard_arabic_stream(
         return
 
     # المحاولة الأولى رُفضت (نافذة إنجليزية/غارباج) — أعِد التوليد بـ prompt عربي صارم
-    _GUARD_REGEN.inc()
+    _record_regen()
     logger.warning("arabic_stream_guard: first attempt non-Arabic — regenerating (strict)")
     non_system = [m for m in messages if m.get("role") != "system"]
     strict_messages = [{"role": "system", "content": _STRICT_ARABIC_PROMPT}, *non_system]
@@ -282,6 +307,6 @@ async def guard_arabic_stream(
         return
 
     # فشل كل شيء → رسالة عربية نظيفة بدل الغارباج (لا silent failure)
-    _GUARD_FALLBACK.inc()
+    _record_fallback()
     logger.error("arabic_stream_guard: regeneration also non-Arabic — emitting clean fallback")
     yield _ARABIC_FALLBACK_MESSAGE

--- a/app/services/skills/arabic_stream_guard.py
+++ b/app/services/skills/arabic_stream_guard.py
@@ -1,0 +1,287 @@
+"""ArabicStreamGuard — حارس اللغة العربية على البثّ الحي (ISS-107).
+
+المشكلة (تجريب حي 2026-06-02):
+    سلسلة النماذج الاحتياطية تنحدر عند ضغط gpt-oss إلى نماذج تُخرِج إنجليزية
+    في حقل ``content`` (مثل ``nemotron-3-super-120b`` → "We need to respond in
+    Arabic...") أو فراغاً (reasoning-only مثل ``glm-4.5-air``). مسار البثّ الحي
+    في ``local_graph.run_local_graph_stream`` و ``run_local_graph_with_exercise_context``
+    كان يبثّ هذه القطع الخام **بلا أي فحص لغة** → الطالب يرى الإنجليزية/الغارباج.
+
+الحل (هذا الـ Skill — يحترم §0.5 و D-047):
+    1. نخزّن **نافذة أولى صغيرة فقط** (~200 حرف) دون إصدار.
+    2. نفحص اللغة على **النثر** (بعد إزالة LaTeX/الرياضيات — لأن LaTeX يضخّم اللاتينية
+       فيُسيء تصنيف العربية الصحيحة؛ gpt-oss-20b الصحيح كان نسبته الخام 0.57).
+    3. عربية → أصدِر النافذة ثم تابع البثّ، مع تنظيف كل قطعة (حذف الرموز الملتصقة
+       «أستاذochemistry» → «أستاذ» + Cyrillic/CJK).
+    4. إنجليزي/غارباج → **لا تُصدِر النافذة**؛ أعِد التوليد مرّة بـ system prompt
+       عربي صارم (سلسلة النماذج كاملة من جديد). إن فشل ثانيةً → أصدِر رسالة عربية
+       نظيفة بدل الغارباج (لا silent failure، لا إنجليزية تصل للطالب).
+
+القاعدة الدائمة (ISS-107): أي مسار بثّ يُولِّد إجابة للطالب يجب أن يمرّ عبر
+``guard_arabic_stream``. لا تبثّ ``ai_client.stream_chat`` خاماً للطالب أبداً.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from prometheus_client import CollectorRegistry, Counter
+
+logger = logging.getLogger("cogniforge.skills.arabic_stream_guard")
+
+# ─── مقاييس Prometheus (registry مستقل لكل skill — §6 doctrine) ────────────────
+_REGISTRY = CollectorRegistry()
+_GUARD_CHECKS = Counter(
+    "cogniforge_skill_lang_guard_checks_total",
+    "عدد فحوصات نافذة اللغة على البثّ الحي",
+    ["result"],  # arabic | rejected
+    registry=_REGISTRY,
+)
+_GUARD_REGEN = Counter(
+    "cogniforge_skill_lang_guard_regenerations_total",
+    "عدد إعادات التوليد بعد رفض النافذة الأولى",
+    registry=_REGISTRY,
+)
+_GUARD_FALLBACK = Counter(
+    "cogniforge_skill_lang_guard_fallback_total",
+    "عدد مرّات إصدار الرسالة العربية النظيفة بعد فشل إعادة التوليد",
+    registry=_REGISTRY,
+)
+
+# ─── ثوابت ────────────────────────────────────────────────────────────────────
+_WINDOW_CHARS = 200
+"""حجم النافذة الأولى المُخزَّنة قبل قرار اللغة (~< 1s زمن أول-قطعة)."""
+
+_ARABIC_RANGE = ("؀", "ۿ")  # كتلة العربية الأساسية
+
+# system prompt عربي صارم لإعادة التوليد (< 1000 حرف — D-067، بلا box-drawing)
+_STRICT_ARABIC_PROMPT = (
+    "أنت أستاذ بكالوريا جزائري. أجب بالعربية الفصحى فقط.\n"
+    "ممنوع منعاً باتاً: أي كلمة إنجليزية أو تفكير بصوت عالٍ (مثل We need / The user / Okay).\n"
+    "ابدأ الإجابة مباشرة بالعربية ضمن سياق سؤال الطالب الحالي. لا تُغيّر الموضوع.\n"
+    "استخدم LaTeX للرياضيات فقط: $$...$$ للمعادلات و \\(...\\) للرموز."
+)
+
+# رسالة عربية نظيفة عند فشل كل المحاولات (بدل الغارباج)
+_ARABIC_FALLBACK_MESSAGE = (
+    "عذراً، تعذّر توليد إجابة سليمة بالعربية في هذه اللحظة. "
+    "يرجى إعادة صياغة سؤالك أو المحاولة مرة أخرى."
+)
+
+# كلمات إنجليزية شائعة في تسريب التفكير/الهلوسة (إشارة قوية على الإنجليزية)
+_ENGLISH_SIGNAL_WORDS = frozenset(
+    {
+        "the",
+        "we",
+        "need",
+        "to",
+        "is",
+        "of",
+        "and",
+        "a",
+        "in",
+        "this",
+        "that",
+        "user",
+        "respond",
+        "explain",
+        "explaining",
+        "something",
+        "says",
+        "want",
+        "function",
+        "integral",
+        "sum",
+        "area",
+        "let",
+        "us",
+        "so",
+        "therefore",
+        "first",
+        "okay",
+        "alright",
+        "should",
+        "must",
+        "will",
+        "here",
+        "what",
+        "covalent",
+        "chemistry",
+        "bond",
+        "bonds",
+        "riemann",
+        "limit",
+    }
+)
+
+# ─── أنماط تنظيف ──────────────────────────────────────────────────────────────
+# LaTeX/رياضيات تُزال قبل حساب نسبة اللغة (LaTeX يضخّم اللاتينية)
+_LATEX_BLOCK = re.compile(r"\$\$.*?\$\$|\$[^$\n]*\$|\\\(.*?\\\)|\\\[.*?\\\]", re.DOTALL)
+_LATEX_CMD = re.compile(r"\\[a-zA-Z]+")
+_MATH_NOISE = re.compile(r"[{}^_\\=+\-*/<>|~`\[\]()]|[0-9]+")
+# كتل غير لاتينية/عربية تُحذف من القطع المبثوثة
+_FOREIGN_BLOCKS = re.compile(r"[Ѐ-ӿ一-鿿぀-ヿㇰ-ㇿ]+")
+# لاتيني ملتصق مباشرةً بحرف عربي (الرمز المشوّه «أستاذochemistry» → «أستاذ»)
+_GLUED_LATIN = re.compile(r"(?<=[؀-ۿ])[A-Za-z]{2,}")
+_ENGLISH_WORD = re.compile(r"[A-Za-z]{2,}")
+
+
+def _strip_math(text: str) -> str:
+    """يزيل LaTeX والرياضيات لعزل النثر اللغوي فقط."""
+    t = _LATEX_BLOCK.sub(" ", text)
+    t = _LATEX_CMD.sub(" ", t)
+    return _MATH_NOISE.sub(" ", t)
+
+
+def arabic_prose_ratio(text: str) -> float:
+    """نسبة الأحرف العربية إلى (العربية + اللاتينية) في النثر بعد إزالة الرياضيات.
+
+    يُعيد 1.0 عند غياب أحرف أبجدية (نص رياضي بحت) — يُعامَل كعربي-آمن.
+    """
+    prose = _strip_math(text)
+    ar = sum(1 for c in prose if _ARABIC_RANGE[0] <= c <= _ARABIC_RANGE[1])
+    la = sum(1 for c in prose if ("a" <= c <= "z") or ("A" <= c <= "Z"))
+    total = ar + la
+    return (ar / total) if total else 1.0
+
+
+def is_probably_non_arabic(window: str) -> bool:
+    """يقرّر إن كانت النافذة الأولى إنجليزية/غارباج (يجب رفضها وإعادة التوليد).
+
+    منطق مزدوج (يتجنّب إساءة تصنيف العربية المثقلة بـ LaTeX — gpt-oss الصحيح ar≈0.57 خام):
+      - بعد إزالة LaTeX: نسبة العربية < 0.35 → إنجليزي.
+      - أو: ≥ 3 كلمات إنجليزية إشاريّة (We/need/user/...) ونسبة العربية < 0.7 → تسريب تفكير.
+    """
+    if not window or not window.strip():
+        return False
+    ratio = arabic_prose_ratio(window)
+    if ratio < 0.35:
+        return True
+    prose = _strip_math(window)
+    english_hits = sum(
+        1 for w in _ENGLISH_WORD.findall(prose) if w.lower() in _ENGLISH_SIGNAL_WORDS
+    )
+    return english_hits >= 3 and ratio < 0.7
+
+
+def sanitize_stream_chunk(text: str) -> str:
+    """ينظّف قطعة مبثوثة: يحذف الكتل الأجنبية والرموز الملتصقة بالعربية.
+
+    «أستاذochemistry» → «أستاذ» | روسي/صيني/ياباني → محذوف.
+    لا يلمس LaTeX («f(x)» المسبوقة بمسافة تبقى) ولا العربية النقية.
+    """
+    if not text:
+        return text
+    out = _FOREIGN_BLOCKS.sub("", text)
+    return _GLUED_LATIN.sub("", out)
+
+
+def _extract_delta_content(raw_chunk: Any) -> str:
+    """يستخرج ``delta.content`` من قطعة OpenRouter SSE (يتجاهل reasoning)."""
+    if not isinstance(raw_chunk, dict):
+        return ""
+    choices = raw_chunk.get("choices")
+    if not choices:
+        return ""
+    delta = choices[0].get("delta", {}) or {}
+    content = delta.get("content")
+    if not content or not isinstance(content, str):
+        return ""
+    return content.replace("\x00", "")
+
+
+async def _guarded_attempt(
+    ai_client: Any,
+    messages: list[dict[str, str]],
+    max_tokens: int | None,
+) -> AsyncGenerator[tuple[str, str], None]:
+    """محاولة واحدة: يخزّن النافذة، يقرّر، ثم يبثّ (chunk) أو يرفض (reject).
+
+    Yields:
+        ("chunk", نص نظيف) أو ("reject", "") — الرفض يعني لم يُبثّ شيء بعد.
+    """
+    buf: list[str] = []
+    buf_len = 0
+    decided = False
+    async for raw in ai_client.stream_chat(messages, max_tokens=max_tokens):
+        content = _extract_delta_content(raw)
+        if not content:
+            continue
+        if not decided:
+            buf.append(content)
+            buf_len += len(content)
+            if buf_len >= _WINDOW_CHARS:
+                window = "".join(buf)
+                if is_probably_non_arabic(window):
+                    _GUARD_CHECKS.labels(result="rejected").inc()
+                    yield ("reject", "")
+                    return
+                _GUARD_CHECKS.labels(result="arabic").inc()
+                decided = True
+                cleaned = sanitize_stream_chunk(window)
+                if cleaned:
+                    yield ("chunk", cleaned)
+                buf = []
+            continue
+        cleaned = sanitize_stream_chunk(content)
+        if cleaned:
+            yield ("chunk", cleaned)
+    # انتهى التيار قبل امتلاء النافذة
+    if not decided and buf:
+        window = "".join(buf)
+        if is_probably_non_arabic(window):
+            _GUARD_CHECKS.labels(result="rejected").inc()
+            yield ("reject", "")
+            return
+        _GUARD_CHECKS.labels(result="arabic").inc()
+        cleaned = sanitize_stream_chunk(window)
+        if cleaned:
+            yield ("chunk", cleaned)
+
+
+async def guard_arabic_stream(
+    ai_client: Any,
+    messages: list[dict[str, str]],
+    max_tokens: int | None = None,
+) -> AsyncGenerator[str, None]:
+    """يلفّ ``ai_client.stream_chat`` بحارس لغة عربية + إعادة توليد عند الفشل.
+
+    Args:
+        ai_client: عميل الـ gateway (``OpenRouterClient``) — يملك ``stream_chat``.
+        messages: [{"role":"system",...},{"role":"user",...}] كما يبنيها local_graph.
+        max_tokens: حدّ الرموز (يُمرَّر كما هو).
+
+    Yields:
+        str: قطع نص عربية نظيفة جاهزة للبثّ للطالب.
+    """
+    emitted = False
+    async for kind, payload in _guarded_attempt(ai_client, messages, max_tokens):
+        if kind == "chunk":
+            emitted = True
+            yield payload
+        elif kind == "reject":
+            break
+    if emitted:
+        return
+
+    # المحاولة الأولى رُفضت (نافذة إنجليزية/غارباج) — أعِد التوليد بـ prompt عربي صارم
+    _GUARD_REGEN.inc()
+    logger.warning("arabic_stream_guard: first attempt non-Arabic — regenerating (strict)")
+    non_system = [m for m in messages if m.get("role") != "system"]
+    strict_messages = [{"role": "system", "content": _STRICT_ARABIC_PROMPT}, *non_system]
+    async for kind, payload in _guarded_attempt(ai_client, strict_messages, max_tokens):
+        if kind == "chunk":
+            emitted = True
+            yield payload
+        elif kind == "reject":
+            break
+    if emitted:
+        return
+
+    # فشل كل شيء → رسالة عربية نظيفة بدل الغارباج (لا silent failure)
+    _GUARD_FALLBACK.inc()
+    logger.error("arabic_stream_guard: regeneration also non-Arabic — emitting clean fallback")
+    yield _ARABIC_FALLBACK_MESSAGE

--- a/tests/services/test_iss107_arabic_stream_guard.py
+++ b/tests/services/test_iss107_arabic_stream_guard.py
@@ -1,0 +1,121 @@
+"""ISS-107 — اختبارات حارس اللغة العربية على البثّ الحي.
+
+يثبت أن الحارس:
+- يكشف الإنجليزية/تسريب التفكير (nemotron-super) ويرفضها.
+- يمرّر العربية الصحيحة المثقلة بـ LaTeX (gpt-oss ar≈0.57 خام — لا false positive).
+- يُنظّف الرموز الملتصقة («أستاذochemistry» → «أستاذ») والكتل الأجنبية.
+- يعيد التوليد عند رفض النافذة، ويُصدِر رسالة عربية نظيفة عند فشل كل المحاولات.
+"""
+
+import pytest
+
+from app.services.skills.arabic_stream_guard import (
+    _ARABIC_FALLBACK_MESSAGE,
+    arabic_prose_ratio,
+    guard_arabic_stream,
+    is_probably_non_arabic,
+    sanitize_stream_chunk,
+)
+
+
+class TestDetection:
+    def test_english_thinking_leak_rejected(self):
+        # عيّنة حية من nemotron-3-super-120b (2026-06-02)
+        t = 'We need to respond in Arabic, explaining something. The user says: "اشرح بالعربية".'
+        assert is_probably_non_arabic(t) is True
+
+    def test_english_riemann_rejected(self):
+        t = "The integral is defined as the limit of the Riemann sums when the mesh tends to zero."
+        assert is_probably_non_arabic(t) is True
+
+    def test_arabic_with_heavy_latex_passes(self):
+        # عيّنة حية من gpt-oss-20b — عربية صحيحة لكن نسبتها الخام 0.57 بسبب LaTeX
+        t = (
+            "## لماذا نحتاج إلى التكامل؟\n\nعند دراسة الدوال العددية نريد معرفة المساحة "
+            "تحت المنحنى $$\\int_0^\\lambda h(x)\\,dx$$ حيث \\(h(x)=x+f(x)\\)"
+        )
+        assert arabic_prose_ratio(t) >= 0.9  # بعد إزالة LaTeX
+        assert is_probably_non_arabic(t) is False
+
+    def test_pure_math_no_prose_passes(self):
+        assert is_probably_non_arabic("$$f'(x) = 2x e^{3x} + 3x^2 e^{3x}$$") is False
+
+    def test_pure_arabic_passes(self):
+        assert is_probably_non_arabic("مرحباً، سأشرح لك الفكرة بالعربية خطوة بخطوة.") is False
+
+    def test_empty_not_flagged(self):
+        assert is_probably_non_arabic("") is False
+        assert is_probably_non_arabic("   ") is False
+
+
+class TestSanitize:
+    def test_glued_latin_stripped(self):
+        assert sanitize_stream_chunk("أستاذochemistry في") == "أستاذ في"
+
+    def test_spaced_latin_preserved(self):
+        # f(x) مسبوقة بمسافة = ليست ملتصقة → تبقى
+        assert "f(x)" in sanitize_stream_chunk("الدالة f(x) معرفة")
+
+    def test_cyrillic_stripped(self):
+        assert "будет" not in sanitize_stream_chunk("نص будет عربي")
+
+
+# ─── مولّد وهمي يحاكي ai_client.stream_chat ──────────────────────────────────
+class _FakeAI:
+    def __init__(self, scripts):
+        # scripts: list of list[str] — قطع كل محاولة بالترتيب
+        self._scripts = list(scripts)
+        self.calls = 0
+
+    async def stream_chat(self, messages, max_tokens=None):
+        idx = min(self.calls, len(self._scripts) - 1)
+        self.calls += 1
+        for piece in self._scripts[idx]:
+            yield {"choices": [{"delta": {"content": piece}}]}
+
+
+async def _collect(gen):
+    return "".join([c async for c in gen])
+
+
+class TestGuardFlow:
+    @pytest.mark.asyncio
+    async def test_arabic_first_attempt_streams(self):
+        ai = _FakeAI(
+            [["مرحباً يا طالب، ", "سنشرح التكامل ", "خطوة بخطوة بالعربية الفصحى لكي تفهم."]]
+        )
+        out = await _collect(guard_arabic_stream(ai, [{"role": "user", "content": "اشرح"}]))
+        assert "التكامل" in out
+        assert ai.calls == 1  # لا إعادة توليد
+
+    @pytest.mark.asyncio
+    async def test_english_triggers_regeneration_to_arabic(self):
+        # المحاولة 1: إنجليزية (يجب رفضها) — المحاولة 2: عربية
+        english = ["We need to respond in Arabic. The user wants explanation of the integral. " * 3]
+        arabic = [
+            "حسناً، ",
+            "التكامل هو مساحة تحت المنحنى، وسأشرحه بالعربية الفصحى بالتفصيل الكامل.",
+        ]
+        ai = _FakeAI([english, arabic])
+        out = await _collect(
+            guard_arabic_stream(
+                ai, [{"role": "system", "content": "long sys"}, {"role": "user", "content": "اشرح"}]
+            )
+        )
+        assert ai.calls == 2  # أعاد التوليد
+        assert "We need" not in out
+        assert "التكامل" in out
+
+    @pytest.mark.asyncio
+    async def test_all_english_emits_clean_arabic_fallback(self):
+        english = [
+            "We need to respond. The user asked. Let us explain the function and the integral. " * 3
+        ]
+        ai = _FakeAI([english, english])  # كلا المحاولتين إنجليزية
+        out = await _collect(
+            guard_arabic_stream(
+                ai, [{"role": "system", "content": "s"}, {"role": "user", "content": "q"}]
+            )
+        )
+        assert out == _ARABIC_FALLBACK_MESSAGE
+        assert "We need" not in out

--- a/tests/services/test_iss107_context_binding.py
+++ b/tests/services/test_iss107_context_binding.py
@@ -1,0 +1,74 @@
+"""ISS-107 — اختبارات ربط سياق التمرين للأسئلة المتابِعة.
+
+يثبت أن «لم افهم التكامل» و«اشرح بالعربية» بعد عرض تمرين 2016 تبقى مربوطة
+بالتمرين (لا تسقط للـ LLM العام → هلوسة كيمياء)، وأنّ غياب التمرين من السياق
+لا يُفعّل الربط (لا false positive).
+"""
+
+from app.services.capabilities.exercise_retrieval import (
+    ExerciseRetrievalRequest,
+    _is_followup_explanation_request,
+    detect_explanation_with_context,
+)
+
+_HISTORY_2016 = [
+    {
+        "role": "user",
+        "content": "تمرين 2016 الدورة الأولى الموضوع الثاني التمرين الرابع الدوال العددية",
+    },
+    {
+        "role": "assistant",
+        "content": (
+            "التمرين الرابع (الدوال العددية): I. g(x)=1+(x^2+x-1)e^{-x} ... "
+            "II. f(x)=-x+(x^2+3x+2)e^{-x} ... III. h(x)=x+f(x) و A(λ)=∫_0^λ h(x)dx"
+        ),
+    },
+]
+
+
+class TestFollowupMarkers:
+    def test_confusion_markers(self):
+        assert _is_followup_explanation_request("لم افهم التكامل")
+        assert _is_followup_explanation_request("مفهمتش")
+        assert _is_followup_explanation_request("كيفاش نحسب")
+
+    def test_bare_explain_and_arabic(self):
+        assert _is_followup_explanation_request("اشرح بالعربية")
+        assert _is_followup_explanation_request("وضّح لي")
+        assert _is_followup_explanation_request("explain in arabic")
+
+    def test_non_followup(self):
+        assert not _is_followup_explanation_request("كم عدد الطلاب")
+
+
+class TestContextBinding:
+    def test_confusion_binds_to_exercise(self):
+        d = detect_explanation_with_context(
+            ExerciseRetrievalRequest(question="لم افهم التكامل"), history_messages=_HISTORY_2016
+        )
+        assert d.recognized is True
+        assert d.matched_entry is not None
+        assert "bac2016" in d.matched_entry.file_path
+
+    def test_explain_in_arabic_binds_to_exercise(self):
+        # هذا هو السيناريو الكارثي الأصلي (كان يهلوس كيمياء)
+        d = detect_explanation_with_context(
+            ExerciseRetrievalRequest(question="اشرح بالعربية"), history_messages=_HISTORY_2016
+        )
+        assert d.recognized is True
+        assert d.matched_entry is not None
+        assert "bac2016" in d.matched_entry.file_path
+        assert d.reason == "bac_explanation_with_conversation_context"
+
+    def test_no_exercise_in_history_does_not_bind(self):
+        d = detect_explanation_with_context(
+            ExerciseRetrievalRequest(question="اشرح بالعربية"), history_messages=[]
+        )
+        assert d.recognized is False
+
+    def test_full_content_loaded_for_binding(self):
+        d = detect_explanation_with_context(
+            ExerciseRetrievalRequest(question="وضّح لي الجزء الثالث"), history_messages=_HISTORY_2016
+        )
+        assert d.recognized is True
+        assert d.full_content and len(d.full_content) > 500

--- a/tests/services/test_iss107_model_chain.py
+++ b/tests/services/test_iss107_model_chain.py
@@ -1,0 +1,82 @@
+"""ISS-107 — اختبار سلسلة النماذج: التقدّم عند content_chunks==0.
+
+يثبت أن نموذجاً ينتج content فارغاً (reasoning-only مثل glm-4.5-air) يُعَدّ
+فشلاً فيتقدّم ``stream_chat`` للنموذج التالي بدل إرجاع إجابة فارغة («لا يجيب»).
+كما يثبت تنظيف السلسلة من النماذج المُثبَت كارثيّتها حياً (2026-06-02).
+"""
+
+import pytest
+
+from app.core.ai_config import get_ai_config
+from app.core.gateway.simple_client import OpenRouterClient
+
+
+class _StubSafetyNet:
+    async def stream_safety_response(self):
+        yield {"choices": [{"delta": {"content": "[safety]"}}]}
+
+
+def _make_client():
+    return OpenRouterClient(
+        api_key="test",
+        primary_model="model-empty",
+        fallback_models=["model-good"],
+        cognitive_engine=None,
+        safety_net=_StubSafetyNet(),
+    )
+
+
+class TestEmptyAdvances:
+    @pytest.mark.asyncio
+    async def test_empty_model_advances_to_next(self, monkeypatch):
+        """model-empty يرفع ValueError (content==0) → ينتقل لـ model-good."""
+        client = _make_client()
+
+        async def fake_stream_model(c, model_id, messages, max_tokens=None):
+            if model_id == "model-empty":
+                # يحاكي ما يفعله _stream_model الحقيقي عند content_chunks==0
+                raise ValueError(f"empty_completion model={model_id} (content_chunks=0)")
+                yield  # pragma: no cover
+            yield {"choices": [{"delta": {"content": "إجابة عربية سليمة"}}]}
+
+        monkeypatch.setattr(client, "_stream_model", fake_stream_model)
+        out = "".join(
+            [
+                ch["choices"][0]["delta"].get("content", "")
+                async for ch in client.stream_chat([{"role": "user", "content": "q"}])
+            ]
+        )
+        assert "إجابة عربية سليمة" in out
+        assert "[safety]" not in out  # لم نلجأ لشبكة الأمان
+
+    @pytest.mark.asyncio
+    async def test_all_empty_falls_to_safety_net(self, monkeypatch):
+        client = _make_client()
+
+        async def all_empty(c, model_id, messages, max_tokens=None):
+            raise ValueError("empty_completion content_chunks=0")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(client, "_stream_model", all_empty)
+        out = "".join(
+            [
+                ch.get("choices", [{}])[0].get("delta", {}).get("content", "") or ""
+                async for ch in client.stream_chat([{"role": "user", "content": "q"}])
+            ]
+        )
+        assert "[safety]" in out  # كل النماذج فشلت → شبكة الأمان
+
+
+class TestChainHygiene:
+    def test_broken_models_removed(self):
+        """النماذج المُثبَت كارثيّتها حياً (2026-06-02) ليست في السلسلة."""
+        cfg = get_ai_config()
+        chain = [cfg.primary_model, *cfg.get_fallback_models()]
+        joined = " ".join(chain)
+        assert "trinity-large-thinking" not in joined  # 404
+        assert "glm-4.5-air" not in joined  # content فارغ
+        assert "nemotron-3-super-120b" not in joined  # إنجليزي في content
+
+    def test_primary_is_verified_arabic(self):
+        cfg = get_ai_config()
+        assert cfg.primary_model == "openai/gpt-oss-120b:free"


### PR DESCRIPTION
Follow-up questions after a BAC exercise collapsed: 'لم افهم التكامل' returned
English (Riemann sums), 'اشرح بالعربية' hallucinated corrupted chemistry.

Live OpenRouter benchmark (real key, 2026-06-02) proved the fallback chain
degrades to English/empty models when gpt-oss stalls:
  nemotron-3-super-120b -> English in content; glm-4.5-air -> empty; trinity -> 404.

Root fixes:
- New Skill app/services/skills/arabic_stream_guard.py wraps both live streaming
  paths: buffers a small first window, detects English PROSE (after stripping
  LaTeX, so legit Arabic+LaTeX is not misflagged), regenerates in strict Arabic,
  emits a clean Arabic fallback on failure, and strips glued tokens
  (أستاذochemistry -> أستاذ).
- simple_client._stream_model raises on content_chunks==0 so the chain advances
  instead of returning an empty answer.
- ai_config fallback chain cleaned (removed the 3 proven-bad models).
- exercise_retrieval binds follow-ups (لم افهم/اشرح بالعربية/وضّح) to the
  in-context exercise so they stay on-topic.

Live-verified: forcing nemotron-3-super (the English producer) as PRIMARY -> guard
regenerates clean Arabic. 23/23 ISS-107 + 123 regression + 6 gateway green.
Full Supabase/WS/browser E2E remains mandatory in Codespaces.

https://claude.ai/code/session_01AoYJsjbGSAhkZGDwUH3WzT