### PR TITLE
feat(orchestrator): activate routes.py at runtime on SQLite + full-stack E2E (D-098)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 # === CogniForge .gitignore - Final Form ===
 # ==========================================
 
+# E2E local/sandbox runtime artifacts (D-098) — never committed
+.cogniforge_e2e.db*
+.e2e_*.log
+
 # 1. Environment & Secrets
 # Never commit secrets, keys, passwords, or local environment settings!
 .env

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -1,5 +1,29 @@
 # Architectural Decisions
-> Last updated: 2026-06-03 | Branch: `claude/probability-exercise-2024-PNalj`
+> Last updated: 2026-06-04 | Branch: `claude/orchestrator-service-runtime-tjjyW`
+
+## D-098 · Orchestrator `routes.py` runtime re-activation on SQLite + full-stack E2E (2026-06-04)
+
+**السياق:** `microservices/orchestrator_service/src/api/routes.py` كان DORMANT في بيئة جديدة (لا uvicorn
+على :8006، تبعيات غير مثبَّتة، منافذ Postgres محجوبة). الهدف: تشغيله حياً وإثبات أنه يجيب عبر E2E كامل.
+
+**التغييرات (جراحية، محروسة بـ `get_backend_name()=="sqlite"` فلا تمسّ مسار Postgres الإنتاجي):**
+1. `database.py:create_engine` — فرع SQLite يبني engine نظيفاً (`check_same_thread=False`) بدل تمرير
+   asyncpg connect_args (يرفضها aiosqlite → TypeError → init_db تتدهور ولا تُنشأ جداول).
+2. `database.py:init_db` — تخطّي psycopg checkpointer على URL سَكوَلايت (يتجنّب حجب ~30s) → MemorySaver.
+3. `routes.py:_stream_chat_langgraph` — معالج `__ERROR__` يسجّل الخطأ/التتبّع الملتقَط من الطابور بدل
+   `exc_info=True` (يطبع `NoneType: None` لأن الاستثناء رُفع في مهمة خلفية).
+4. `scripts/e2e_orchestrator_live.py` (جديد) — أداة E2E تختبر المسارات الثلاثة (direct/monolith/frontend).
+
+**القرار:** monolith + orchestrator يتشاركان ملف SQLite واحد (WAL) حين تُحجب Supabase — monolith يُنشئ جداول
+المحادثات، orchestrator يقرأ/يكتبها (مرآة بنية Supabase المشتركة).
+
+**التحقق الحي (2026-06-04 — SQLite + OpenRouter حقيقي):** `:8006/health graph_ready=true,startup_state=ready`
+| warmup شغّل LangGraph (`admin.count_python_files → 1584`) | مباشر: نيوتن 24 delta+LaTeX، جاذبية 27، سرعة/تسارع 46
+| monolith WS: 13-node كامل (Supervisor→…→Synthesizer→Validator) 10 delta، دفعة 4/5 عبر orchestrator | frontend
+proxy :5000: طاقة حركية 21 delta + `$$K=½mv²$$`، إغلاق 1000 | 11 إجابة 200، كل العُقد نُفِّذت | Supabase عبر الجسر:
+PG 17.6، الحسابان الحقيقيان (id=1 admin، id=7 user). **القيود:** Postgres TCP محجوب في sandbox → حفظ على SQLite،
+Supabase تحقَّق قراءةً عبر الجسر، التشغيل الكامل ضد Supabase في Codespaces عبر الـ runbook. **gates:**
+ruff/format/runtime_truth/validate_structure/ci_guardrails ✅. مُوثَّق في CLAUDE.md §6.85.
 
 ## D-097 · Catastrophic Explanation Fix — context loss + fake steps + incomplete urn (2026-06-03)
 

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -1,7 +1,24 @@
 # Open Issues & Bugs
-> Last updated: 2026-06-03 | Branch: `claude/probability-exercise-2024-PNalj`
+> Last updated: 2026-06-04 | Branch: `claude/orchestrator-service-runtime-tjjyW`
 
 ---
