### PR TITLE
Fix Probability UI Combinatorics historical pollution (D-152)

### DIFF
--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -5093,3 +5093,15 @@ count=0; (3) concept-naming unified by construction (same key space as micro-sim
 «ما القيم التي يمكن أن يأخذها X؟») instead of punting; deterministic, redaction-safe, no behavior
 change for uncovered concepts. Verification: `scripts/verify_iss119_live.py` (ALL PASS) + 6 tests.
 **Mandatory live E2E in Codespaces** (real secrets, WS path) per §6.55. CLAUDE.md §6.127.
+
+
+## Memory / Decisions Update
+- **Context:** The `FullExerciseStory` UI component for probability combinatorics suffered from "historical pollution" (e.g. `C(23,3)=1771`) where elements like `بطاقة رقم 0 اضغط للكشف` passed in the `history_text` were mistakenly extracted as real entities by `_extract_count_entities`.
+- **Action:** Implemented a Strict Validation Gate inside `ProbabilityCalculatorSkill._strategy_composition`. We extract explicitly stated probability fractions from the problem `source` using regex `r'(\d+)\s*/\s*(\d+)'`. We reject the generation path (returning `None`) if the dynamically computed `total_combinations` does not have a clean modular relationship with any of the stated denominators.
+- **Result:** Invalid entities injected via user chat history can no longer override explicitly stated values and mathematical facts in the problem itself, successfully forcing fallback to deep generative text without corrupting the visual state.
+
+
+## Memory / Decisions Update
+- **Context:** The `FullExerciseStory` UI component for probability combinatorics suffered from "historical pollution" (e.g. `C(23,3)=1771`) where elements like `بطاقة رقم 0 اضغط للكشف` passed in the `history_text` were mistakenly extracted as real entities by `_extract_count_entities`.
+- **Action:** Implemented a Strict Validation Gate inside `ProbabilityCalculatorSkill._strategy_composition`. We extract explicitly stated probability fractions from the problem `source` using regex `r'(\d+)\s*/\s*(\d+)'`. We reject the generation path (returning `None`) if the dynamically computed `total_combinations` does not have a clean modular relationship with any of the stated denominators.
+- **Result:** Invalid entities injected via user chat history can no longer override explicitly stated values and mathematical facts in the problem itself, successfully forcing fallback to deep generative text without corrupting the visual state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10771,3 +10771,15 @@ The following foundational architectural invariants have been established in the
 |----------|---------|
 | D-146 | Agentic Cognitive Runtime doctrine |
 | **D-147** | **خطوة التطبيق المرتبطة بالتمرين تستبدل الـ punt السقراطي العام (يحلّ كارثة E(X) — ISS-119)** |
+
+
+### Probability Skill Validation Gate (D-152)
+- To prevent UI state corruption from historical chat text containing entities (like UI labels e.g., "بطاقة رقم 0 اضغط للكشف"), `ProbabilityCalculatorSkill` enforces a strict arithmetic Validation Gate.
+- The generated `total_combinations` (sample space denominator) must perfectly align with explicitly stated denominators provided in the original text (e.g., `P(B)=56/165` mandates `165` or a multiple of it).
+- If a mismatch is detected, the combinatorial visualization path is safely aborted (`return None`), and the system gracefully degrades to standard LLM logic.
+
+
+### Probability Skill Validation Gate (D-152)
+- To prevent UI state corruption from historical chat text containing entities (like UI labels e.g., "بطاقة رقم 0 اضغط للكشف"), `ProbabilityCalculatorSkill` enforces a strict arithmetic Validation Gate.
+- The generated `total_combinations` (sample space denominator) must perfectly align with explicitly stated denominators provided in the original text (e.g., `P(B)=56/165` mandates `165` or a multiple of it).
+- If a mismatch is detected, the combinatorial visualization path is safely aborted (`return None`), and the system gracefully degrades to standard LLM logic.

