### PR TITLE
D-179 Phase 2a: introduce BaseSkill ABC + skill_counter helper

### DIFF
--- a/.memory/ci-gates.md
+++ b/.memory/ci-gates.md
@@ -1,12 +1,20 @@
 # CI Gates — Pre-merge Required Checks
-> Last updated: 2026-05-06 | Branch: `claude/autonomous-runtime-observability-pjzY9`
+> Last updated: 2026-07-22 | Branch: `claude/oop-claude-md-update-e2ziez`
+> **D-179 note:** the `guardrails` job now also runs `check_test_hygiene.py`,
+> `check_legacy_invariants.py` (D-173), `check_model_chain_parity.py` (D-174),
+> `check_no_cross_service_imports.py`, `check_ports_consistency.py`,
+> `check_single_brain_control_plane.py`, `check_core_kernel_acl.py`,
+> `check_abstraction_consumed.py` (D-176). The Skills Doctrine gate
+> (`skills-doctrine-gate.yml` → `check_skills_doctrine.py`) and the Pedagogical-OS gate
+> (`check_pedagogical_os.py`) both stay green after the BaseSkill adoption (23 skills).
 
 ## Required jobs (must be green)
 | Workflow | Job | What it enforces |
 |---|---|---|
 | `ci.yml` | `lint` | `ruff check .` + `ruff format --check .` |
 | `ci.yml` | `contracts` | gateway/provider parity (`scripts/fitness/check_gateway_provider_contracts.py` + `tests/contracts/`) |
-| `ci.yml` | `guardrails` | `ci_guardrails.py` + `check_no_app_imports_in_microservices.py --strict` + `check_route_registry_parity.py` + `check_tracing_gate.py` |
+| `ci.yml` | `guardrails` | `ci_guardrails.py` + `check_no_app_imports_in_microservices.py --strict` + `check_route_registry_parity.py` + `check_tracing_gate.py` + `check_test_hygiene.py` + `check_legacy_invariants.py` + `check_model_chain_parity.py` + `check_no_cross_service_imports.py` + `check_ports_consistency.py` + `check_single_brain_control_plane.py` + `check_core_kernel_acl.py` + `check_abstraction_consumed.py` |
+| `skills-doctrine-gate.yml` | `check_skills_doctrine` | every skill imports from `doctrine.py`; ~15 `check_*_wired` token-assertions (BaseSkill adoption preserves all) |
 | `ci.yml` | `test` | full pytest suite (`tests/`) |
 | `ci.yml` | `required-ci` | aggregator — fails if any required job fails |
 | `structure-validation.yml` | structure-validation | `scripts/validate_structure.py` |

--- a/.memory/context.md
+++ b/.memory/context.md
@@ -5,6 +5,9 @@
 > See `cognitive_lab_philosophy.md` for the foundational doctrine.
 
 # CogniForge — Project Context
+> 🟢 **آخر تحديث تشغيلي: 2026-07-22 · Branch `claude/oop-claude-md-update-e2ziez` (D-179):** طبقة
+> المهارات موحَّدة على قاعدة `BaseSkill` (OOP، 23 مهارة)؛ تحقّق حيّ E2E أثبت «يجيب على كل سؤال»
+> (4/4 عربي+LaTeX عبر PRIMARY `openai/gpt-oss-20b:free`)؛ تماسك `.memory` مُصلَح (backfill 6 عناوين).
 > 🧭 **الرؤية الثورية وخارطة الطريق:** المصدر الحيّ الوحيد هو **`.memory/roadmap.md`** (ملخّص في CLAUDE.md §0.6).
 > 🏗️ **العدسة المعمارية (Agentic Runtime):** `.memory/agentic_runtime_doctrine.md` (D-146 · CLAUDE.md §0.7) — خريطة الطبقات مُقيَّمة بصدق حسب §6.6.
 > Last updated: **2026-07-18** | Branch: `claude/project-refactor-microservices-a9unyi` (D-170: تفكيك آخر ملفَّين ضخمَين — `chat_with_agent` **1,926→440 سطراً** عبر 13 مرحلة sub-generator (`TurnContext` + 6 وحدات turn_* مُضافة لـ `TUTOR_SOURCE_FILES`)، `local_graph.py` **1,769→1,193 سطراً** (مُطهِّرات + شرح مُستخرَجان + re-export خلفي)، `probability_skill.py` **1,685→1,462** (نماذج Pydantic → `probability_models.py`) · **D-171 يُغلق ISS-132**: هوية الإدمن (`is_admin/user_role/scope`) تُصرَّح في `AgentState` + تُمرَّر مُسوَّرةً بـ `_is_admin_payload` فتعبر الرسم الـ12-node (كانت الأداة تُنفَّذ ثم تُرفَض ADMIN_ACCESS_DENIED) — §6.143. سبقه D-168 §6.141 · D-169 §6.142 · D-165/D-166/D-167 §6.140).

--- a/.memory/decisions.md
+++ b/.memory/decisions.md
@@ -5,6 +5,41 @@
 > See `cognitive_lab_philosophy.md` for the foundational doctrine.
 
 # Architectural Decisions
+## D-179 · BaseSkill OOP + تحقّق حيّ من ضمان الإجابة + إصلاح تماسك الذاكرة (2026-07-22)
+**السياق:** طلب المالك (١) تطبيق OOP متقدّم على طبقة المهارات، (٢) التأكّد حياً أن النظام «يجيب على
+كل الأسئلة»، (٣) إصلاح انحراف تماسك `.memory/` + `CLAUDE.md`، مع بقاء GitHub Actions أخضر 100%.
+كشف الفحص أن طبقة `app/services/skills/` بلا **قاعدة موحَّدة**: كل مهارة تُعيد كتابة نفس البنية
+الثلاثية يدوياً (هوية `name`/`version`، singleton كسول `_x_singleton`+`get_x_skill()` في ~16 ملفاً،
+وحارس Prometheus المُعاد `try: from prometheus_client…` في ~13 ملفاً). كما أن `.memory` يحمل انحراف
+تنظيم: `issues.md` متأخّر عن `decisions.md`، وستّة قرارات مُشار إليها في `CLAUDE.md`/البوّابات بلا
+عناوين (D-035/037/044/045/109/152).
+
+**القرار (OOP — بلا تغيير سلوك، صفر كسر بوّابة):**
+- وحدة جديدة `app/services/skills/base.py`: `BaseSkill[InT, OutT]` (ABC، PEP-695 generics) تُوحِّد
+  الهوية + singleton كسول لكل-صنف (`instance()` يُعيد `Self`) + نقطة دخول polymorphic `run()`؛
+  ومساعدان `skill_counter`/`skill_histogram` يُوحِّدان حارس Prometheus (على `REGISTRY` العام
+  الافتراضي — **لا CollectorRegistry جديد**؛ no-op عند غياب prometheus). dep-free، بلا استيراد
+  عابر للخدمات. مُعاد التصدير من جذر الحزمة.
+- **تبنٍّ عبر 23 مهارة**: Wave 1 (9 مهارات بلا بوّابة token) توحّد أيضاً الـ accessor عبر
+  `instance()`؛ Wave 2 (14 مهارة محروسة بـ`check_*_wired`) تُبقي accessor كما هو (تحفُّظاً) وتضيف
+  `run` المُفوِّض للطريقة الأصلية (invoke/align/check/decide/redact/read/interpret/…). **كل token
+  محروس مُصان حرفياً**، و`dialogue_manager` يبقى خالياً من `async def decide`/`get_ai_client`/
+  `send_message` المحظورة. المحرك الاحتمالي + gateway/model-chain **لم تُمسّ** (حماية مسار الإجابة).
+- اختبارات `tests/services/test_skills_base.py` (7) تُثبت: ABC حقيقي، singleton مُخبَّأ، `invoke`
+  يلتقط الاستثناء، `skill_counter` آمن لإعادة الاستيراد — دليل تشغيلي (ضد ZOMBIE §6.6).
+
+**التحقق الحي E2E (2026-07-22، sandbox — منافذ Postgres 5432/6543 محجوبة، HTTPS عبر الوكيل يعمل):**
+- **مسار الإجابة الحيّ** (المفتاح الحقيقي + `MODEL_CHAIN` القانونية + منطق D-177): 4 أسئلة تعليمية
+  (تكامل/قانون أوم/احتمالات/نهاية sin x/x الصعبة) كلها أُجيبت في المرور الأول بـ PRIMARY
+  `openai/gpt-oss-20b:free` عربي+LaTeX، TTFT 1.75–17s → `ALL_ANSWERED=True` (صفر safety-net).
+- **fastpath التحية** حتمي <1ms يفصل «السلام عليكم»→ردّ فوري عن «اشرح لي التكامل»→LLM.
+- **جسر DB HTTPS/443** (`scripts/db_bridge.py`): `SELECT 1 → {"ok":1}` HTTP 200. البوّابة الكاملة
+  full-Postgres + WS مؤجَّلة لـ Codespaces (`.memory/runbooks/e2e-codespaces.md`).
+
+**البوّابات الخضراء بعد التبنّي:** `ruff check+format`، `check_skills_doctrine`، `check_pedagogical_os`،
+`ci_guardrails`، `check_legacy_invariants` (349)، `check_no_cross_service_imports`،
+`check_single_brain_control_plane`، `check_abstraction_consumed`، `runtime_truth --check` (بلا `--update`).
+
 ## D-178 · خط الوكلاء المتعددين يصل full — إصلاح مهلة reasoning (2026-07-22)
 **السياق:** تجريب حي للخدمات المصغرة (بالمفاتيح الحقيقية + postgres محلي) كشف أن `POST /compose`
 يعطي `pipeline_mode="partial"` (planning+research فقط، **reasoning غائب**) وإجابة خطأ 53 حرفاً.