+
+## ISS-ORCH-SQLITE-001 — Orchestrator `routes.py` خامل + لا يُشغَّل على SQLite (محلول، D-098, 2026-06-04)
+
+**العَرَض:** الـ orchestrator (`microservices/orchestrator_service/src/api/routes.py`) خامل في بيئة جديدة:
+لا uvicorn على :8006، تبعيات غير مثبَّتة، ومنافذ Supabase Postgres (5432/6543) محجوبة فلا يتصل بقاعدته.
+
+**الجذر:** `database.py:create_engine` كان يمرّر دائماً asyncpg connect_args (`statement_cache_size`/
+`prepared_statement_cache_size`/ssl) → aiosqlite يرفضها بـ TypeError على أول اتصال → `init_db()` تتدهور
+ولا تُنشأ جداول → كل persistence يفشل (403/خطأ). كذلك `init_db` كان يحاول psycopg على URL سَكوَلايت (حجب ~30s).
+
+**الإصلاح (D-098):** فرعان محروسان بـ `get_backend_name()=="sqlite"` في `database.py` (create_engine نظيف +
+init_db يتخطّى psycopg → MemorySaver) + إصلاح error-logging في `routes.py:_stream_chat_langgraph`. مسار Postgres
+الإنتاجي غير ممسوس. + `scripts/e2e_orchestrator_live.py` (أداة E2E).
+
+**التحقق الحي:** `:8006/health graph_ready=true` | E2E 4 طبقات (direct/monolith/frontend) كلها تجيب بإجابات عربية
++ LaTeX حقيقية عبر OpenRouter | 13-node graph نُفِّذ كاملاً | Supabase عبر الجسر: PG 17.6 + الحسابان الحقيقيان.
+**القيد:** Postgres محجوب في sandbox → حفظ على SQLite؛ التشغيل الكامل ضد Supabase في Codespaces (CLAUDE.md §6.85 runbook).
 
 ## ✅ Resolved 2026-06-03 (ISS-108 — catastrophic explanations: context-loss hallucination + fake steps + incomplete urn)
 

--- a/.memory/runtime_truth.md
+++ b/.memory/runtime_truth.md
@@ -1,6 +1,25 @@
 # Runtime Truth Lock
-> Last updated: **2026-05-28** | Branch: `main`
-> Previous: `feat/math-explanation-generative-ui`
+> Last updated: **2026-06-04** | Branch: `claude/orchestrator-service-runtime-tjjyW`
+> Previous: `main`
+
+## Orchestrator `routes.py` Re-Activation (2026-06-04, D-098) — SQLite-Mode Full-Stack E2E
+
+**Status: orchestrator-service StateGraph (13-node) → ✅ ACTIVE (re-verified live on SQLite + real OpenRouter).**
+
+Live evidence (sandbox: Postgres TCP blocked → shared SQLite + real OpenRouter/Tavily; Supabase read via HTTPS bridge):
+- `:8006/health → {"status":"ok","graph_ready":true,"startup_state":"ready"}`; warmup ran the graph
+  (`admin.count_python_files → 1584`); `startup_info{checkpointer_backend="memory",graph_ready="true",pipeline_enabled="true"}`.
+- **Direct** `POST :8006/api/chat/messages` → real Arabic+LaTeX answers (Newton 24Δ `$$\vec F=m\vec a$$`, gravity 27Δ,
+  speed/accel 46Δ).
+- **Monolith WS** `:8000/api/chat/ws` → full 13-node graph executed (Supervisor→QueryRewriter→QueryAnalyzer→
+  InternalRetriever→Reranker→WebSearchFallback→Synthesizer→Validator); batch 4/5 routed through orchestrator.
+- **Frontend proxy** `:5000/api/chat/ws` (query-param) → server.js queue→flush→orchestrator hit (200) → 21Δ `$$K=½mv²$$`.
+- Live node counts: Supervisor×11, Validator×11, educational-pipeline×6, GeneralKnowledge×5, ExecuteTool×1; **11 answers (200)**.
+- Supabase via bridge: PostgreSQL 17.6; accounts `benmerahhoussam16@gmail.com`(id=1,admin), `houssamannaba963@gmail.com`(id=7,user).
+
+Fixes (D-098, guarded by `get_backend_name()=="sqlite"` — Postgres path untouched): `database.py:create_engine` SQLite branch,
+`database.py:init_db` psycopg-skip→MemorySaver, `routes.py:_stream_chat_langgraph` error-log fidelity. Tool: `scripts/e2e_orchestrator_live.py`.
+Constraint: full Supabase-backed run is in Codespaces (egress open) via CLAUDE.md §6.85 runbook. Gates ✅ (ruff/format/runtime_truth/validate_structure/ci_guardrails).
 
 ## ISS-092 Live Verification (2026-05-28) — System Not Responding + Kick-to-Login Fix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7973,3 +7973,110 @@ $ set -a && . .devcontainer/secrets.env && set +a && python3 scripts/db_bridge.p
 |----------|---------|
 | D-DB-BRIDGE-001 | جسر Supabase عبر HTTPS:443 |
 | **D-097** | **كارثة الشرح: فقدان السياق (هلوسة) + خطوات وهمية + كيس ناقص + جدار نص + سلسلة نماذج** |