--- a/app/services/skills/probability_skill.py
+++ b/app/services/skills/probability_skill.py
@@ -1183,10 +1183,12 @@ class ProbabilityCalculatorSkill:
 
         # Validation Gate: Reject if total_comb contradicts explicitly stated denominators in the exercise text
         # This prevents UI corruption from historical text pollution
-        stated_denoms_match = re.findall(r'(\d+)\s*/\s*(\d+)', combined)
+        stated_denoms_match = re.findall(r"(\d+)\s*/\s*(\d+)", combined)
         if stated_denoms_match:
             stated_denoms = {int(den) for _, den in stated_denoms_match if int(den) > 1}
-            if stated_denoms and not any((total_comb % d == 0) or (d % total_comb == 0) for d in stated_denoms):
+            if stated_denoms and not any(
+                (total_comb % d == 0) or (d % total_comb == 0) for d in stated_denoms
+            ):
                 return None
 
         groups: list[CombinationGroup] = []
@@ -1283,10 +1285,12 @@ class ProbabilityCalculatorSkill:
 
         # Validation Gate: Reject if total_comb contradicts explicitly stated denominators in the exercise text
         # This prevents UI corruption from historical text pollution
-        stated_denoms_match = re.findall(r'(\d+)\s*/\s*(\d+)', combined)
+        stated_denoms_match = re.findall(r"(\d+)\s*/\s*(\d+)", combined)
         if stated_denoms_match:
             stated_denoms = {int(den) for _, den in stated_denoms_match if int(den) > 1}
-            if stated_denoms and not any((total_comb % d == 0) or (d % total_comb == 0) for d in stated_denoms):
+            if stated_denoms and not any(
+                (total_comb % d == 0) or (d % total_comb == 0) for d in stated_denoms
+            ):
                 return None
 
         steps: list[ExerciseStep] = []

--- a/app/services/skills/probability_skill.py
+++ b/app/services/skills/probability_skill.py
@@ -1181,6 +1181,14 @@ class ProbabilityCalculatorSkill:
         if total_comb < 1:
             return None
 
+        # Validation Gate: Reject if total_comb contradicts explicitly stated denominators in the exercise text
+        # This prevents UI corruption from historical text pollution
+        stated_denoms_match = re.findall(r'(\d+)\s*/\s*(\d+)', combined)
+        if stated_denoms_match:
+            stated_denoms = {int(den) for _, den in stated_denoms_match if int(den) > 1}
+            if stated_denoms and not any((total_comb % d == 0) or (d % total_comb == 0) for d in stated_denoms):
+                return None
+
         groups: list[CombinationGroup] = []
         same_group = 0
         for label_pos, _neg, count in comp_raw:
@@ -1272,6 +1280,14 @@ class ProbabilityCalculatorSkill:
         total_comb = math.comb(total, k)
         if total_comb < 1:
             return None
+
+        # Validation Gate: Reject if total_comb contradicts explicitly stated denominators in the exercise text
+        # This prevents UI corruption from historical text pollution
+        stated_denoms_match = re.findall(r'(\d+)\s*/\s*(\d+)', combined)
+        if stated_denoms_match:
+            stated_denoms = {int(den) for _, den in stated_denoms_match if int(den) > 1}
+            if stated_denoms and not any((total_comb % d == 0) or (d % total_comb == 0) for d in stated_denoms):
+                return None
 
         steps: list[ExerciseStep] = []
 


### PR DESCRIPTION
Fix Probability UI Combinatorics historical pollution (D-152)

- Implemented a strict validation gate inside `ProbabilityCalculatorSkill._strategy_composition` and `_build_combinations`.
- Explicitly stated denominators in the context are extracted and compared against the dynamically generated `total_combinations`.
- If the computed sample space has been inflated by spurious historical entities (like UI interactive markers) and does not map cleanly, the visualization path degrades safely to `None` avoiding arithmetic hallucinations in the UI.

---
*PR created automatically by Jules for task [6535565338395549606](https://jules.google.com/task/6535565338395549606) started by @HOUSSAM16ai*