### PR TITLE
fix: Restrict CONTENT_RETRIEVAL regex greediness

### DIFF
--- a/.memory/routing_philosophy.md
+++ b/.memory/routing_philosophy.md
@@ -1,0 +1,25 @@
+# Routing Philosophy Doctrine
+
+## 1. Purpose
+To define the strict architectural boundaries for Intent Classification and Query Routing across the platform, preventing Semantic Hijacking (where broad terms capture unrelated analytical requests).
+
+## 2. Core Invariant
+Intent Routing MUST NOT rely on unbounded greedy regular expressions (`(.*)`) or keyword dictatorships (e.g., broad matches for the word "تمرين"). Analytical, deep reasoning, and complex mission intents hold strict priority over simple content retrieval.
+
+## 3. Runtime Implications
+- Intent regexes MUST use exact bounds (`^`, `$`) and length constraints (e.g., `.{0,60}`) to limit their capture radius.
+- Standard Arabic keywords (e.g., "الاحتمالات") are prefixed with definite articles. Therefore, Python word boundaries (`\b`) MUST be avoided around standard Arabic keywords if they break prefixed matches, unless specifically handled.
+- The default behavior for unmatched, long, or complex inputs must fall through to an analytical engine (`DEFAULT`, `DEEP_ANALYSIS`, or `MISSION_COMPLEX`).
+
+## 4. Service Mapping
+- `app/services/chat/intent_registry.py` (Central Registry)
+- `app/services/chat/intent_detector.py` (Monolith Fallback Router)
+- `microservices/orchestrator_service/src/services/overmind/utils/intent_detector.py` (Microservice Router)
+
+## 5. Student Interaction Contract
+When a student pastes a long problem description or an analytical question containing words like "تمرين", the system MUST NOT blindly serve a retrieved document. Instead, it must trigger the tutor to read, analyze, and assist the student pedagogically.
+
+## 6. Acceptance Criteria
+- A purely conversational or long analytical query containing the word "تمرين" does not trigger `CONTENT_RETRIEVAL`.
+- A direct, short query like "اريد تمرين الاحتمالات" successfully triggers `CONTENT_RETRIEVAL`.
+- The regex logic remains consistent across both Monolith and Microservice intent detectors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10726,7 +10726,7 @@ The following foundational architectural invariants have been established in the
 
 1. **Trace Continuity (Split-Brain Tracing Resolved):** Microservices strictly isolate context while participating in standard W3C tracing. The Orchestrator microservice correctly parses W3C `traceparent` headers via `microservices/orchestrator_service/src/api/trace_utils.py`, injecting `langsmith-trace` into LangGraph execution, preventing disconnected traces across system boundaries.
 2. **Rendering Integrity (DOM Leakage Fixed):** UI elements holding state enforce strict true DOM exclusion via React's `inert` attribute and structured `visibility: hidden` delayed CSS transitions to prevent sidebars from remaining queryable while visually hidden, thereby preserving pedagogical Socratic masking.
-3. **Routing Philosophy (IntentGreediness Fixed):** Broad heuristic intent matching (e.g. any message with 'تمرين') has been replaced with bounded, bounded regex patterns (`\b`) prioritizing specific `_ANALYTICS_PATTERNS` before `_EDUCATIONAL_PATTERNS` across both `app/services/chat/local_graph.py` and `app/telemetry/path_observer.py`, stopping general questions from being hijacked into educational logic flows.
+3. **Routing Philosophy (IntentGreediness Fixed):** Broad heuristic intent matching (e.g. any message with 'تمرين') has been replaced with bounded, length-bounded regex patterns (`.{0,60}` and removal of `\b` for Arabic prefixed words) prioritizing specific `_ANALYTICS_PATTERNS` before `_EDUCATIONAL_PATTERNS` across both `app/services/chat/local_graph.py` and `app/telemetry/path_observer.py`, stopping general questions from being hijacked into educational logic flows.
 
 ---
 

--- a/app/services/chat/intent_detector.py
+++ b/app/services/chat/intent_detector.py
@@ -100,7 +100,7 @@ class IntentDetector:
             # Flexible Content Retrieval: Catch implicit content requests
             # e.g., "Math 2024", "Probability", "Subject 1", "Lesson about X"
             (
-                r"((أ|ا)ريد|بدي|i want|need|show|أعطني|هات|give me)?\s*(.*)(20[1-2][0-9]|bac|بكالوريا|subject|topic|lesson|درس|موضوع|تمارين|تمرين|exam|exercise|exercises|question|احتمالات|دوال|متتاليات|probability|functions|sequences)(.+)?",
+                r"^((أ|ا)ريد|بدي|i want|need|show|أعطني|هات|give me)?\s*(.{0,60})(20[1-2][0-9]|bac|بكالوريا|subject|topic|lesson|درس|موضوع|تمارين|تمرين|exam|exercise|exercises|question|احتمالات|دوال|متتاليات|probability|functions|sequences)(.{0,60})?$",
                 ChatIntent.CONTENT_RETRIEVAL,
                 self._extract_query_optional,
             ),

--- a/app/services/chat/intent_registry.py
+++ b/app/services/chat/intent_registry.py
@@ -113,7 +113,7 @@ def register_default_patterns() -> None:
 
     # Content retrieval (high priority)
     IntentPatternRegistry.register(
-        r"((أ|ا)ريد|بدي|i want|need|show|أعطني|هات|give me)?\s*(.*)(20[1-2][0-9]|bac|بكالوريا|subject|topic|lesson|درس|موضوع|تمارين|تمرين|exam|exercise|exercises|احتمالات|دوال|متتاليات|probability|functions|sequences)(.+)?",
+        r"^((أ|ا)ريد|بدي|i want|need|show|أعطني|هات|give me)?\s*(.{0,60})(20[1-2][0-9]|bac|بكالوريا|subject|topic|lesson|درس|موضوع|تمارين|تمرين|exam|exercise|exercises|احتمالات|دوال|متتاليات|probability|functions|sequences)(.{0,60})?$",
         ChatIntent.CONTENT_RETRIEVAL,
         priority=80,
     )

--- a/microservices/orchestrator_service/src/services/overmind/utils/intent_detector.py
+++ b/microservices/orchestrator_service/src/services/overmind/utils/intent_detector.py
@@ -90,7 +90,7 @@ class IntentDetector:
                 self._empty_params,
             ),
             (
-                r"((أ|ا)ريد|بدي|i want|need|show|أعطني|هات|give me)?\s*(.*)(20[1-2][0-9]|bac|بكالوريا|subject|topic|lesson|درس|موضوع|تمارين|تمرين|exam|exercise|exercises|احتمالات|دوال|متتاليات|probability|functions|sequences)(.+)?",
+                r"^((أ|ا)ريد|بدي|i want|need|show|أعطني|هات|give me)?\s*(.{0,60})(20[1-2][0-9]|bac|بكالوريا|subject|topic|lesson|درس|موضوع|تمارين|تمرين|exam|exercise|exercises|احتمالات|دوال|متتاليات|probability|functions|sequences)(.{0,60})?$",
                 ChatIntent.CONTENT_RETRIEVAL,
                 self._extract_query_optional,
             ),


### PR DESCRIPTION
Fixes a critical routing bug where long analytical queries were being misclassified as Content Retrieval requests.

---
*PR created automatically by Jules for task [4971306035366070017](https://jules.google.com/task/4971306035366070017) started by @HOUSSAM16ai*