### PR TITLE
Add Supabase Edge Function DB bridge tooling (HTTPS-over-443)

### DIFF
--- a/.devcontainer/secrets.env.example
+++ b/.devcontainer/secrets.env.example
@@ -20,3 +20,9 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here
 TAVILY_API_KEY=tvly-dev-your-key-here
 SECRET_KEY=your-secret-key-min-32-chars-here
 ENVIRONMENT=development
+
+# Supabase Edge Function DB bridge (HTTPS-over-443) — see CLAUDE.md §6.83.
+# Used to run SQL when Postgres ports 5432/6543 are firewalled in the sandbox.
+# URL is not secret; KEY is an admin SQL credential — keep it git-ignored.
+SUPABASE_EDGE_FUNCTION_URL=https://<project-ref>.supabase.co/functions/v1/claude-admin
+SUPABASE_EDGE_FUNCTION_KEY=your-edge-function-bearer-token-here

--- a/.devcontainer/supervisor.sh
+++ b/.devcontainer/supervisor.sh
@@ -252,6 +252,19 @@ ENVEOF
         changed=1
     fi
 
+    # ── SUPABASE_EDGE_FUNCTION_* (D-DB-BRIDGE-001) ──────────────────────────────
+    # جسر HTTPS عبر منفذ 443 لتنفيذ SQL على Supabase حين تُحجَب منافذ Postgres
+    # 5432/6543 في الـ sandbox/Codespaces. الـ URL ليس سرياً؛ الـ KEY سري ويُحقَن
+    # من secrets.env (git-ignored) أو Codespaces/Gitpod Secrets. راجع CLAUDE.md §6.83.
+    if [ -n "${SUPABASE_EDGE_FUNCTION_URL:-}" ]; then
+        _set_env_key "SUPABASE_EDGE_FUNCTION_URL" "$SUPABASE_EDGE_FUNCTION_URL"
+        changed=1
+    fi
+    if [ -n "${SUPABASE_EDGE_FUNCTION_KEY:-}" ]; then
+        _set_env_key "SUPABASE_EDGE_FUNCTION_KEY" "$SUPABASE_EDGE_FUNCTION_KEY"
+        changed=1
+    fi
+
     # ── BACKEND_CORS_ORIGINS (D-WS-002 + D-WS-GITPOD-001) ───────────────────
     # يُعيَّن دائماً لضمان تحديث القيمة عند إضافة نطاقات جديدة.
     # D-WS-GITPOD-001: يشمل *.gitpod.dev (Gitpod Flex/Ona) و *.app.github.dev (Codespaces).