+
+---
+
+## 6.85 Orchestrator `routes.py` Runtime Re-Activation — SQLite-Mode Full-Stack E2E (2026-06-04, D-098)
+
+> طلب المستخدم: تشغيل حي حقيقي (runtime) للملف `microservices/orchestrator_service/src/api/routes.py`
+> الذي كان **خاملاً** (لا يُطلَق، التبعيات غير مثبَّتة) وإثبات أنه **يجيب عن الأسئلة** عبر
+> **E2E كامل شامل (FULL STACK)** بالأسرار الحقيقية. هذا القسم يحكم تشغيل الـ orchestrator على
+> SQLite حين تُحجب منافذ Postgres — لا يُكسر بدون ADR.
+
+### لماذا كان «خاملاً» وما الذي أُصلِح
+
+`routes.py` مُوصَّل بالكامل (HTTP `/api/chat/messages` + WS `/api/chat/ws` + admin WS + `/agent/chat`
++ `/compose` + missions) لكنه DORMANT في بيئة جديدة لثلاثة أسباب: (1) لا توجد عملية uvicorn على `:8006`،
+(2) تبعيات Python غير مثبَّتة (`fastapi` غير موجود في clone جديد)، (3) **منافذ Supabase Postgres
+(5432/6543) محجوبة** فالـ orchestrator لا يستطيع الاتصال بقاعدة بياناته. الإصلاح (D-098 — جراحي،
+محروس بحيث لا يمسّ مسار Postgres الإنتاجي إطلاقاً):
+
+| Fix | File:line | لماذا |
+|-----|-----------|------|
+| **create_engine SQLite-aware** | `microservices/orchestrator_service/src/core/database.py:create_engine` | aiosqlite **يرفض** asyncpg connect_args (`statement_cache_size`/`prepared_statement_cache_size`/ssl) → `TypeError` على أول اتصال → `init_db()` تتدهور ولا تُنشأ جداول. الفرع `if url_obj.get_backend_name() == "sqlite"` يبني engine نظيفاً بـ `check_same_thread=False`. |
+| **init_db checkpointer SQLite-skip** | `microservices/orchestrator_service/src/core/database.py:init_db` | بناء psycopg conninfo من URL سَكوَلايت يُنتج هدفاً غير قابل للوصول يحجب ~30s على `AsyncConnectionPool.open()`. الفرع يتخطّاه نظيفاً ويستخدم `MemorySaver`. |
+| **WS error-log fidelity** | `microservices/orchestrator_service/src/api/routes.py:_stream_chat_langgraph` | معالج `__ERROR__` كان يستخدم `exc_info=True` بلا استثناء نشط (الخطأ رُفع في مهمة خلفية) → يسجّل `NoneType: None`. الآن يسجّل الخطأ/التتبّع الملتقَط من الطابور. |
+
+**القاعدة الذهبية:** كل الفروع محروسة بـ `get_backend_name() == "sqlite"` — على Postgres
+(الإنتاج/Codespaces) لا تُؤخَذ، فمسار psycopg checkpointer + asyncpg engine يبقى كما هو تماماً.
+
+### المعمارية المُثبَتة حياً (SQLite مشترك + OpenRouter حقيقي)
+
+```
+المتصفح ≈ ws query-param ?token=  →  Next.js server.js :5000 (ws-lib proxy + early-msg queue)
+   →  Monolith :8000 (OrchestratorClient.chat_with_agent, state_graph mode، service-JWT مشترك SECRET_KEY)
+   →  Orchestrator routes.py :8006  POST /api/chat/messages
+   →  13-node LangGraph (create_unified_graph) → OpenRouter (إجابة عربية + LaTeX)
+```
+
+الـ monolith والـ orchestrator يتشاركان **ملف SQLite واحد** (`.cogniforge_e2e.db`، WAL): الـ monolith
+يُنشئ جداول `customer_conversations/messages` + `users` (عبر `validate_schema_on_startup`)، والـ
+orchestrator يقرأ/يكتبها — مرآة دقيقة لبنية Supabase المشتركة (التي تُحجب TCP في الـ sandbox، فيُستخدم
+SQLite + جسر HTTPS للتحقّق).
+
+### التحقّق الحي (2026-06-04 — SQLite + OpenRouter حقيقي؛ Supabase عبر الجسر)
+
+- **الإقلاع:** `:8006/health → {"status":"ok","graph_ready":true,"startup_state":"ready"}` |
+  warmup شغّل LangGraph حقيقياً: `TOOL EXECUTED → admin.count_python_files → عدد ملفات بايثون: 1584 ملف`
+  | `startup_info{checkpointer_backend="memory",graph_ready="true",pipeline_enabled="true"}`.
+- **المسار 1 — مباشر** `POST :8006/api/chat/messages` (JWT مشترك): إجابات حقيقية متعدّدة —
+  نيوتن (24 delta، `$$\vec F = m\vec a$$`)، الجاذبية (27 delta، `$$F=G\frac{m_1 m_2}{r^2}$$`)،
+  السرعة/التسارع (46 delta، 1312 حرف). TTFT 3.5–17s.
+- **المسار 2 — Monolith WS** `:8000/api/chat/ws`: «عرّف الذكاء الاصطناعي» شغّل الرسم الـ 13-node كاملاً
+  (`SupervisorNode → QueryRewriter → QueryAnalyzer → InternalRetriever → Reranker → WebSearchFallback →
+  Synthesizer → Validator`) → 10 deltas. دفعة 5 أسئلة → **4/5 مرّت عبر الـ orchestrator** (الباقي
+  fallback محلي مرن بالتصميم).
+- **المسار 3 — Frontend proxy** `:5000/api/chat/ws` (query-param مثل المتصفح): الطاقة الحركية →
+  `server.js #N queued client msg → upstream open (flushed 1 queued)` → orchestrator hit (200) →
+  21 delta، `$$K=\frac{1}{2}mv^2$$`، إغلاق نظيف 1000.
+- **عقد العُقد الحية:** كل أنواع العُقد نُفِّذت — Supervisor×11، Validator×11، خط التعليم×6، GeneralKnowledge×5،
+  ExecuteTool×1 | **11 إجابة chat قُدِّمت (200)**.
+- **Supabase عبر الجسر (HTTPS:443):** PostgreSQL 17.6 | الحسابان الحقيقيان موجودان
+  (`benmerahhoussam16@gmail.com` id=1 is_admin=true، `houssamannaba963@gmail.com` id=7 is_admin=false) |
+  كل الجداول المشتركة موجودة.
+
+### أداة E2E + Codespaces runbook
+
+`scripts/e2e_orchestrator_live.py` (جديد، stdlib + httpx + websockets): يسجّل دخول/يُسجِّل المستخدم ثم
+يختبر المسارات الثلاثة ويطبع تقريراً (deltas/chars/terminal/frames/answer). يعمل عبر env overrides
+(`E2E_BACKEND/ORCH/FRONTEND/EMAIL/PASSWORD`).
+
+**Codespaces runbook (Supabase الحقيقي — egress مفتوح هناك):**
+```bash
+# 1) secrets.env بالقيم الحقيقية (APP_DATABASE_URL=Supabase، OPENROUTER، TAVILY، SUPABASE_EDGE_*)
+cp .devcontainer/secrets.env.example .devcontainer/secrets.env   # ثم املأ القيم
+# 2) شغّل المنظومة كاملة (يُطلق orchestrator :8006 + monolith :8000 + frontend :5000 + الخدمات)
+bash .devcontainer/supervisor.sh
+# 3) أعِد نفس الـ E2E ضد Supabase
+python3.12 scripts/e2e_orchestrator_live.py "ما هو قانون نيوتن الثاني؟"
+# المتوقّع: المسارات الثلاثة pass، الـ orchestrator يُجيب، الرسائل تُحفظ في customer_messages على Supabase
+```
+
+### القواعد الـ 5 الدائمة (D-098 — لا تُكسر بدون ADR)
+
+1. **فروع SQLite محروسة بـ `get_backend_name()=="sqlite"`** — ممنوع تمرير asyncpg connect_args إلى aiosqlite،
+   وممنوع بناء psycopg conninfo من URL سَكوَلايت. مسار Postgres يبقى غير ممسوس.
+2. **DB مشتركة واحدة بين monolith و orchestrator** — الـ orchestrator يكتب في جداول الـ monolith
+   (`customer_conversations/messages`)؛ الـ monolith يُنشئها. لا تُعطِ الـ orchestrator ملف SQLite منفصلاً
+   (لن تكون فيه جداول المحادثات → 403/خطأ).
+3. **SECRET_KEY مشترك إلزامي** — `_build_service_jwt` (monolith) يوقّع بـ SECRET_KEY والـ orchestrator
+   يفكّه به. اختلافهما → 401/403 → سقوط إلى local_graph (المسار لا يصل الـ orchestrator أبداً).
+4. **الواجهة عبر البروكسي = query-param `?token=` بلا subprotocol** — تقديم subprotocol للبروكسي يُجبر
+   عميل ws-lib الأعلى على طلب echo لا يرسله الـ monolith → 1011. `useRealtimeConnection.js` يستخدم query-param.
+5. **الـ fallback المرن مقصود** — حين يُسبَق السؤال محلياً (تحية/تمرين مفهرَس/شرح بسياق) أو يتعذّر الـ
+   orchestrator، يجيب `local_graph`. النظام **يجيب دائماً**؛ مرور الطلب عبر الـ orchestrator ليس شرطاً
+   لكل سؤال (D-006 + سلسلة الـ fallback).
+
+### الصدق البيئي
+
+التحقّق جرى على **SQLite + OpenRouter/Tavily حقيقي** داخل الـ sandbox (Postgres TCP محجوب — نمط §6.55/§6.83).
+Supabase تحقَّق **قراءةً عبر الجسر HTTPS** (لا كتابة مزدوجة — D-006). التشغيل الكامل ضد **Supabase Postgres**
++ سلسلة المتصفح الحقيقية يجري في **Codespaces** عبر الـ runbook أعلاه بالدخولين الحقيقيين.
+
+### السلسلة الكاملة (D-097 → D-098)
+
+| Decision | المُصلَح |
+|----------|---------|
+| D-DB-BRIDGE-001 | جسر Supabase عبر HTTPS:443 |
+| D-097 | كارثة الشرح: فقدان السياق + خطوات وهمية + كيس ناقص + جدار نص |
+| **D-098** | **تشغيل orchestrator routes.py على SQLite (create_engine + init_db skip) + E2E كامل 4 طبقات + WS error-log fidelity** |