@@ -1597,6 +1632,18 @@ start" — this is the right hook.
 **Status**: IMPLEMENTED 2026-05-07 — see branch `claude/fix-monitoring-port-hQ7JL` and CLAUDE.md §6.12.
 
 
+## D-035 · Planning Agent Live Activation + Docker Compose Stack — Step 6 (2026-05-10)
+`planning-agent` activated as a uvicorn process on `:8002` (third microservice ACTIVE), DSPy +
+LangGraph with a fallback chain when `OPENROUTER_API_KEY` is absent; independent `CollectorRegistry`
+(11 `cogniforge_planning_*` metrics), supervisor STEP 4F, `docker-compose.step6.yml`.
+Full narrative: `CLAUDE.md` (Microservices Step 6 entry). Backfilled header (D-179 coherence sweep).
+
+## D-037 · Reasoning Agent Live Activation — Step 8 (2026-05-11)
+`reasoning-agent` activated as a uvicorn process on `:8008` (fifth microservice ACTIVE), MCTS always
+enabled, LLM via OpenRouter when keyed else mock; lazy `AIService` (ISS-039-B) so startup never
+raises without a key. 11 `cogniforge_reasoning_*` metrics, supervisor STEP 4H.
+Full narrative: `CLAUDE.md` (Microservices Step 8 entry). Backfilled header (D-179 coherence sweep).
+
 ## D-034 · User Service Activated as uvicorn Process on :8001 — Step 5 (2026-05-10)
 **Decision**: `user-service` is activated as a uvicorn process on `:8001` in Codespaces (no Docker). It is the second microservice to go ACTIVE alongside `orchestrator-service` (:8006). Starts automatically via `supervisor.sh:launch_user_service()` (STEP 4E) when `DATABASE_URL` is set.
 **Reason**: Step 4 proved the uvicorn-process pattern for microservice activation in Codespaces (no Docker-in-Docker). `user-service` is the natural next candidate: it has a complete FastAPI app, its own DB schema, auth routes, and UMS routes. Adding `/metrics` (prometheus_client) makes it fully observable.
@@ -1661,6 +1708,20 @@ debugging misclassifications. Backward-compatible: callers only read `.recognize
 - `_build_psycopg_conninfo` — يجب أن يُزيل `+asyncpg` ويُضيف `sslmode=require`.
 - `checkpointer_backend` label في `STARTUP_INFO` — يُستخدم في CI gate و Grafana.
 **Status**: IMPLEMENTED 2026-05-11 — branch `feat/microservices-step10-postgres-checkpointer`.
+
+## D-044 · Full-Stack Live Surgical Verification with Real Secrets (2026-05-11)
+All 8 microservices started with real `OPENROUTER_API_KEY` + `TAVILY_API_KEY` + `DATABASE_URL`
+(Supabase); Skills Pipeline confirmed `pipeline_mode="full"` with real LLM. Fixes: ISS-047
+(`gpt-4o-mini` + `MAX_TOKENS=1024` for reasoning-agent 402), content-retrieval-skill `:8009` DOWN→UP,
+113 ruff errors, 10 test failures. Full narrative: `CLAUDE.md` (Live Surgical Verification entry).
+Backfilled header (D-179 coherence sweep).
+
+## D-045 · Microservices Answer Users End-to-End (2026-05-11)
+Full WebSocket chat path verified live: `User WS → :8000 → OrchestratorClient.chat_with_agent() →
+:8006 StateGraph (13 nodes) → Planning:8002 + Research:8007 + Reasoning:8008 → streaming NDJSON`.
+Fixes ISS-048 (`ALLOW_CONTAINER_LOCALHOST_ORCHESTRATOR`), ISS-049 (conversation-service
+`prometheus_client`), ISS-050 (E2E WS with real JWT). Full narrative: `CLAUDE.md` (End-to-End User
+Routing entry). Backfilled header (D-179 coherence sweep).
 
 ## D-043 · Live Runtime Audit — Full Stack Verified (2026-05-11)
 **Decision**: تحديث جميع ملفات الذاكرة (`CLAUDE.md`, `.memory/`) بناءً على تشخيص حي مباشر لجميع الخدمات.
@@ -4520,6 +4581,12 @@ LearningPathCard.jsx + CSS (theme-law). LEARNING_PATH_DOCTRINE v1.0.0 + manifest
 gate. **القواعد:** يُبنى فوق student_mastery_probability لا يُعيد اختراعه؛ حتمي
 بلا I/O؛ تسلسل المنهج خريطة ثابتة (لا overfitting)؛ fail-open.
 
+## D-109 · CritiqueNode (PLANNED — لم يُنفَّذ بعد)
+عنوان مستقل يحلّ الإشارات المعلّقة في `CLAUDE.md` §0.7 و`check_pedagogical_os.py`. لا كود بعد —
+CritiqueNode مرحلة نقد ذاتي مُصمَّمة (تُقيِّم مخرج المُركِّب قبل بثّه) ضمن الحزمة المشتركة أدناه.
+التفصيل الكامل في الرأس المُجمَّع `## D-108/D-109/D-110` مباشرةً بعد هذا السطر. عنوان مُستكمَل
+(جولة تماسك D-179).
+
 ## D-108/D-109/D-110 — Mastery-Aware Orchestrator / CritiqueNode / Real Synthesis (مُصمَّمة)
 تطوير ثوري للـ orchestrator: P1 يثبّت cognitive_context في AgentState ويُقرأ في
 SupervisorNode/SynthesizerNode (D-104 يثبّت الموجِّه في السؤال الآن)؛ P2 عقدة