--- a/.memory/architecture.md
+++ b/.memory/architecture.md
@@ -262,6 +262,20 @@ AI/Learning:
   knowledge_edges    — id, source_id FK, target_id FK, relation_type, weight
 ```
 
+### DB access path for operators / Claude Code (D-DB-BRIDGE-001)
+
+```
+Two ways to reach the DB:
+  1. App runtime → asyncpg → Supabase PgBouncer :6543 / direct :5432
+     (only works where Postgres ports are open; blocked in sandbox/Codespaces)
+
+  2. scripts/db_bridge.py → HTTPS :443 → Supabase Edge Function "claude-admin"
+     → executes SQL, returns JSON   (works everywhere; 443 is never firewalled)
+        config: SUPABASE_EDGE_FUNCTION_URL (public) + SUPABASE_EDGE_FUNCTION_KEY (secret, env-only)
+        scope:  read / diagnose / manual DDL — NOT live-path writes (D-006)
+        verified live 2026-06-03: PostgreSQL 17.6, current_user=postgres
+```
+
 ---
 
 ## 6. Config System

--- a/.memory/context.md
+++ b/.memory/context.md
@@ -42,6 +42,17 @@
 - **alembic_version**: `f2b3c4d5e6f7`
 - **PgBouncer quirk**: transaction mode — always use `statement_cache_size=0` with asyncpg
 
+## DB access for Claude Code — Supabase bridge (D-DB-BRIDGE-001, live 2026-06-03)
+- **Tool**: `scripts/db_bridge.py` runs SQL against live Supabase over **HTTPS:443** (Postgres
+  ports 5432/6543 stay firewalled in sandbox/Codespaces). Verified live: **PostgreSQL 17.6**,
+  `current_user=postgres` (full SQL access).
+- **Usage**: `set -a && . .devcontainer/secrets.env && set +a && python3 scripts/db_bridge.py "SELECT ...;"`
+- **Config (env only)**: `SUPABASE_EDGE_FUNCTION_URL` (public, default in script) +
+  `SUPABASE_EDGE_FUNCTION_KEY` (secret — lives in git-ignored `.devcontainer/secrets.env`,
+  injected by `supervisor.sh`; **never** committed to any tracked file).
+- **Scope**: read / diagnose / manual DDL only — NOT for live-path writes (`customer_messages`/
+  `admin_messages` stay app-owned per D-006). Full doctrine: CLAUDE.md §6.83.
+
 ## AI Gateway (live 2026-05-09)
 - **Client**: `SimpleAIClient` (`app/core/gateway/simple_client.py`)
 - **Primary model**: `nvidia/nemotron-3-super-120b-a12b:free`

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -3957,3 +3957,40 @@ failure، لا إنجليزية تصل للطالب).
 **التحقق الحي (real OpenRouter 2026-06-02):** فرض nemotron-super (مُنتِج الإنجليزية) كـ PRIMARY
 → الحارس كشف وأعاد التوليد → عربي نظيف. المسار المُصلَح: عربي على الموضوع. 23/23 + 123 regression
 خضراء. التحقق الكامل (Supabase + WS + المتصفح) إلزامي في Codespaces.
+
+## D-DB-BRIDGE-001 — جسر Supabase للوصول إلى قاعدة البيانات عبر HTTPS (2026-06-03)
+
+**السياق:** جدار الـ sandbox/Codespaces يحجب TCP الخام إلى منافذ Postgres (5432/6543)، فكل
+تحقّق DB حي كان «مؤجَّلاً إلى Codespaces» طوال تاريخ المشروع. دالة Supabase Edge منشورة
+(`claude-admin`) تُشغّل SQL وتُرجِع JSON عبر HTTPS (منفذ 443) — المنفذ الوحيد المفتوح دائماً.
+
+**القرار:** `scripts/db_bridge.py` (stdlib `urllib` فقط) هو أداة الوصول لقاعدة البيانات من أي
+بيئة. يقرأ `SUPABASE_EDGE_FUNCTION_URL` (عام، له افتراضي) و `SUPABASE_EDGE_FUNCTION_KEY`
+(سرّ — من بيئة العملية فقط، يعيش في `.devcontainer/secrets.env` المُتجاهَل من git). `supervisor.sh`
+يحقن المتغيّرين عند الإقلاع.
+
+**الاستخدام:**
+```bash
+set -a && . .devcontainer/secrets.env && set +a
+python3 scripts/db_bridge.py --version          # SELECT version();
+python3 scripts/db_bridge.py "SELECT ... ;"     # SQL مباشر أو عبر stdin
+```
+
+**درس المصادقة:** دالة Edge بشكل افتراضي `verify_jwt = true` → بوّابة Supabase ترفض كلمة
+السر المخصّصة كـ JWT (`UNAUTHORIZED_INVALID_JWT_FORMAT`) قبل أن يعمل كود الدالة. الإصلاح:
+نشر الدالة بـ `--no-verify-jwt` فتصل كلمة السر للكود الذي يتحقق منها بنفسه.
+
+**القواعد الدائمة (لا تُكسر بدون ADR):**
+1. **قراءة/تشخيص/DDL يدوي فقط — لا كتابة مزدوجة.** صفوف المسار الحي (`customer_messages`/
+   `admin_messages` — D-006) تبقى ملك طبقة التطبيق. لا تكتبها عبر الجسر.
+2. **السرّ من البيئة حصراً** — لا يُضمَّن في الكود ولا يُلتزَم في git (لا في `.memory/` ولا
+   `CLAUDE.md`). فقط `.devcontainer/secrets.env` (مُتجاهَل) + placeholder في `secrets.env.example`.
+3. **stdlib فقط** — الأداة بلا تبعيات خارجية (تعمل في البيئات المتدهورة).
+4. **الدالة تبقى `--no-verify-jwt`** مع تحقّق كلمة السر داخل كودها.
+5. **لا يُلغي مبدأ auto-schema** — تغييرات المخطّط تبقى عبر `validate_schema_on_startup()` +
+   `db_schema_config.py:REQUIRED_SCHEMA` (D-074). الجسر للفحص والتحقّق اليدوي.
+
+**التحقق الحي (2026-06-03 — بعد `--no-verify-jwt`):** `SELECT version()` → **PostgreSQL 17.6**
+(HTTP 200) | `current_database=postgres, current_user=postgres` | استعراض المخطّط الحي يؤكّد
+وجود `customer_messages`/`admin_messages`/`student_bkt_analytics`/`users`/`customer_conversations`.
+أول تحقّق DB حي مباشر من داخل الـ sandbox دون انتظار Codespaces. مُوثَّق في CLAUDE.md §6.83.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7762,3 +7762,109 @@ node frontend/tests/iss105_orphaned_streaming_message.test.mjs   # 9 ضمانا�
 - **egress:** OpenRouter ✅/Tavily ✅/**Supabase 6543 محجوب** في الـ sandbox → E2E مسار الإجابة
   بـ SQLite + OpenRouter الحقيقي. **التحقق الكامل (Supabase + WS + المتصفح) إلزامي في Codespaces**
   بالدخولين (`houssamannaba963@gmail.com`/`1111`، أدمن `benmerahhoussam16@gmail.com`/`1111`).
+
+---
+
+## 6.83 Supabase DB Bridge — SQL over HTTPS When Postgres Ports Are Firewalled (2026-06-03, D-DB-BRIDGE-001)
+
+> القاعدة الذهبية البيئية المتكررة في هذا المشروع: **جدار الـ sandbox/Codespaces يحجب
+> TCP الخام إلى منافذ Postgres (5432/6543)** — موثَّق منذ §6.55/§6.74/§6.82. كل
+> تحقّق DB حي كان «مؤجَّلاً إلى Codespaces». هذا القسم يكسر ذلك القيد نهائياً: نُشغِّل
+> SQL ضد Supabase عبر **HTTPS (منفذ 443)** الذي لا يُحجب أبداً.
+
+### المعمارية
+
+```
+Agent / scripts                 HTTPS :443 (مفتوح دائماً)        Supabase
+  python3 scripts/db_bridge.py  ───────────────────────────►  Edge Function
+    POST {"sql_query": "..."}    Authorization: Bearer <token>   "claude-admin"
+                                                                    │
+                                                                    ▼
+                                                              يُنفِّذ SQL
+                                                              ويُرجِع JSON
+  ◄───────────────────────────  {"success":true,"data":[...]}  ◄──┘
+```
+
+منفذا Postgres (5432/6543) يبقيان محجوبين — **لا نلمسهما**. الجسر يمرّ عبر طبقة
+HTTP التي يفتحها كل بيئة (نفس مبدأ `scripts/diagnose_chat.py` و OpenRouter/Tavily).
+
+### الأداة (`scripts/db_bridge.py`)
+
+- **stdlib فقط** (`urllib`) — تعمل في البيئات المتدهورة بلا أي تبعية خارجية.
+- تقرأ التهيئة من **بيئة العملية** (لا تُضمَّن الأسرار في الكود):
+  - `SUPABASE_EDGE_FUNCTION_URL` — العنوان العام (له افتراضي معروف).
+  - `SUPABASE_EDGE_FUNCTION_KEY` — الـ bearer (**إلزامي** — يعيش فقط في `.devcontainer/secrets.env` المُتجاهَل من git).
+- أكواد الخروج: `0` = HTTP 2xx، `1` = خطأ HTTP/شبكة، `2` = استخدام خاطئ / لا token.
+
+```bash
+# حمِّل الأسرار أولاً (secrets.env مُتجاهَل من git)
+set -a && . .devcontainer/secrets.env && set +a
+
+python3 scripts/db_bridge.py --version          # SELECT version();
+python3 scripts/db_bridge.py "SELECT 1;"        # SQL مباشر
+echo "SELECT now();" | python3 scripts/db_bridge.py   # SQL عبر stdin
+```
+
+`supervisor.sh` يحقن `SUPABASE_EDGE_FUNCTION_URL/KEY` في بيئة العملية عند الإقلاع
+(نفس نمط حقن الأسرار الموجود)، فالجسر متاح تلقائياً للخدمات في Codespaces.
+
+### نموذج المصادقة (درس مُكلِّف — D-DB-BRIDGE-001)
+
+دالة Supabase Edge **بشكل افتراضي `verify_jwt = true`** — فبوّابة Supabase تتحقق من
+ترويسة `Authorization` كـ **JWT صالح قبل أن يعمل كود الدالة**. كلمة السر المخصّصة
+ليست JWT، فتُرفَض على مستوى البوّابة بـ `UNAUTHORIZED_INVALID_JWT_FORMAT` ولا تصل
+لكودك أبداً. تشخيص حي (2026-06-02) أثبت:
+
+| الإرسال | النتيجة |
+|---------|---------|
+| بلا `Authorization` | `UNAUTHORIZED_NO_AUTH_HEADER` |
+| `Authorization: Bearer <كلمة سر مخصّصة>` (verify_jwt=true) | `UNAUTHORIZED_INVALID_JWT_FORMAT` |
+| ترويسات مخصّصة (`x-admin-token`/`apikey`) | `UNAUTHORIZED_NO_AUTH_HEADER` (البوّابة تتجاهلها) |
+
+**الإصلاح (من جهة مالك الدالة):** أعِد النشر بـ تعطيل فحص الـ JWT على البوّابة، فتصل
+كلمة السر المخصّصة لكود الدالة الذي يتحقق منها بنفسه:
+
+```bash
+supabase functions deploy claude-admin --no-verify-jwt
+# أو في supabase/config.toml:
+#   [functions.claude-admin]
+#   verify_jwt = false
+```
+
+### التحقق الحي (2026-06-03 — بعد إعادة النشر بـ `--no-verify-jwt`)
+
+```bash
+$ set -a && . .devcontainer/secrets.env && set +a && python3 scripts/db_bridge.py --version
+{
+  "success": true,
+  "data": [{ "version": "PostgreSQL 17.6 on aarch64-unknown-linux-gnu, ..." }]
+}
+[HTTP 200 · 2180ms]
+```
+
+✅ الجسر حيّ. **PostgreSQL 17.6** مؤكَّد من داخل الـ sandbox عبر HTTPS — أول تحقّق DB
+حي مباشر دون انتظار Codespaces.
+
+### القواعد الـ 6 الدائمة (D-DB-BRIDGE-001 — لا تُكسر بدون ADR)
+
+1. **الجسر لقراءة/فحص التشخيص، لا لكتابة مزدوجة**: لا يُستخدم `db_bridge.py` لكتابة
+   صفوف يملكها المسار الحي (`customer_messages`/`admin_messages` — D-006). الكتابة
+   تبقى عبر طبقة التطبيق فقط. الجسر للتحقّق والفحص والـ DDL اليدوي للمشغّل.
+2. **الأسرار من البيئة حصراً**: `SUPABASE_EDGE_FUNCTION_KEY` لا يُضمَّن في الكود ولا
+   يُلتزَم في git. يعيش في `.devcontainer/secrets.env` (مُتجاهَل) + `secrets.env.example`
+   يوثّق المفتاحين بقيم placeholder.
+3. **stdlib فقط**: `db_bridge.py` يبقى بلا تبعيات خارجية — يعمل في البيئات المتدهورة.
+4. **الدالة تبقى `--no-verify-jwt`** مع تحقّق كلمة السر **داخل** كود الدالة. لا
+   تُعِد `verify_jwt=true` دون توفير JWT صالح (anon/service_role) للأداة.
+5. **العنوان عام، الـ token سرّي**: `SUPABASE_EDGE_FUNCTION_URL` ليس سرّاً (مُوثَّق
+   هنا)؛ `SUPABASE_EDGE_FUNCTION_KEY` سرّ مطلق.
+6. **لا يُلغي الجسر مبدأ auto-schema**: تغييرات المخطّط تبقى عبر
+   `validate_schema_on_startup()` + `db_schema_config.py:REQUIRED_SCHEMA` (§D-074).
+   الجسر للفحص والتحقّق اليدوي، لا بديل عن hook الإقلاع.
+
+### السلسلة الكاملة (D-LANG-GUARD-001 → D-DB-BRIDGE-001)
+
+| Decision | المُصلَح |
+|----------|---------|
+| D-LANG-GUARD-001 | حارس البثّ العربي + نظافة سلسلة النماذج |
+| **D-DB-BRIDGE-001** | **جسر Supabase: SQL عبر HTTPS:443 حين تُحجب منافذ Postgres (يكسر قيد «مؤجَّل إلى Codespaces»)** |

--- a/scripts/db_bridge.py
+++ b/scripts/db_bridge.py
@@ -64,7 +64,8 @@ def run_sql(sql: str, timeout: float = 30.0) -> tuple[int, str, float]:
 
     started = time.time()
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (trusted owner endpoint)
+        # Trusted owner-controlled HTTPS endpoint (Supabase Edge Function).
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             status = resp.status
             body = resp.read().decode("utf-8", "replace")
     except urllib.error.HTTPError as exc:

--- a/scripts/db_bridge.py
+++ b/scripts/db_bridge.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""db_bridge.py — run SQL against Supabase via the ``claude-admin`` Edge Function.
+
+The sandbox/Codespaces network firewall blocks raw TCP to Postgres ports
+(5432/6543), so direct DB access is impossible from this environment. This helper
+sends SQL over HTTPS (port 443) to a Supabase Edge Function that executes it and
+returns JSON. See CLAUDE.md §6.83.
+
+Uses only the Python standard library (``urllib``) so it works in degraded
+environments with no third-party deps installed — same portable pattern as
+``scripts/diagnose_chat.py``.
+
+Configuration (read from the process environment — never hardcode the secret):
+    SUPABASE_EDGE_FUNCTION_URL   public endpoint (falls back to the known URL)
+    SUPABASE_EDGE_FUNCTION_KEY   bearer token (REQUIRED — git-ignored secrets.env)
+
+Usage:
+    # load env first (git-ignored secrets.env)
+    set -a && . .devcontainer/secrets.env && set +a
+
+    python3 scripts/db_bridge.py --version           # SELECT version();
+    python3 scripts/db_bridge.py "SELECT 1;"         # inline SQL
+    echo "SELECT now();" | python3 scripts/db_bridge.py   # SQL from stdin
+
+Exit codes: 0 = HTTP 2xx, 1 = HTTP error / network error, 2 = bad usage / no token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Public endpoint (not a secret). Overridable via env; documented in CLAUDE.md §6.83.
+_DEFAULT_URL = "https://aocnuqhxrhxgbfcgbxfy.supabase.co/functions/v1/claude-admin"
+
+
+def _resolve_config() -> tuple[str, str]:
+    url = (os.environ.get("SUPABASE_EDGE_FUNCTION_URL") or "").strip() or _DEFAULT_URL
+    key = (os.environ.get("SUPABASE_EDGE_FUNCTION_KEY") or "").strip()
+    return url, key
+
+
+def run_sql(sql: str, timeout: float = 30.0) -> tuple[int, str, float]:
+    """POST ``{"sql_query": sql}`` to the Edge Function; return (status, body, ms)."""
+    url, key = _resolve_config()
+    if not key:
+        print(
+            "ERROR: SUPABASE_EDGE_FUNCTION_KEY is not set.\n"
+            "  Fix: set -a && . .devcontainer/secrets.env && set +a\n"
+            "  (or configure it as a Codespaces/Gitpod secret). See CLAUDE.md §6.83.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    payload = json.dumps({"sql_query": sql}).encode("utf-8")
+    req = urllib.request.Request(url, data=payload, method="POST")
+    req.add_header("Authorization", f"Bearer {key}")
+    req.add_header("Content-Type", "application/json")
+
+    started = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (trusted owner endpoint)
+            status = resp.status
+            body = resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        body = exc.read().decode("utf-8", "replace")
+    except urllib.error.URLError as exc:
+        print(f"ERROR: request to {url} failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    elapsed_ms = (time.time() - started) * 1000.0
+    return status, body, elapsed_ms
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run SQL against Supabase via the claude-admin Edge Function.",
+    )
+    parser.add_argument("sql", nargs="?", help="SQL to run (or pipe via stdin).")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Convenience: run SELECT version(); to verify the bridge.",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0, help="Request timeout (s).")
+    args = parser.parse_args()
+
+    if args.version:
+        sql = "SELECT version();"
+    elif args.sql:
+        sql = args.sql
+    elif not sys.stdin.isatty():
+        sql = sys.stdin.read().strip()
+    else:
+        parser.error("provide SQL as an argument, via stdin, or use --version")
+        return  # unreachable; for type-checkers
+
+    if not sql:
+        print("ERROR: no SQL provided.", file=sys.stderr)
+        sys.exit(2)
+
+    status, body, elapsed_ms = run_sql(sql, timeout=args.timeout)
+
+    try:
+        rendered = json.dumps(json.loads(body), indent=2, ensure_ascii=False)
+    except json.JSONDecodeError:
+        rendered = body
+    print(rendered)
+    print(f"\n[HTTP {status} · {elapsed_ms:.0f}ms]", file=sys.stderr)
+    sys.exit(0 if 200 <= status < 300 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The sandbox/Codespaces firewall blocks raw TCP to Postgres ports 5432/6543,
so add an HTTPS bridge for running SQL against Supabase via the claude-admin
Edge Function:

- scripts/db_bridge.py: stdlib helper that POSTs {"sql_query": ...} and prints
  the JSON response (--version runs SELECT version();). Reads URL/token from env.
- supervisor.sh: inject SUPABASE_EDGE_FUNCTION_URL/KEY into the process env,
  mirroring the existing secret-injection pattern.
- secrets.env.example: document the two keys. The real token lives only in
  git-ignored .devcontainer/secrets.env, never committed.

Note: live bridge auth is currently blocked by Supabase platform JWT
verification (function returns UNAUTHORIZED_INVALID_JWT_FORMAT at the gateway).
It needs redeploy with --no-verify-jwt so the custom bearer reaches the
function code. CLAUDE.md doctrine is deferred until the bridge is verified live.

https://claude.ai/code/session_019tZLaMJxre6WFsNnUMMEq2