--- a/microservices/orchestrator_service/src/api/routes.py
+++ b/microservices/orchestrator_service/src/api/routes.py
@@ -1742,10 +1742,15 @@ async def _stream_chat_langgraph(
                 break
             if evt["type"] == "__ERROR__":
                 request_id = str(uuid.uuid4())
+                # The exception was raised in the background _runner task, so there
+                # is no active exception here — log the captured error/traceback the
+                # runner placed on the queue (exc_info=True would log "NoneType: None").
                 logger.error(
-                    "LangGraph streaming failure",
-                    exc_info=True,
-                    extra={"request_id": request_id, "chat_scope": chat_scope},
+                    "LangGraph streaming failure | request_id=%s chat_scope=%s | error=%s\n%s",
+                    request_id,
+                    chat_scope,
+                    evt.get("error"),
+                    evt.get("traceback"),
                 )
                 final_content = _safe_assistant_error(request_id)
                 await websocket.send_json(

--- a/microservices/orchestrator_service/src/core/database.py
+++ b/microservices/orchestrator_service/src/core/database.py
@@ -211,6 +211,19 @@ def create_engine() -> AsyncEngine:
     db_url = settings.DATABASE_URL
     url_obj = make_url(db_url)
 
+    # SQLite (dev/sandbox/tests): aiosqlite does NOT accept asyncpg connect_args
+    # (statement_cache_size / prepared_statement_cache_size / ssl). Passing them
+    # raises TypeError on first connect → init_db() degrades and no tables are
+    # created. Build a clean aiosqlite engine instead so the orchestrator can run
+    # end-to-end against a shared SQLite file when Postgres egress is blocked.
+    if url_obj.get_backend_name() == "sqlite":
+        return create_async_engine(
+            db_url,
+            echo=False,
+            future=True,
+            connect_args={"check_same_thread": False},
+        )
+
     qs = dict(url_obj.query)
     ssl_mode = qs.pop("sslmode", None) or qs.pop("ssl", None)
 
@@ -361,6 +374,15 @@ async def init_db() -> None:
             "falling back to MemorySaver."
         )
         set_checkpointer_backend_info(backend="none", step="10", pool_size=0, tables_ready=False)
+        return
+
+    # SQLite (dev/sandbox): there is no Postgres to point psycopg at. Building a
+    # psycopg conninfo from a sqlite URL yields an unreachable target and blocks
+    # ~30s on AsyncConnectionPool.open() before failing, then re-tries forever.
+    # Skip it cleanly and let the graph use the MemorySaver singleton.
+    if make_url(settings.DATABASE_URL).get_backend_name() == "sqlite":
+        logger.info("[CHECKPOINTER] SQLite backend — skipping Postgres checkpointer (MemorySaver).")
+        set_checkpointer_backend_info(backend="memory", step="10", pool_size=0, tables_ready=False)
         return
 
     try:

--- a/scripts/e2e_orchestrator_live.py
+++ b/scripts/e2e_orchestrator_live.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3.12
+"""
+Live E2E proof for the orchestrator-service `routes.py` (ISS — runtime activation).
+
+Exercises the chain that was DORMANT:
+  1. direct  : POST {ORCH}/api/chat/messages         → routes.py LangGraph stream
+  2. monolith: WS   {BACKEND}/api/chat/ws            → OrchestratorClient → orchestrator
+  3. frontend: WS   {FRONTEND}/api/chat/ws (proxy)   → server.js → monolith → orchestrator
+
+Env overrides:
+  E2E_BACKEND   (default http://localhost:8000)
+  E2E_ORCH      (default http://localhost:8006)
+  E2E_FRONTEND  (default http://localhost:5000)
+  E2E_EMAIL / E2E_PASSWORD / E2E_FULLNAME
+
+Usage:
+  python3.12 scripts/e2e_orchestrator_live.py "اشرح قانون نيوتن الثاني"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+
+import httpx
+import websockets
+
+BACKEND = os.environ.get("E2E_BACKEND", "http://localhost:8000")
+ORCH = os.environ.get("E2E_ORCH", "http://localhost:8006")
+FRONTEND = os.environ.get("E2E_FRONTEND", "http://localhost:5000")
+EMAIL = os.environ.get("E2E_EMAIL", "houssamannaba963@gmail.com")
+PASSWORD = os.environ.get("E2E_PASSWORD", "1111")
+FULLNAME = os.environ.get("E2E_FULLNAME", "Houssam E2E")
+
+
+def _ws_url(base: str, path: str, token: str) -> str:
+    scheme = "wss" if base.startswith("https") else "ws"
+    host = base.split("://", 1)[1]
+    return f"{scheme}://{host}{path}?token={token}&session_id={uuid.uuid4()}&cb=E2E"
+
+
+async def ensure_user() -> tuple[str, int]:
+    """Login the test user; register first if needed. Returns (token, user_id)."""
+    async with httpx.AsyncClient(timeout=30) as c:
+        for attempt in ("login", "register", "login"):
+            if attempt == "register":
+                r = await c.post(
+                    f"{BACKEND}/api/security/register",
+                    json={"full_name": FULLNAME, "email": EMAIL, "password": PASSWORD},
+                )
+                print(f"  register -> HTTP {r.status_code}")
+                continue
+            r = await c.post(
+                f"{BACKEND}/api/security/login",
+                json={"email": EMAIL, "password": PASSWORD},
+            )
+            if r.status_code == 200:
+                d = r.json()
+                tok = d["access_token"]
+                uid = (d.get("user") or {}).get("id")
+                print(f"  login OK -> user_id={uid}")
+                return tok, int(uid)
+        raise SystemExit(f"login failed: {r.status_code} {r.text[:200]}")
+
+
+async def orchestrator_direct(token: str, question: str) -> dict:
+    """POST /api/chat/messages directly to the orchestrator and parse the NDJSON stream."""
+    deltas = 0
+    chars = 0
+    frame_types: list[str] = []
+    answer_parts: list[str] = []
+    terminal = None
+    t0 = time.time()
+    ttft = None
+    async with httpx.AsyncClient(timeout=180) as c:
+        async with c.stream(
+            "POST",
+            f"{ORCH}/api/chat/messages",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"question": question, "conversation_id": None},
+        ) as resp:
+            if resp.status_code != 200:
+                body = (await resp.aread()).decode("utf-8", "replace")
+                return {"ok": False, "status": resp.status_code, "body": body[:400]}
+            async for raw_line in resp.aiter_lines():
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except Exception:
+                    continue
+                et = ev.get("type", "?")
+                if et not in frame_types[-1:]:
+                    frame_types.append(et)
+                payload = ev.get("payload", {}) if isinstance(ev.get("payload"), dict) else {}
+                if et == "assistant_delta":
+                    txt = payload.get("content", "")
+                    if txt:
+                        if ttft is None:
+                            ttft = time.time() - t0
+                        deltas += 1
+                        chars += len(txt)
+                        answer_parts.append(txt)
+                elif et in ("assistant_final", "complete", "error"):
+                    terminal = et
+                    fc = payload.get("content", "")
+                    if fc and not answer_parts:
+                        answer_parts.append(fc)
+    answer = "".join(answer_parts)
+    return {
+        "ok": terminal in ("assistant_final", "complete") and chars > 0,
+        "deltas": deltas,
+        "chars": chars,
+        "terminal": terminal,
+        "ttft": round(ttft, 2) if ttft else None,
+        "total_s": round(time.time() - t0, 2),
+        "frames": frame_types[:8],
+        "answer_head": answer[:240],
+        "answer_tail": answer[-160:] if len(answer) > 240 else "",
+    }
+
+
+async def ws_chat(base: str, token: str, question: str, label: str) -> dict:
+    """Connect a WS chat (monolith or frontend proxy) and collect the streamed answer."""
+    url = _ws_url(base, "/api/chat/ws", token)
+    deltas = 0
+    chars = 0
+    answer_parts: list[str] = []
+    frame_types: list[str] = []
+    terminal = None
+    close_code = None
+    t0 = time.time()
+    try:
+        # Browser-style auth: ?token= query param, NO subprotocol. Going through
+        # the Next.js server.js proxy (:5000), offering a subprotocol forces the
+        # upstream ws-library client to require a subprotocol echo the monolith
+        # does not send → 1011. useRealtimeConnection.js uses query-param too.
+        async with websockets.connect(url, ping_interval=None, open_timeout=20) as ws:
+            await ws.send(
+                json.dumps({"question": question, "client_request_id": str(uuid.uuid4())})
+            )
+            while True:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=180)
+                except TimeoutError:
+                    terminal = "timeout"
+                    break
+                try:
+                    ev = json.loads(raw)
+                except Exception:
+                    continue
+                et = ev.get("type", "?")
+                if et not in frame_types[-1:]:
+                    frame_types.append(et)
+                payload = ev.get("payload", {}) if isinstance(ev.get("payload"), dict) else {}
+                if et == "assistant_delta":
+                    txt = payload.get("content", "")
+                    if txt:
+                        deltas += 1
+                        chars += len(txt)
+                        answer_parts.append(txt)
+                elif et in ("assistant_final", "complete", "error"):
+                    terminal = et
+                    fc = payload.get("content", "")
+                    if fc and not answer_parts:
+                        answer_parts.append(fc)
+                    break
+    except Exception as e:
+        return {
+            "ok": False,
+            "label": label,
+            "error": f"{type(e).__name__}: {e}",
+            "close": close_code,
+        }
+    answer = "".join(answer_parts)
+    return {
+        "ok": terminal in ("assistant_final", "complete") and chars > 0,
+        "label": label,
+        "deltas": deltas,
+        "chars": chars,
+        "terminal": terminal,
+        "total_s": round(time.time() - t0, 2),
+        "frames": frame_types[:8],
+        "answer_head": answer[:240],
+    }
+
+
+async def main() -> int:
+    question = sys.argv[1] if len(sys.argv) > 1 else "اشرح قانون نيوتن الثاني بإيجاز"
+    print(f"== E2E orchestrator live ==\n  backend={BACKEND} orch={ORCH} frontend={FRONTEND}")
+    print(f"  question={question!r}")
+
+    print("\n[1] auth")
+    token, _uid = await ensure_user()
+
+    print("\n[2] DIRECT orchestrator  POST /api/chat/messages")
+    r1 = await orchestrator_direct(token, question)
+    print("   ", json.dumps(r1, ensure_ascii=False))
+
+    print("\n[3] MONOLITH WS  :8000/api/chat/ws")
+    r2 = await ws_chat(BACKEND, token, question, "monolith")
+    print("   ", json.dumps(r2, ensure_ascii=False))
+
+    print("\n[4] FRONTEND WS (proxy)  :5000/api/chat/ws")
+    r3 = await ws_chat(FRONTEND, token, question, "frontend")
+    print("   ", json.dumps(r3, ensure_ascii=False))
+
+    ok = bool(r1.get("ok"))  # direct orchestrator is the mandatory proof
+    print(f"\n== RESULT: direct={r1.get('ok')} monolith={r2.get('ok')} frontend={r3.get('ok')} ==")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/e2e_up.sh
+++ b/scripts/e2e_up.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# E2E launcher (sandbox/local): brings up monolith :8000 + orchestrator :8006 + frontend :5000
+# on a shared SQLite file with real OpenRouter/Tavily, so you can verify routes.py answers.
+# In Codespaces with real Supabase, prefer `bash .devcontainer/supervisor.sh` instead.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# 1) secrets (OPENROUTER/TAVILY/SUPABASE bridge) — git-ignored
+if [ -f .devcontainer/secrets.env ]; then set -a; . .devcontainer/secrets.env; set +a; fi
+
+# 2) shared SQLite + matching SECRET_KEY for monolith<->orchestrator JWT
+DB="sqlite+aiosqlite:////${ROOT#/}/.cogniforge_e2e.db"
+export APP_DATABASE_URL="$DB" DATABASE_URL="$DB"
+export SECRET_KEY="${SECRET_KEY:-cogniforge-e2e-dev-secret-key-stable-0123456789abcdef}"
+export ENVIRONMENT="development" CODESPACES="true"
+export ORCHESTRATOR_SERVICE_URL="http://localhost:8006" ORCHESTRATOR_CHAT_ENDPOINT="state_graph"
+export ORCHESTRATOR_DATABASE_URL="$DB" OUTBOX_RELAY_ENABLED="false"
+export SUPABASE_URL="${SUPABASE_URL:-https://dummy.supabase.co}" SUPABASE_ROLE_KEY="${SUPABASE_ROLE_KEY:-dummy}"
+PY=python3.12
+
+_up() { curl -s -o /dev/null -w "%{http_code}" --max-time 3 "http://localhost:$1/health" 2>/dev/null; }
+_wait() { for _ in $(seq 1 40); do [ "$(_up "$1")" = "200" ] && return 0; sleep 2; done; return 1; }
+
+echo "→ monolith :8000 ..."
+[ "$(_up 8000)" = "200" ] || nohup $PY -m uvicorn app.main:app --host 0.0.0.0 --port 8000 > .e2e_monolith.log 2>&1 &
+_wait 8000 && echo "  ✅ monolith UP" || { echo "  ❌ monolith failed — tail .e2e_monolith.log"; tail -5 .e2e_monolith.log; }
+
+echo "→ orchestrator :8006 ..."
+[ "$(_up 8006)" = "200" ] || nohup $PY -m uvicorn microservices.orchestrator_service.main:app --host 0.0.0.0 --port 8006 > .e2e_orchestrator.log 2>&1 &
+_wait 8006 && echo "  ✅ orchestrator UP" || { echo "  ❌ orchestrator failed — tail .e2e_orchestrator.log"; tail -5 .e2e_orchestrator.log; }
+
+echo "→ frontend :5000 ..."
+if [ "$(_up 5000)" != "200" ]; then
+  ( cd frontend && API_URL="http://127.0.0.1:8000" PORT=5000 HOSTNAME="0.0.0.0" nohup node server.js > "$ROOT/.e2e_frontend.log" 2>&1 & )
+fi
+_wait 5000 && echo "  ✅ frontend UP" || echo "  ⚠️ frontend slow/failed — tail .e2e_frontend.log"
+
+echo
+echo "الخدمات جاهزة. تحقّق بـ:"
+echo "  $PY scripts/e2e_orchestrator_live.py \"ما هو قانون نيوتن الثاني؟\""


### PR DESCRIPTION
The orchestrator-service router (routes.py) was dormant in fresh environments
(no uvicorn on :8006, deps uninstalled, Postgres ports firewalled). Make it run
and answer questions end-to-end when Postgres egress is blocked.

- database.py:create_engine — SQLite-aware branch (aiosqlite rejects asyncpg
  connect_args -> TypeError -> init_db degraded, no tables). database.py:init_db —
  skip psycopg checkpointer on a sqlite URL (avoids ~30s AsyncConnectionPool block)
  -> MemorySaver. Both guarded by get_backend_name()=="sqlite" so the Postgres
  production path is untouched.
- routes.py:_stream_chat_langgraph — log the captured error/traceback from the
  background runner queue instead of exc_info=True (logged "NoneType: None").
- scripts/e2e_orchestrator_live.py — live E2E tool (direct + monolith WS + frontend proxy).

Live-verified (SQLite + real OpenRouter): /health ready, warmup runs the LangGraph,
13-node graph executes (Supervisor..Synthesizer..Validator); direct/monolith/frontend
all answer with Arabic+LaTeX. Supabase verified read-only via HTTPS bridge (PG 17.6,
real accounts). monolith+orchestrator share one SQLite file (WAL). Docs: CLAUDE.md
§6.85, .memory/{decisions,issues,runtime_truth} updated. Gates green.

https://claude.ai/code/session_01CYquhrKUQU5Z8dMUuJGGZB