@@ -5332,6 +5399,11 @@ change for uncovered concepts. Verification: `scripts/verify_iss119_live.py` (AL
 - **Context:** The `FullExerciseStory` UI component for probability combinatorics suffered from "historical pollution" (e.g. `C(23,3)=1771`) where elements like `بطاقة رقم 0 اضغط للكشف` passed in the `history_text` were mistakenly extracted as real entities by `_extract_count_entities`.
 - **Action:** Implemented a Strict Validation Gate inside `ProbabilityCalculatorSkill._strategy_composition`. We extract explicitly stated probability fractions from the problem `source` using regex `r'(\d+)\s*/\s*(\d+)'`. We reject the generation path (returning `None`) if the dynamically computed `total_combinations` does not have a clean modular relationship with any of the stated denominators.
 - **Result:** Invalid entities injected via user chat history can no longer override explicitly stated values and mathematical facts in the problem itself, successfully forcing fallback to deep generative text without corrupting the visual state.
+
+## D-152 · بوّابة كشف المقام «slash-only» — الاحتمال الحتمي (2026-07-02)
+عنوان مستقل يحلّ الإشارة المعلّقة في `CLAUDE.md` §0.8 و`check_pedagogical_os.py:215`. البوّابة
+الحتمية لكشف المقام كانت تعتمد الشرطة «/» فقط فعميت عن `\frac` في LaTeX (انحدار مُحصَّن الآن في
+`check_pedagogical_os.py`). أُدمج ضمن عمل D-153 (ISS-120) أدناه. عنوان مُستكمَل (جولة تماسك D-179).
 
 ## D-153 (2026-07-02) — ISS-120: أسئلة-فقط للمحرك الرمزي + الحيرة ليست إجابة + دستور Pedagogical OS
 **Context:** live transcript on BAC-2024: phantom «بطاقة رقم 0 (العدد 3)» + C(14,3)=364 emitted to a

--- a/.memory/issues.md
+++ b/.memory/issues.md
@@ -1,4 +1,28 @@
 # Open Issues & Bugs
+## 🧭 Coherence log — decisions wave D-172 → D-179 (2026-07-18 → 07-22)
+
+هذا السجلّ يوثّق موجة القرارات التي لم تُسجَّل لها إدخالات issue أثناء تسارع العمل (جولة تماسك D-179):
+
+- **D-172** (07-18) — Docker full-stack قابل لإعادة الإنتاج: شبكة compose-managed + جسر أسرار تلقائي
+  + «الصحة لا تكذب» (sqlite/mock تحت الإنتاج ⇒ `degraded`) + checkpointer=postgres مُثبَت.
+- **D-173** (07-21) — ثورة التوثيق: `CLAUDE.md` 12,082→966 سطراً + توحيد `.memory/` + حذف عنقود KAgent
+  الميت + API-first 100% (عقود OpenAPI لكل الخدمات + بوّابة تكافؤ).
+- **D-174** (07-21) — إغلاق الفجوات الحقيقية: API-first 11/11، بوّابة تكافؤ سلسلة النماذج، تكافؤ الرصد.
+- **D-175** (07-21) — طبقة الأسس النظرية `app/core/foundations/` (dep-free): combinatorics · number_theory
+  · logic · probability · information_theory · algorithms — بدائيات مُتحقَّقة ترفع `FoundationsError`.
+- **D-176** (07-21) — فرض حدود التجريد + بوّابة anti-ZOMBIE للـ ports السداسية.
+- **D-177** (07-22) — صمود الـ rate-limit «يجيب على كل سؤال»: تصنيف 429 + مرور ثانٍ محدود +
+  `FIRST_TOKEN_TIMEOUT=30s` + حارس تسرّب reasoning. (يُغلق طلب المالك «يجيب على كل الأسئلة».)
+- **D-178** (07-22) — خط الوكلاء المتعددين يصل `full`: رفع مهلتي reasoning/skills المتناسقتين (env-overridable).
+- **D-179** (07-22) — BaseSkill OOP عبر 23 مهارة + تحقّق حيّ E2E من ضمان الإجابة + إصلاح تماسك الذاكرة
+  (backfill عناوين D-035/037/044/045/109/152 + هذا السجلّ). لا issue جديد — عمل بنيوي/توثيقي، صفر كسر بوّابة.
+
+**تحقّق حيّ D-179 (2026-07-22):** 4 أسئلة تعليمية أُجيبت في المرور الأول بـ PRIMARY
+`openai/gpt-oss-20b:free` عربي+LaTeX (`ALL_ANSWERED=True`)؛ fastpath التحية حتمي <1ms؛ جسر DB
+HTTPS/443 `SELECT 1→{"ok":1}`. كل البوّابات خضراء (ruff/doctrine/pedagogical-os/guardrails/runtime-truth).
+
+---
+
 ## ✅ Resolved 2026-06-27 (ISS-117 — Repetitive loops and context drift due to stateless graph)
 **Symptom:** AI tutor repeats same definitions, ignores correct answers, and gets hijacked by intent detector regexes.
 **Root:** Lack of stateful pedagogical progression. local_graph ignored TutorState and PedagogicalPolicyEngine.

--- a/.memory/progress.md
+++ b/.memory/progress.md
@@ -1,5 +1,28 @@
 # Progress — What Has Been Done
-> Last updated: 2026-05-23 | Branch: `feat/math-explanation-generative-ui`
+> Last updated: 2026-07-22 | Branch: `claude/oop-claude-md-update-e2ziez`
+
+---
+
+## ✅ Session: 2026-07-22 — D-179: BaseSkill OOP + live answer-guarantee + memory coherence
+
+**Branch**: `claude/oop-claude-md-update-e2ziez`
+**Goal**: OOP متقدّم على طبقة المهارات + تحقّق حيّ «يجيب على كل سؤال» + إصلاح تماسك `.memory`.
+
+### ما تم إنجازه
+- **`app/services/skills/base.py`** جديد: `BaseSkill[InT,OutT]` (ABC، PEP-695) — هوية `name/version`
+  + singleton كسول لكل-صنف (`instance()→Self`) + `run()` polymorphic + `skill_counter/skill_histogram`
+  (حارس Prometheus مُوحَّد على `REGISTRY` العام، بلا registry جديد). 7 اختبارات في
+  `tests/services/test_skills_base.py`.
+- **تبنٍّ عبر 23 مهارة**: Wave 1 (9 بلا بوّابة) توحّد accessor عبر `instance()`؛ Wave 2 (14 محروسة)
+  تضيف `run` مُفوِّض مع صون كل token محروس. المحرك الاحتمالي + gateway/model-chain لم تُمسّ.
+- **تحقّق حيّ E2E** (sandbox، Postgres محجوب، HTTPS يعمل): 4 أسئلة تعليمية أُجيبت في المرور الأول
+  بـ `openai/gpt-oss-20b:free` عربي+LaTeX (`ALL_ANSWERED=True`)؛ fastpath التحية <1ms؛ جسر DB
+  `SELECT 1→{"ok":1}` HTTP 200.
+- **تماسك الذاكرة**: backfill عناوين D-035/037/044/045/109/152 + D-179 + سجلّ موجة D-172→179 في
+  `issues.md` + تحديث `tasks/progress/context/ci-gates`.
+- **بوّابات خضراء**: ruff check+format، check_skills_doctrine، check_pedagogical_os، ci_guardrails،
+  check_legacy_invariants (349)، check_no_cross_service_imports، check_single_brain_control_plane،
+  check_abstraction_consumed، runtime_truth --check (بلا `--update`).
 
 ---
 

--- a/.memory/runbooks/e2e-codespaces.md
+++ b/.memory/runbooks/e2e-codespaces.md
@@ -7,6 +7,13 @@
 > **لماذا Codespaces لا الـ sandbox:** الـ sandbox يحجب منافذ Postgres (5432/6543) ويفتقد
 > تبعيات التطبيق + `frontend/node_modules`، فلا يستطيع الـ uvicorn الوصول إلى Supabase.
 > Codespaces يفتح egress ويثبّت التبعيات. (نمط موثّق: CLAUDE.md §6.55 / §6.83 / §6.98.)
+>
+> **D-179 (2026-07-22):** «يجيب على كل سؤال» مُتحقَّق منه حيّاً في الـ sandbox عبر مسار الإجابة
+> المباشر (المفتاح الحقيقي + `MODEL_CHAIN` القانونية + منطق D-177 rate-limit): 4/4 أسئلة تعليمية
+> عربي+LaTeX عبر PRIMARY `openai/gpt-oss-20b:free`. المكدس الكامل full-Postgres + WebSocket
+> يُشغَّل هنا في Codespaces: `.devcontainer/supervisor.sh` (8 خدمات + Grafana:3001 + Prometheus:9090)
+> ثم `python scripts/verify_full_stack_codespaces.py` (المونوليث:8000 + خدمات 8001-8009 `/health`
+> + `/compose` pipeline_mode + دور WS حيّ). المنافذ: 8000 مونوليث · 5000 واجهة · 8001-8009 خدمات.
 
 ---
 

--- a/.memory/tasks.md
+++ b/.memory/tasks.md
@@ -1,7 +1,19 @@
 # Tasks — What Comes Next
 > 🧭 **خارطة الطريق الثورية الكاملة (المراحل M0→M11):** **`.memory/roadmap.md`** — المصدر الحيّ الوحيد. المخطّط التالي: M6 صدق BKT · M7 واجهات بلا أرقام · M8 وضع التحقق · M9 فجوة الوهم · M10 هجرة الرسم.
-> Last updated: 2026-05-23 | Branch: `feat/math-explanation-generative-ui`
+> Last updated: 2026-07-22 | Branch: `claude/oop-claude-md-update-e2ziez`
 > Priority: 🔴 Critical → 🟡 Medium → 🟢 Nice-to-have
+
+---
+
+## ✅ Resolved — D-179: BaseSkill OOP + live answer-guarantee + memory coherence (2026-07-22)
+- طبقة `app/services/skills/` الآن على قاعدة `BaseSkill` موحَّدة (23 مهارة): هوية + singleton +
+  `run()` polymorphic + `skill_counter` (حارس Prometheus DRY). تحقّق حيّ E2E أثبت «يجيب على كل سؤال»
+  (4/4 عربي+LaTeX عبر PRIMARY). تماسك `.memory` مُصلَح (backfill 6 عناوين + D-179).
+
+### 🟡 التالي المقترح (بعد D-179)
+- **إكمال تبنّي BaseSkill (اختياري)**: `probability_brain/*` + `probability_tutor_brain` مُستثناة عمداً
+  (محرك حتمي محروس بمانيفستات/legacy-invariants) — أي تبنٍّ لاحق يتطلّب حذراً مماثلاً.
+- **M6 صدق BKT** — المقياس الوحيد: فجوة الوهم (المدعوم − المؤجَّل غير المدعوم). راجع `roadmap.md`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,20 @@ user-service          :8001  ← Skill: إدارة المستخدمين (Identit
   ]) → إجابة مُركَّبة من skills متخصصة
 ```
 
+### القاعدة الموحَّدة `BaseSkill` (D-179 — 2026-07-22)
+
+المصدر الكائني الموحَّد لكل مهارة في المونوليث هو `app/services/skills/base.py:BaseSkill[InT, OutT]`
+(ABC). كل مهارة (٢٣ مهارة اليوم) تَرِث منه فتحصل على: هوية موحَّدة (`name`/`version`)، singleton كسول
+لكل-صنف (`instance()` يُعيد `Self` — يستبدل نمط `_x_singleton` + `get_x_skill()`)، ونقطة دخول
+polymorphic `run()` تُفوِّض لطريقة المهارة الأصلية (`invoke`/`align`/`decide`/`evaluate`/…). ومساعدا
+`skill_counter`/`skill_histogram` يُوحِّدان حارس Prometheus المُعاد على `REGISTRY` العام (**بلا
+`CollectorRegistry` جديد** — القاعدة «لا تشارك registry» تخصّ الخدمات المصغرة لا المونوليث). المحرك
+الاحتمالي الحتمي (`probability_brain/*`) + `gateway`/model-chain **مُستثناة عمداً** (حماية مسار
+الإجابة). أي مهارة جديدة يجب أن تَرِث `BaseSkill`.
+
 ### قواعد إلزامية لكل Skill جديد
 
-1. **Skill يجب أن يملك `/metrics` endpoint** — بدونه لا يُعتبر Skill حقيقياً
+1. **Skill يجب أن يرث `BaseSkill`** ويملك `/metrics` (أو `skill_counter`) — بدونه لا يُعتبر Skill حقيقياً
 2. **Skill يجب أن يملك اختبارات** — minimum: happy path + error path
 3. **Skill لا يستدعي Skill آخر مباشرة** — يمر عبر orchestrator فقط
 4. **Skill يُسجِّل كل invocation** — `record_{skill}_invocation(action, status, duration)`
@@ -996,6 +1007,7 @@ Typical latency: 6–18s (OpenRouter free tier). `persisted` event only when orc
 | WebSocket | D-WS-001 → D-WS-PROXY-004 · D-096 · ISS-092→101 |
 | الواجهة/الثيم | D-049 → D-059 |
 | تفكيك التعقيد | D-163 → D-172 |
-| النماذج | D-060 · D-067 · D-088 · D-167 |
-| التوثيق/CI | D-105 · D-141 · D-156 · **D-173** |
+| النماذج | D-060 · D-067 · D-088 · D-167 · D-177 · D-178 |
+| Skills / OOP | §0.5 · D-069 · D-100 · **D-179** (`BaseSkill` قاعدة موحَّدة عبر ٢٣ مهارة) |
+| التوثيق/CI | D-105 · D-141 · D-156 · **D-173** · **D-179** |
 | البنية التحتية (Docker/Observability) | §6.10 → §6.18 · D-172 |

--- a/app/services/skills/__init__.py
+++ b/app/services/skills/__init__.py
@@ -76,6 +76,11 @@ from app.services.skills.bac_exercise_skill import (
     SkillFailure,
     SkillMode,
 )
+from app.services.skills.base import (
+    BaseSkill,
+    skill_counter,
+    skill_histogram,
+)
 from app.services.skills.bkt_engine import (
     BKTEngine,
     BKTEvaluation,
@@ -288,6 +293,7 @@ __all__ = [
     "BKTEngine",
     "BKTEvaluation",
     "BKTEvaluationInput",
+    "BaseSkill",
     "CompositionItem",
     "ConceptDiagnosisInput",
     "ConceptDiagnosisOutput",
@@ -388,4 +394,6 @@ __all__ = [
     "redact_chunk",
     "redact_final_answers",
     "sanitize_stream_chunk",
+    "skill_counter",
+    "skill_histogram",
 ]

--- a/app/services/skills/adaptive_pedagogy_skill.py
+++ b/app/services/skills/adaptive_pedagogy_skill.py
@@ -26,6 +26,7 @@ import time
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import (
     ADAPTIVE_PEDAGOGY_DOCTRINE_VERSION,
 )
@@ -199,11 +200,15 @@ def _classify_support_level(mastery: float | None, cognitive_load: str) -> int:
     return level
 
 
-class AdaptivePedagogySkill:
+class AdaptivePedagogySkill(BaseSkill):
     """Skill رسمي (§0.5): مسؤولية واحدة — تحويل صورة المتعلم إلى توجيه تدريسي."""
 
     name = "adaptive_pedagogy"
     doctrine_version = ADAPTIVE_PEDAGOGY_DOCTRINE_VERSION
+
+    def run(self, payload: PedagogyInput) -> PedagogyDirective:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`derive`."""
+        return self.derive(payload)
 
     def derive(self, payload: PedagogyInput) -> PedagogyDirective:
         """يشتق التوجيه التربوي حتمياً — لا يرفع أبداً نحو المسار الحي."""

--- a/app/services/skills/answer_quality_skill.py
+++ b/app/services/skills/answer_quality_skill.py
@@ -36,6 +36,7 @@ from typing import ClassVar, Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import (
     EXPLANATION_DOCTRINE,
     MODEL_ANSWER_RELIANCE_RULES,
@@ -279,7 +280,7 @@ def _build_improvement_header(issues: list[QualityIssue], answer: str) -> str:
 # ── AnswerQualitySkill ────────────────────────────────────────────────────────
 
 
-class AnswerQualitySkill:
+class AnswerQualitySkill(BaseSkill):
     """
     Skill تقييم جودة الإجابة وتحسينها وفق الـ doctrines الرسمية.
 
@@ -300,6 +301,11 @@ class AnswerQualitySkill:
     # نسخة الـ Skill — تُستخدم في Prometheus و CI gate
     VERSION: ClassVar[str] = "1.0.0"
     SKILL_NAME: ClassVar[str] = "answer_quality"
+    name: ClassVar[str] = "answer_quality"
+
+    def run(self, inp: AnswerQualityInput):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`evaluate`."""
+        return self.evaluate(inp)
 
     def evaluate(self, inp: AnswerQualityInput) -> AnswerQualityOutput | AnswerQualityFailure:
         """

--- a/app/services/skills/answer_redaction_skill.py
+++ b/app/services/skills/answer_redaction_skill.py
@@ -27,6 +27,7 @@ import time
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import (
     ANSWER_REDACTION_DOCTRINE_VERSION,
     WORKED_EXAMPLE_CLOSE,
@@ -279,7 +280,7 @@ def _record_metric(status: str, redactions: int, duration_s: float) -> None:
         obs.record_metric("skill.answer_redaction.duration_seconds", duration_s)
 
 
-class AnswerRedactionSkill:
+class AnswerRedactionSkill(BaseSkill):
     """واجهة Skill رسمية للـ registry + القياس (D-113).
 
     عقد دائم (لا يُكسر بدون ADR):
@@ -292,6 +293,11 @@ class AnswerRedactionSkill:
 
     VERSION = DOCTRINE_VERSION
     SKILL_NAME = "answer_redaction"
+    name = "answer_redaction"
+
+    def run(self, payload: AnswerRedactionInput | str) -> AnswerRedactionOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`redact`."""
+        return self.redact(payload)
 
     def redact(self, payload: AnswerRedactionInput | str) -> AnswerRedactionOutput:
         t0 = time.perf_counter()

--- a/app/services/skills/bac_exercise_skill.py
+++ b/app/services/skills/bac_exercise_skill.py
@@ -60,6 +60,7 @@ from app.services.capabilities.exercise_retrieval import (
     format_exercise_for_display,
     load_exercise_content,
 )
+from app.services.skills.base import BaseSkill
 
 # ─────────────────────────────────────────────────────────────────────────────
 # D-069 (2026-05-18): Single Source of Truth = `app.services.skills.doctrine`
@@ -193,7 +194,7 @@ def _record_metric(mode: str, status: str, duration_s: float) -> None:
         pass
 
 
-class BACExerciseSkill:
+class BACExerciseSkill(BaseSkill[BACSkillInput, SkillOutput]):
     """Skill رسمي يستبدل Prompt Spaghetti بـ contract محدَّد ومستقل.
 
     Usage:
@@ -215,8 +216,12 @@ class BACExerciseSkill:
     أو `_stream_exercise_explanation_response` التي تستهلك المخرج.
     """
 
-    name: str = "bac_exercise"
-    version: str = "1.0.0"
+    name: ClassVar[str] = "bac_exercise"
+    version: ClassVar[str] = "1.0.0"
+
+    def run(self, payload: BACSkillInput) -> SkillOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`invoke`."""
+        return self.invoke(payload)
 
     # ─────────────────────────────────────────────────────────────────────
     # واجهة الاستدعاء المتزامنة

--- a/app/services/skills/base.py
+++ b/app/services/skills/base.py
@@ -31,7 +31,7 @@ Design rules (kept deliberately narrow so the skills-layer stays clean):
 from __future__ import annotations
 
 import abc
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 
 __all__ = ["BaseSkill", "skill_counter", "skill_histogram"]
 
@@ -122,7 +122,7 @@ class BaseSkill[InT, OutT](abc.ABC):
     version: ClassVar[str] = "1.0.0"
 
     @classmethod
-    def instance(cls) -> BaseSkill:
+    def instance(cls) -> Self:
         """Return a process-wide singleton of the concrete skill class.
 
         The cache lives on the concrete class (``cls.__dict__``), so each subclass

--- a/app/services/skills/base.py
+++ b/app/services/skills/base.py
@@ -1,0 +1,146 @@
+"""BaseSkill — canonical OOP base for every CogniForge skill (D-179).
+
+CLAUDE.md §0.5 mandates that every AI capability be a *Skill*: an independent,
+measurable, testable, replaceable unit. Historically each skill hand-rolled the
+same three cross-cutting concerns:
+
+1. **Identity** — an ad-hoc ``name`` / ``_skill_name`` / ``version`` attribute.
+2. **Lazy singleton** — a module-level ``_x_singleton`` plus a ``get_x_skill()``
+   accessor (repeated in ~16 skill modules).
+3. **Prometheus metrics** — the verbose, re-import-safe
+   ``try: from prometheus_client import REGISTRY, Counter ...`` guard block
+   (repeated in ~13 skill modules).
+
+``BaseSkill`` consolidates (1) and (2) into a small abstract base, and
+``skill_counter`` / ``skill_histogram`` consolidate (3) into two helpers. This is
+pure OOP structure — it changes no skill's behaviour, contracts, or metric names.
+
+Design rules (kept deliberately narrow so the skills-layer stays clean):
+
+* **Dependency-free** beyond the standard library and an *optional* lazy import of
+  ``prometheus_client``. When prometheus is unavailable the helpers return a
+  no-op object, so metrics never raise.
+* **Never creates a new ``CollectorRegistry``** — the helpers register on the
+  default global ``REGISTRY`` exactly as the existing skills do (the "never share
+  a CollectorRegistry across microservices" rule is about *microservices*; inside
+  the monolith the default registry is the single shared one).
+* **No cross-service imports, no heavy ``app.*`` imports** — importing this module
+  must stay cheap so any skill can adopt it.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, ClassVar
+
+__all__ = ["BaseSkill", "skill_counter", "skill_histogram"]
+
+
+class _NoopMetric:
+    """Stand-in returned when ``prometheus_client`` is absent or registration fails.
+
+    Mirrors the ``Counter``/``Histogram`` fluent surface so call sites
+    (``.labels(...).inc()`` / ``.observe(...)``) never raise.
+    """
+
+    def labels(self, *args: Any, **kwargs: Any) -> _NoopMetric:
+        return self
+
+    def inc(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def observe(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def _existing_collector(name: str) -> Any | None:
+    """Return the already-registered collector for ``name`` (re-import safe)."""
+    try:
+        from prometheus_client import REGISTRY
+    except Exception:  # pragma: no cover - prometheus not installed
+        return None
+    mapping = getattr(REGISTRY, "_names_to_collectors", {})
+    # A Counter registered as ``x_total`` is indexed under several timeseries
+    # names; try the exact name and the common ``_total`` suffix variants.
+    for key in (name, f"{name}_total", name.removesuffix("_total")):
+        collector = mapping.get(key)
+        if collector is not None:
+            return collector
+    return None
+
+
+def skill_counter(name: str, documentation: str, labelnames: tuple[str, ...] = ()) -> Any:
+    """Return a Prometheus ``Counter`` registered once on the default REGISTRY.
+
+    Consolidates the re-import-safe guard block duplicated across skill modules:
+    the first import registers the counter; a re-import (common in tests) returns
+    the *existing* collector instead of raising ``Duplicated timeseries``. When
+    ``prometheus_client`` is unavailable, returns a :class:`_NoopMetric`.
+    """
+    try:
+        from prometheus_client import Counter
+    except Exception:  # pragma: no cover - prometheus not installed
+        return _NoopMetric()
+    try:
+        return Counter(name, documentation, list(labelnames))
+    except ValueError:
+        return _existing_collector(name) or _NoopMetric()
+
+
+def skill_histogram(name: str, documentation: str, labelnames: tuple[str, ...] = ()) -> Any:
+    """Return a Prometheus ``Histogram`` registered once on the default REGISTRY.
+
+    Same re-import-safe semantics as :func:`skill_counter`.
+    """
+    try:
+        from prometheus_client import Histogram
+    except Exception:  # pragma: no cover - prometheus not installed
+        return _NoopMetric()
+    try:
+        return Histogram(name, documentation, list(labelnames))
+    except ValueError:
+        return _existing_collector(name) or _NoopMetric()
+
+
+class BaseSkill[InT, OutT](abc.ABC):
+    """Abstract base for every CogniForge skill.
+
+    Provides shared **identity** (``name`` / ``version``) and a per-concrete-class
+    **lazy singleton** (:meth:`instance`) so skills stop re-implementing the
+    ``_x_singleton`` + ``get_x_skill()`` pattern. Concrete skills implement
+    :meth:`run` as a thin, uniform entry point that routes to their existing
+    action method (``invoke`` / ``align`` / ``decide`` / ``evaluate`` / ...),
+    enabling polymorphic dispatch (``for skill in registry: skill.run(payload)``)
+    without changing any skill's public contract.
+
+    ``BaseSkill`` itself is abstract and cannot be instantiated.
+    """
+
+    #: Stable skill identifier (e.g. ``"greeting"``). Concrete skills set this.
+    name: ClassVar[str] = ""
+    #: Semantic version of the skill's contract.
+    version: ClassVar[str] = "1.0.0"
+
+    @classmethod
+    def instance(cls) -> BaseSkill:
+        """Return a process-wide singleton of the concrete skill class.
+
+        The cache lives on the concrete class (``cls.__dict__``), so each subclass
+        gets its own instance and subclasses never share a parent's cached object.
+        """
+        cached = cls.__dict__.get("_singleton_instance")
+        if cached is None:
+            cached = cls()
+            cls._singleton_instance = cached  # type: ignore[attr-defined]
+        return cached
+
+    @abc.abstractmethod
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        """Primary capability entry point.
+
+        Concrete skills route this to their existing action method. It may return
+        a value directly or an awaitable for async skills — callers await when
+        needed. Kept intentionally untyped so heterogeneous skill signatures share
+        one polymorphic surface.
+        """
+        raise NotImplementedError

--- a/app/services/skills/bkt_engine.py
+++ b/app/services/skills/bkt_engine.py
@@ -49,6 +49,7 @@ import time
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import BKT_COGNITIVE_DOCTRINE_VERSION
 
 # ── معاملات BKT الافتراضية ───────────────────────────────────────────────────────
@@ -535,7 +536,7 @@ class BKTEvaluation(RobustBaseModel):
 
 
 # ── Skill ─────────────────────────────────────────────────────────────────────────
-class BKTEngine:
+class BKTEngine(BaseSkill):
     """
     Skill حتمي لتتبّع المعرفة البايزي.
 
@@ -548,6 +549,12 @@ class BKTEngine:
     """
 
     _skill_name: str = "bkt"
+    name = "bkt"
+
+    def run(self, payload):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`evaluate`."""
+        return self.evaluate(payload)
+
     #: إصدار الـ doctrine الذي يلتزم به هذا الـ Skill (D-074). يُربط بـ
     #: doctrine.BKT_COGNITIVE_DOCTRINE_VERSION — single source of truth.
     doctrine_version: str = BKT_COGNITIVE_DOCTRINE_VERSION

--- a/app/services/skills/concept_diagnosis_skill.py
+++ b/app/services/skills/concept_diagnosis_skill.py
@@ -40,6 +40,7 @@ from typing import Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import CONCEPT_DIAGNOSIS_DOCTRINE_VERSION
 
 # ── الـ enum الثابت (الطبقة 1 تُصنّف إليه حصراً) ──────────────────────────────────
@@ -258,7 +259,7 @@ def _infer_misconception(concept: str, normalized: str) -> Misconception:
     return "none"
 
 
-class ConceptDiagnosisSkill:
+class ConceptDiagnosisSkill(BaseSkill[ConceptDiagnosisInput, ConceptDiagnosisOutput]):
     """
     Skill عصبي-رمزي لتشخيص المفهوم + المفهوم الخاطئ (الطبقتان 1 و 5 — D-127).
 
@@ -269,8 +270,13 @@ class ConceptDiagnosisSkill:
     """
 
     _skill_name: str = "concept_diagnosis"
+    name = "concept_diagnosis"
     doctrine_version: str = CONCEPT_DIAGNOSIS_DOCTRINE_VERSION
     _LLM_TIMEOUT_S: float = 8.0
+
+    def run(self, payload: ConceptDiagnosisInput):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`diagnose` (async)."""
+        return self.diagnose(payload)
 
     @staticmethod
     def diagnose_deterministic(question: str) -> ConceptDiagnosisOutput:
@@ -360,15 +366,9 @@ class ConceptDiagnosisSkill:
             return None
 
 
-_concept_diagnosis_singleton: ConceptDiagnosisSkill | None = None
-
-
 def get_concept_diagnosis_skill() -> ConceptDiagnosisSkill:
-    """يُرجع نسخة مفردة (lazy singleton)."""
-    global _concept_diagnosis_singleton
-    if _concept_diagnosis_singleton is None:
-        _concept_diagnosis_singleton = ConceptDiagnosisSkill()
-    return _concept_diagnosis_singleton
+    """يُرجع نسخة مفردة (BaseSkill.instance)."""
+    return ConceptDiagnosisSkill.instance()
 
 
 __all__ = [

--- a/app/services/skills/content_integrity_skill.py
+++ b/app/services/skills/content_integrity_skill.py
@@ -36,6 +36,7 @@ from typing import Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import CONTENT_INTEGRITY_DOCTRINE_VERSION
 
 logger = logging.getLogger("cogniforge.skills.content_integrity")
@@ -425,7 +426,7 @@ def sanitize_final_text(text: str, support_level: int | None = None) -> str:
         return cleaned
 
 
-class ContentIntegritySkill:
+class ContentIntegritySkill(BaseSkill):
     """واجهة Skill رسمية للـ registry + القياس (D-100).
 
     عقد دائم (لا يُكسر بدون ADR):
@@ -439,6 +440,11 @@ class ContentIntegritySkill:
 
     VERSION = DOCTRINE_VERSION
     SKILL_NAME = "content_integrity"
+    name = "content_integrity"
+
+    def run(self, payload: ContentIntegrityInput | str) -> ContentIntegrityOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`check`."""
+        return self.check(payload)
 
     def check(self, payload: ContentIntegrityInput | str) -> ContentIntegrityOutput:
         t0 = time.perf_counter()

--- a/app/services/skills/dialogue_manager_skill.py
+++ b/app/services/skills/dialogue_manager_skill.py
@@ -33,6 +33,7 @@ import re
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import DIALOGUE_MANAGER_DOCTRINE_VERSION
 
 _AR_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
@@ -154,7 +155,7 @@ except Exception:  # pragma: no cover
         pass
 
 
-class DialogueManagerSkill:
+class DialogueManagerSkill(BaseSkill):
     """مدير الحوار — المُنفّذ لقرارات السياسة التربوية (D-142 Phase 2 / Phase 3).
 
     عقد دائم (لا يُكسر بدون ADR):
@@ -164,6 +165,12 @@ class DialogueManagerSkill:
     """
 
     _skill_name: str = "dialogue_manager"
+    name = "dialogue_manager"
+
+    def run(self, payload):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`decide`."""
+        return self.decide(payload)
+
     doctrine_version: str = DIALOGUE_MANAGER_DOCTRINE_VERSION
 
     def decide(self, payload: DialogueInput) -> DialogueDecision:

--- a/app/services/skills/exercise_alignment_skill.py
+++ b/app/services/skills/exercise_alignment_skill.py
@@ -13,6 +13,7 @@ from typing import ClassVar, Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 
 
 class ExerciseAlignmentInput(RobustBaseModel):
@@ -31,8 +32,10 @@ class ExerciseAlignmentOutput(RobustBaseModel):
     applied: bool = False
 
 
-class ExerciseAlignmentSkill:
+class ExerciseAlignmentSkill(BaseSkill[ExerciseAlignmentInput, ExerciseAlignmentOutput]):
     """مهارة حتمية لمحاذاة الإجابة مع معطيات السؤال."""
+
+    name: ClassVar[str] = "exercise_alignment"
 
     _COLOR_ALIASES: ClassVar[dict[str, tuple[str, ...]]] = {
         "white": ("بيضاء", "أبيض", "ابيض"),
@@ -45,6 +48,10 @@ class ExerciseAlignmentSkill:
     _COLOR_TOKENS: ClassVar[tuple[str, ...]] = tuple(
         token for aliases in _COLOR_ALIASES.values() for token in aliases
     )
+
+    def run(self, payload: ExerciseAlignmentInput) -> ExerciseAlignmentOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`align`."""
+        return self.align(payload)
 
     def align(self, payload: ExerciseAlignmentInput) -> ExerciseAlignmentOutput:
         """ينفّذ محاذاة ألوان الاحتمالات ويُعيد نصاً منقحاً."""
@@ -87,12 +94,6 @@ class ExerciseAlignmentSkill:
         )
 
 
-_exercise_alignment_skill: ExerciseAlignmentSkill | None = None
-
-
 def get_exercise_alignment_skill() -> ExerciseAlignmentSkill:
-    """يُعيد Singleton لمهارة المحاذاة."""
-    global _exercise_alignment_skill
-    if _exercise_alignment_skill is None:
-        _exercise_alignment_skill = ExerciseAlignmentSkill()
-    return _exercise_alignment_skill
+    """يُعيد Singleton لمهارة المحاذاة (BaseSkill.instance)."""
+    return ExerciseAlignmentSkill.instance()

--- a/app/services/skills/greeting_skill.py
+++ b/app/services/skills/greeting_skill.py
@@ -25,6 +25,8 @@ import re
 import time
 from typing import ClassVar, Literal
 
+from app.services.skills.base import BaseSkill
+
 try:
     from pydantic import BaseModel, Field
 except ImportError:  # pragma: no cover
@@ -185,7 +187,7 @@ def _record_metric(status: str, duration_s: float) -> None:
         pass
 
 
-class GreetingSkill:
+class GreetingSkill(BaseSkill[GreetingSkillInput, GreetingSkillResult]):
     """Skill رسمي للتحيات — يعيد ردود deterministic بدون LLM.
 
     Usage:
@@ -202,8 +204,12 @@ class GreetingSkill:
     4. مقاييس Prometheus — `cogniforge_skill_greeting_invocations_total{status}`.
     """
 
-    name: str = "greeting"
-    version: str = "1.0.0"
+    name: ClassVar[str] = "greeting"
+    version: ClassVar[str] = "1.0.0"
+
+    def run(self, payload: GreetingSkillInput) -> GreetingSkillResult:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`invoke`."""
+        return self.invoke(payload)
 
     def invoke(self, payload: GreetingSkillInput) -> GreetingSkillResult:
         """نقطة الدخول — يُرجع GreetingSkillOutput أو GreetingSkillFailure."""

--- a/app/services/skills/learning_path_skill.py
+++ b/app/services/skills/learning_path_skill.py
@@ -25,6 +25,7 @@ from typing import Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import LEARNING_PATH_DOCTRINE_VERSION
 
 logger = logging.getLogger("cogniforge.skills.learning_path")
@@ -120,7 +121,7 @@ def _record_metric(status: str, difficulty: str, duration_s: float) -> None:
 # ── الـ Skill ──────────────────────────────────────────────────────────────────
 
 
-class LearningPathSkill:
+class LearningPathSkill(BaseSkill):
     """محرّك المسار التعلّمي الحتمي.
 
     عقد دائم (لا يُكسر بدون ADR):
@@ -132,6 +133,11 @@ class LearningPathSkill:
 
     VERSION = DOCTRINE_VERSION
     SKILL_NAME = "learning_path"
+    name = "learning_path"
+
+    def run(self, payload: LearningPathInput) -> LearningPathOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`derive`."""
+        return self.derive(payload)
 
     def derive(self, payload: LearningPathInput) -> LearningPathOutput:
         t0 = time.perf_counter()

--- a/app/services/skills/math_skill.py
+++ b/app/services/skills/math_skill.py
@@ -60,6 +60,7 @@ except ImportError:  # pragma: no cover
 
 from app.core.schemas import RobustBaseModel
 from app.services.skills.bac_exercise_skill import SkillFailure
+from app.services.skills.base import BaseSkill
 
 logger = get_logger("skill.math")
 
@@ -143,7 +144,7 @@ class MathSkillOutput(RobustBaseModel):
 # ── Skill ───────────────────────────────────────────────────────────────────────
 
 
-class MathSkill:
+class MathSkill(BaseSkill[MathSkillInput, MathSkillOutput]):
     """
     Skill رسمي لحل وشرح أسئلة الرياضيات.
 
@@ -156,6 +157,11 @@ class MathSkill:
     """
 
     _skill_name: str = "math"
+    name = "math"
+
+    def run(self, payload: MathSkillInput):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`invoke` (async)."""
+        return self.invoke(payload)
 
     # Dynamic resolution path to keep `app/` free of AST-level
     # `from microservices.*` imports (enforced by tests/architecture/test_boundaries.py).

--- a/app/services/skills/mcp_tool_skill.py
+++ b/app/services/skills/mcp_tool_skill.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 
 logger = logging.getLogger("cogniforge.skills.mcp_tool")
 
@@ -78,8 +79,14 @@ class MCPToolOutput(RobustBaseModel):
     error: str | None = None
 
 
-class MCPToolSkill:
+class MCPToolSkill(BaseSkill[MCPToolInput, MCPToolOutput | None]):
     """Skill جسر أدوات MCP — list + call عبر MCPServer."""
+
+    name = "mcp_tool"
+
+    def run(self, payload: MCPToolInput):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`call` (async)."""
+        return self.call(payload)
 
     @staticmethod
     def is_enabled() -> bool:
@@ -133,12 +140,6 @@ class MCPToolSkill:
             return None
 
 
-_skill_singleton: MCPToolSkill | None = None
-
-
 def get_mcp_tool_skill() -> MCPToolSkill:
-    """يُعيد Singleton لمهارة جسر MCP."""
-    global _skill_singleton
-    if _skill_singleton is None:
-        _skill_singleton = MCPToolSkill()
-    return _skill_singleton
+    """يُعيد Singleton لمهارة جسر MCP (BaseSkill.instance)."""
+    return MCPToolSkill.instance()

--- a/app/services/skills/micro_simulation_skill.py
+++ b/app/services/skills/micro_simulation_skill.py
@@ -16,6 +16,7 @@ CLAUDE.md §0.5: «كل قدرة ذكاء اصطناعي يجب أن تكون Sk
 
 from __future__ import annotations
 
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import MICRO_SIMULATION_DOCTRINE_VERSION
 
 #: قيد صارم على الطول (نقد المالك #2): محاكاة مصغّرة لا «شرح جديد كامل».
@@ -108,7 +109,7 @@ APPLY_STEPS: dict[str, str] = {
 }
 
 
-class MicroSimulationSkill:
+class MicroSimulationSkill(BaseSkill):
     """
     خادم المحاكيات المصغّرة الحتمي (D-138 — خادم محتوى L3).
 
@@ -119,6 +120,12 @@ class MicroSimulationSkill:
     """
 
     _skill_name: str = "micro_simulation"
+    name = "micro_simulation"
+
+    def run(self, concept_id):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`get_micro_simulation`."""
+        return self.get_micro_simulation(concept_id)
+
     doctrine_version: str = MICRO_SIMULATION_DOCTRINE_VERSION
 
     def get_micro_simulation(self, concept_id: str) -> str | None:

--- a/app/services/skills/output_firewall.py
+++ b/app/services/skills/output_firewall.py
@@ -39,6 +39,7 @@ from typing import ClassVar, Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 
 logger = logging.getLogger(__name__)
 
@@ -255,7 +256,7 @@ def _clean_channel_b(text: str) -> str:
 # ── OutputFirewall Skill ──────────────────────────────────────────────────────
 
 
-class OutputFirewall:
+class OutputFirewall(BaseSkill[FirewallInput, FirewallOutput]):
     """
     جدار الحماية المزدوج للقنوات — V46.0.
 
@@ -274,6 +275,12 @@ class OutputFirewall:
 
     VERSION: ClassVar[str] = "1.0.0"
     SKILL_NAME: ClassVar[str] = "output_firewall"
+    name: ClassVar[str] = "output_firewall"
+    version: ClassVar[str] = "1.0.0"
+
+    def run(self, inp: FirewallInput) -> FirewallOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`check`."""
+        return self.check(inp)
 
     def check(self, inp: FirewallInput) -> FirewallOutput:
         """
@@ -428,15 +435,9 @@ class OutputFirewall:
 
 # ── Singleton ─────────────────────────────────────────────────────────────────
 # Singleton: مُهيَّأ مرة واحدة — لا state داخلي، آمن للاستخدام المتزامن.
-_output_firewall: OutputFirewall | None = None
-
-
 def get_output_firewall() -> OutputFirewall:
-    """يُعيد singleton من OutputFirewall."""
-    global _output_firewall
-    if _output_firewall is None:
-        _output_firewall = OutputFirewall()
-    return _output_firewall
+    """يُعيد singleton من OutputFirewall (BaseSkill.instance)."""
+    return OutputFirewall.instance()
 
 
 def apply_channel_b_firewall(

--- a/app/services/skills/pedagogical_escalation_skill.py
+++ b/app/services/skills/pedagogical_escalation_skill.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import PEDAGOGICAL_ESCALATION_DOCTRINE_VERSION
 
 _AR_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
@@ -85,7 +86,7 @@ class EscalationDecision(RobustBaseModel):
     rationale: str = ""
 
 
-class PedagogicalEscalationSkill:
+class PedagogicalEscalationSkill(BaseSkill):
     """
     المصفوفة التصعيدية التكيّفية (D-138).
 
@@ -98,6 +99,12 @@ class PedagogicalEscalationSkill:
     """
 
     _skill_name: str = "pedagogical_escalation"
+    name = "pedagogical_escalation"
+
+    def run(self, payload):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`decide`."""
+        return self.decide(payload)
+
     doctrine_version: str = PEDAGOGICAL_ESCALATION_DOCTRINE_VERSION
 
     # ── إشارات الدخل ──────────────────────────────────────────────────────────

--- a/app/services/skills/pedagogical_policy_skill.py
+++ b/app/services/skills/pedagogical_policy_skill.py
@@ -34,6 +34,7 @@ from typing import Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import PEDAGOGICAL_POLICY_DOCTRINE_VERSION
 
 #: ميزانية الأسئلة السقراطية لكل مسار — بعدها ⇒ حلّ رمزي (لا استجواب لا نهائي).
@@ -412,7 +413,7 @@ except Exception:  # pragma: no cover
         pass
 
 
-class PedagogicalPolicySkill:
+class PedagogicalPolicySkill(BaseSkill):
     """
     Skill حتمي لاختيار التدخّل التربوي (الطبقة 4 — D-129/D-130).
 
@@ -425,6 +426,12 @@ class PedagogicalPolicySkill:
     """
 
     _skill_name: str = "pedagogical_policy"
+    name = "pedagogical_policy"
+
+    def run(self, payload):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`decide`."""
+        return self.decide(payload)
+
     doctrine_version: str = PEDAGOGICAL_POLICY_DOCTRINE_VERSION
 
     def decide(self, payload: PolicyInput) -> PolicyOutput:

--- a/app/services/skills/retrieval_rerank_skill.py
+++ b/app/services/skills/retrieval_rerank_skill.py
@@ -20,6 +20,7 @@ from typing import Any
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 
 logger = logging.getLogger("cogniforge.skills.retrieval_rerank")
 
@@ -82,8 +83,14 @@ class RetrievalRerankOutput(RobustBaseModel):
     degraded: bool = False
 
 
-class RetrievalRerankSkill:
+class RetrievalRerankSkill(BaseSkill[RetrievalRerankInput, RetrievalRerankOutput]):
     """Skill استرجاع دلالي + إعادة ترتيب — مُغلَّف فوق LlamaIndex/Reranker drivers."""
+
+    name = "retrieval_rerank"
+
+    def run(self, payload: RetrievalRerankInput):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`retrieve` (async)."""
+        return self.retrieve(payload)
 
     @staticmethod
     def is_enabled() -> bool:
@@ -189,12 +196,6 @@ def _as_doc(item: Any) -> dict[str, Any]:
     return {"text": str(item), "score": None}
 
 
-_skill_singleton: RetrievalRerankSkill | None = None
-
-
 def get_retrieval_rerank_skill() -> RetrievalRerankSkill:
-    """يُعيد Singleton لمهارة الاسترجاع + إعادة الترتيب."""
-    global _skill_singleton
-    if _skill_singleton is None:
-        _skill_singleton = RetrievalRerankSkill()
-    return _skill_singleton
+    """يُعيد Singleton لمهارة الاسترجاع + إعادة الترتيب (BaseSkill.instance)."""
+    return RetrievalRerankSkill.instance()

--- a/app/services/skills/semantic_property_skill.py
+++ b/app/services/skills/semantic_property_skill.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import SEMANTIC_PROPERTY_DOCTRINE_VERSION
 
 _AR_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
@@ -676,7 +677,7 @@ _EXERCISE_DUMP_MARKERS: tuple[str, ...] = (
 )
 
 
-class SemanticPropertySkill:
+class SemanticPropertySkill(BaseSkill):
     """
     الطبقة الدلالية + Misconception Graph (الطبقة 2 — D-131).
 
@@ -687,6 +688,12 @@ class SemanticPropertySkill:
     """
 
     _skill_name: str = "semantic_property"
+    name = "semantic_property"
+
+    def run(self, question):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`interpret`."""
+        return self.interpret(question)
+
     doctrine_version: str = SEMANTIC_PROPERTY_DOCTRINE_VERSION
     _LLM_TIMEOUT_S: float = 8.0
 

--- a/app/services/skills/socratic_evaluator_skill.py
+++ b/app/services/skills/socratic_evaluator_skill.py
@@ -41,6 +41,7 @@ import time
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import SOCRATIC_EVALUATOR_DOCTRINE_VERSION
 
 _AR_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
@@ -229,7 +230,7 @@ except Exception:  # pragma: no cover
 _DEFAULT_ENCOURAGEMENT = "أحسنت — استنتاجك في محله. لنُكمل معاً خطوةً بخطوة."
 
 
-class SocraticEvaluatorSkill:
+class SocraticEvaluatorSkill(BaseSkill):
     """
     Skill الإصغاء النشط (الطبقة 1 — D-130).
 
@@ -240,6 +241,12 @@ class SocraticEvaluatorSkill:
     """
 
     _skill_name: str = "socratic_evaluator"
+    name = "socratic_evaluator"
+
+    def run(self, payload):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`evaluate` (async)."""
+        return self.evaluate(payload)
+
     doctrine_version: str = SOCRATIC_EVALUATOR_DOCTRINE_VERSION
     _LLM_TIMEOUT_S: float = 12.0
 

--- a/app/services/skills/student_state_skill.py
+++ b/app/services/skills/student_state_skill.py
@@ -38,6 +38,7 @@ from typing import Literal
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import STUDENT_STATE_DOCTRINE_VERSION
 
 #: نيّات الطالب — ماذا يريد (لا «ما المفهوم»).
@@ -274,7 +275,7 @@ def _assess_frustration(question: str, history: list[dict[str, str]] | None) -> 
     return "low"
 
 
-class StudentStateSkill:
+class StudentStateSkill(BaseSkill):
     """
     قراءة حالة الطالب كإشارة قرار (D-133).
 
@@ -286,6 +287,12 @@ class StudentStateSkill:
     """
 
     _skill_name: str = "student_state"
+    name = "student_state"
+
+    def run(self, payload):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`read`."""
+        return self.read(payload)
+
     doctrine_version: str = STUDENT_STATE_DOCTRINE_VERSION
     _LLM_TIMEOUT_S: float = 8.0
 

--- a/app/services/skills/topic_lock.py
+++ b/app/services/skills/topic_lock.py
@@ -32,6 +32,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from app.core.schemas import RobustBaseModel
+from app.services.skills.base import BaseSkill
 
 logger = logging.getLogger(__name__)
 
@@ -319,7 +320,7 @@ class TopicLockOutput(RobustBaseModel):
 # ── TopicLock Skill ───────────────────────────────────────────────────────────
 
 
-class TopicLock:
+class TopicLock(BaseSkill[TopicLockInput, TopicLockOutput]):
     """
     Skill قفل الموضوع وحماية نقاء السياق — V46.0.
 
@@ -332,6 +333,12 @@ class TopicLock:
 
     VERSION: ClassVar[str] = "1.0.0"
     SKILL_NAME: ClassVar[str] = "topic_lock"
+    name: ClassVar[str] = "topic_lock"
+    version: ClassVar[str] = "1.0.0"
+
+    def run(self, inp: TopicLockInput) -> TopicLockOutput:
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`check`."""
+        return self.check(inp)
 
     def check(self, inp: TopicLockInput) -> TopicLockOutput:
         """
@@ -387,15 +394,9 @@ class TopicLock:
 
 
 # ── Singleton ─────────────────────────────────────────────────────────────────
-_topic_lock: TopicLock | None = None
-
-
 def get_topic_lock() -> TopicLock:
-    """يُعيد singleton من TopicLock."""
-    global _topic_lock
-    if _topic_lock is None:
-        _topic_lock = TopicLock()
-    return _topic_lock
+    """يُعيد singleton من TopicLock (BaseSkill.instance)."""
+    return TopicLock.instance()
 
 
 __all__ = [

--- a/app/services/skills/understanding_state_skill.py
+++ b/app/services/skills/understanding_state_skill.py
@@ -31,6 +31,7 @@ import contextlib
 from dataclasses import dataclass
 from typing import Literal
 
+from app.services.skills.base import BaseSkill
 from app.services.skills.doctrine import UNDERSTANDING_STATE_DOCTRINE_VERSION
 
 KCState = Literal["not_addressed", "explained", "understood"]
@@ -122,7 +123,7 @@ except Exception:  # pragma: no cover
         pass
 
 
-class UnderstandingStateSkill:
+class UnderstandingStateSkill(BaseSkill):
     """
     محرّك حالة الفهم (Learning State — D-135).
 
@@ -136,6 +137,12 @@ class UnderstandingStateSkill:
     """
 
     _skill_name: str = "understanding_state"
+    name = "understanding_state"
+
+    def run(self, *args, **kwargs):
+        """Polymorphic entry point (BaseSkill) — delegates to :meth:`decide`."""
+        return self.decide(*args, **kwargs)
+
     doctrine_version: str = UNDERSTANDING_STATE_DOCTRINE_VERSION
     _MAX_LEVEL: int = 3
 

--- a/tests/services/test_skills_base.py
+++ b/tests/services/test_skills_base.py
@@ -1,0 +1,91 @@
+"""Runtime evidence for the BaseSkill OOP consolidation (D-179).
+
+Proves the new abstraction is real (import + call chain + runtime evidence — the
+anti-ZOMBIE doctrine of CLAUDE.md §6.6), not just present in the tree.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from app.services.skills.base import BaseSkill, skill_counter, skill_histogram
+
+
+def test_baseskill_is_abstract() -> None:
+    """BaseSkill cannot be instantiated directly (true ABC)."""
+    with pytest.raises(TypeError):
+        BaseSkill()  # type: ignore[abstract]
+
+
+def test_concrete_skill_instantiable_and_runs() -> None:
+    class _Echo(BaseSkill):
+        name = "echo"
+
+        def run(self, payload):
+            return payload
+
+    skill = _Echo()
+    assert skill.name == "echo"
+    assert skill.version == "1.0.0"
+    assert skill.run("hi") == "hi"
+
+
+def test_instance_is_cached_per_class() -> None:
+    class _A(BaseSkill):
+        name = "a"
+
+        def run(self, *a, **k):
+            return "a"
+
+    class _B(BaseSkill):
+        name = "b"
+
+        def run(self, *a, **k):
+            return "b"
+
+    a1, a2 = _A.instance(), _A.instance()
+    b1 = _B.instance()
+    assert a1 is a2  # same object across calls
+    assert a1 is not b1  # subclasses do not share a cached instance
+    assert isinstance(a1, _A) and isinstance(b1, _B)
+
+
+def test_run_supports_heterogeneous_signatures() -> None:
+    """run() is untyped so a skill whose action is 'align' can delegate to it."""
+
+    class _Aligner(BaseSkill):
+        name = "aligner"
+
+        def align(self, text: str) -> str:
+            return text.upper()
+
+        def run(self, *args, **kwargs):
+            return self.align(*args, **kwargs)
+
+    assert _Aligner.instance().run("ok") == "OK"
+
+
+def test_skill_counter_is_reimport_safe() -> None:
+    """skill_counter registers once and never raises on duplicate registration."""
+    c1 = skill_counter("cogniforge_test_base_probe_total", "probe counter", ("status",))
+    # Second call with the same name must not raise Duplicated timeseries.
+    c2 = skill_counter("cogniforge_test_base_probe_total", "probe counter", ("status",))
+    # Both are usable (real Counter or no-op) — the fluent API never raises.
+    c1.labels(status="ok").inc()
+    c2.labels(status="ok").inc()
+
+
+def test_skill_histogram_is_reimport_safe() -> None:
+    h1 = skill_histogram("cogniforge_test_base_hist_seconds", "probe hist", ("kind",))
+    h2 = skill_histogram("cogniforge_test_base_hist_seconds", "probe hist", ("kind",))
+    h1.labels(kind="x").observe(0.1)
+    h2.labels(kind="x").observe(0.2)
+
+
+def test_base_module_reexported_from_package() -> None:
+    """BaseSkill and helpers are importable from the skills package root."""
+    pkg = importlib.import_module("app.services.skills")
+    assert getattr(pkg, "BaseSkill", None) is BaseSkill
+    assert callable(getattr(pkg, "skill_counter", None))


### PR DESCRIPTION
Consolidates the three cross-cutting concerns every skill hand-rolled:
shared identity (name/version), a per-class lazy singleton (instance()),
and the re-import-safe Prometheus guard (skill_counter/skill_histogram).
Dependency-free; uses the default global REGISTRY (no new CollectorRegistry);
no cross-service imports. Re-exported from the skills package root.

7 runtime-evidence tests in tests/services/test_skills_base.py. ruff clean,
skills-doctrine + runtime-truth + test-hygiene gates green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LewzWuQkUN2Tpkq3aJzM68