### PR TITLE
Make the front door tell the same truth as the constitution

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,0 +1,430 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/hero-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/brand/hero-light.svg">
+  <img alt="CogniForge — المختبر المعرفي: محرّك تعلّمٍ قابل للتحقّق" src="docs/assets/brand/hero-light.svg" width="100%">
+</picture>
+
+<br/>
+
+**محرّك تعلّمٍ يقيس ما يعرفه الطالب فعلاً — ويرفض أن يُسلّمه الجواب.**
+
+المستودع `NAAS-Agentic-Core` · المحرّك **CogniForge** · المنتج **ETAALIM.AI** · مبنيٌّ لبكالوريا الجزائر، ومُهندَسٌ على المعيار الذي تُدقّق به أسواق أمريكا وأوروبا.
+
+<br/>
+
+[![مختبر معرفي](https://img.shields.io/badge/%D9%85%D8%AE%D8%AA%D8%A8%D8%B1_%D9%85%D8%B9%D8%B1%D9%81%D9%8A-%D9%84%D8%A7_%D9%85%D8%B9%D9%84%D9%85_%D8%AF%D8%B1%D8%AF%D8%B4%D8%A9-F4A98A?style=flat-square&labelColor=24211C)](#١--ما-هذا-النظام-فعلاً)
+[![حتمي](https://img.shields.io/badge/%D8%A7%D9%84%D8%A3%D8%B1%D9%82%D8%A7%D9%85-%D8%B5%D9%81%D8%B1_LLM_%D9%81%D9%8A_%D8%A7%D9%84%D9%85%D8%B3%D8%A7%D8%B1-7C5CBF?style=flat-square&labelColor=24211C)](#٥--النواة-المعرفية)
+[![حقيقة تشغيلية](https://img.shields.io/badge/%D8%A7%D9%84%D8%AD%D9%82%D9%8A%D9%82%D8%A9-%D8%A7%D8%B3%D8%AA%D9%8A%D8%B1%D8%A7%D8%AF_%2B_%D8%B3%D9%84%D8%B3%D9%84%D8%A9_%2B_%D8%A8%D8%B1%D9%87%D8%A7%D9%86-A78BE0?style=flat-square&labelColor=24211C)](#٦--انضباط-الحقيقة)
+[![مفروض](https://img.shields.io/badge/%D9%83%D9%84_%D9%82%D8%A7%D9%86%D9%88%D9%86-%D9%8A%D9%8F%D8%B3%D9%85%D9%91%D9%8A_%D9%81%D8%A7%D8%B1%D8%B6%D9%87-FFC9B4?style=flat-square&labelColor=24211C)](#٧--كل-قانون-يسمي-فارضه)
+<br/>
+[![Python](https://img.shields.io/badge/Python-3.12-7C5CBF?style=flat-square&labelColor=24211C)](pyproject.toml)
+[![FastAPI](https://img.shields.io/badge/FastAPI-monolith_%2B_islands-F4A98A?style=flat-square&labelColor=24211C)](app)
+[![Next.js](https://img.shields.io/badge/Next.js-frontend-A78BE0?style=flat-square&labelColor=24211C)](frontend)
+[![CI](https://img.shields.io/badge/required--ci-aggregated-1F6B46?style=flat-square&labelColor=24211C)](.github/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-MIT-FFC9B4?style=flat-square&labelColor=24211C)](LICENSE)
+
+[English](README.md) · **العربية**
+
+</div>
+
+---
+
+> [!IMPORTANT]
+> **النظام ليس معلّم دردشة. هو مختبر معرفي — محرّك تفكير يُنمذج تفكير الطالب ويختبره ويحسّنه.**
+> الدردشة واجهة تسليم لا أكثر. والقلب هو: واجهة الكائنات التفاعلية · النمذجة المعرفية · ذاكرة الخطأ · التوليد التكيّفي · المحاكاة.
+> — [`CLAUDE.md`](CLAUDE.md) §0، الدستور التشغيلي الذي يرثه كل مساهمٍ وكل وكيل.
+
+---
+
+## الفهرس
+
+| | | |
+|---|---|---|
+| [١ · ما هذا النظام فعلاً](#١--ما-هذا-النظام-فعلاً) | [٧ · كل قانون يسمّي فارضه](#٧--كل-قانون-يسمي-فارضه) | [١٣ · عقد الـCI](#١٣--عقد-الـci) |
+| [٢ · لماذا نحجب الجواب](#٢--لماذا-نحجب-الجواب-نتيجة-منشورة-لا-ذوق-تصميم) | [٨ · طبقات التنسيق التسع](#٨--طبقات-التنسيق-التسع) | [١٤ · الحماية وحدّ المصداقية](#١٤--الحماية-وحماية-البيانات-وحد-المصداقية) |
+| [٣ · الوظائف الأربع](#٣--الوظائف-الأربع-واختبار-الحذف) | [٩ · ما لم يُبنَ عمداً](#٩--ما-لم-يبن-عمداً) | [١٥ · خريطة سلطة التوثيق](#١٥--خريطة-سلطة-التوثيق) |
+| [٤ · المعمارية](#٤--المعمارية-في-لمحة) | [١٠ · البدء السريع](#١٠--البدء-السريع) | [١٦ · المساهمة](#١٦--المساهمة) |
+| [٥ · النواة المعرفية](#٥--النواة-المعرفية) | [١١ · خريطة المستودع](#١١--خريطة-المستودع) | [١٧ · الرخصة والاستشهاد](#١٧--الرخصة-والاستشهاد-والتواصل) |
+| [٦ · انضباط الحقيقة](#٦--انضباط-الحقيقة) | [١٢ · خارطة الطريق](#١٢--خارطة-الطريق) | |
+
+---
+
+## ١ · ما هذا النظام فعلاً
+
+ثمانمئة ألف طالبٍ جزائري يجلسون لامتحان البكالوريا. المحتوى مجّانيٌّ أصلاً — Dzexams وONEFD ويوتيوب. والشرح صار مجّانياً يوم شُحنت النماذج اللغوية العامّة. **ولا واحدٌ منهما نادر، فلا واحدٌ منهما يستحقّ ثمناً.**
+
+الذي لا وجود له في هذا السوق هو نظامٌ يعرف **ما لا يعرفه طالبٌ بعينه**، ويرتّب الساعات المتبقّية بما يُكسب نقاطاً في الامتحان فعلاً، ويرفض أن يُنتج الخطوة التي ما زال الطالب قادراً على توليدها، ويُثبت العائد للوليّ الذي يدفع.
+
+وهذا بالضبط ما يبنيه هذا المستودع.
+
+> **الجملة الدستورية:** «الطالب لا يرسل سؤالاً إلى النظام؛ الطالب يدخل مسار تعلّم حيّ، والنظام مسؤول عن حفظ هذا المسار من الانهيار.» — [`.memory/pedagogical_os.md`](.memory/pedagogical_os.md) (D-153)
+
+ثلاث خصائص تجعله غير مألوف، وثلاثتها مفروضةٌ ببوّابات CI لا موعودةٌ في نثر:
+
+1. **الأرقام لا تُولَّد أبداً.** كل احتمالٍ وعددٍ وقيمةٍ تركيبية تأتي من محرّكٍ رمزي حتمي. النموذج اللغوي يسرد الفهم، ولا يقرّر الحقيقة أبداً.
+2. **الجواب محجوبٌ بقانون.** لا يكشف النظام نتيجةً ولا خطوةً يستطيع الطالب توليدها. وهذه نتيجةٌ تجريبية منشورة لا تفضيلٌ أسلوبي — انظر [§٢](#٢--لماذا-نحجب-الجواب-نتيجة-منشورة-لا-ذوق-تصميم).
+3. **لا قدرةَ تُدَّعى بلا برهان.** المكوّن `ACTIVE` فقط باستيرادٍ + سلسلة نداء + دليلٍ تشغيلي. وما دون ذلك يُوسَم `PARTIAL` أو `DORMANT` أو `ZOMBIE` — علانيةً في [`.memory/runtime_truth.md`](.memory/runtime_truth.md).
+
+---
+
+## ٢ · لماذا نحجب الجواب: نتيجة منشورة لا ذوق تصميم
+
+Bastani وآخرون، *PNAS* (2025) — تجربة ميدانية عشوائية على نحو ألف تلميذٍ ثانوي في الرياضيات:
+
+<div align="center">
+
+| الحالة | أثناء التمرين | في الامتحان بلا مساعدة |
+|:---|:---:|:---:|
+| وصولٌ حرّ بواجهة تشبه ChatGPT | **+٤٨٪** | **أسوأ بـ١٧٪** ممّن لم يستعمل شيئاً أصلاً |
+| النموذج نفسه بضوابط تربوية (تلميحات لا إجابات) | **+١٢٧٪** | الضرر أُلغي |
+
+</div>
+
+مجموعة الوصول الحرّ *شعرت* بأنها أفضل بكثير، و*أدّت* أسوأ حين سُحبت الأداة. وهذه المسافة بين الطلاقة المُتوهَّمة والقدرة الراسخة اسمها هنا **فجوة الوهم**، وتقليصها هو **مقياس النجاح الوحيد** الذي نُحسّن عليه.
+
+> **أهدافٌ ممنوعة دائماً:** مدّة الجلسة · عدد الرسائل · الرضا اللحظي. النظام الذي يُعظّم هذه الثلاثة يُعظّم الوهم نفسه.
+
+**فجوة الوهم = الأداء المدعوم − القدرة غير المدعومة المؤجَّلة.** تُبَثّ باسم `cogniforge_tutor_illusion_gap` وتُعرَض على [لوحة Grafana رقم 180](observability/grafana/dashboards/180-illusion-gap.json). وحين لا يبلغ القياس نضجاً يسمح بالصدق — ملاحظاتٌ غير مدعومة أقلّ من الحدّ — يُرجِع `null` لا صفراً. الصفر يُقرأ «فقدناهم»، والحقيقة «لم نعرف بعد».
+
+الحجّة كاملةً بمراجعها: [`docs/VALUE_DOCTRINE.md`](docs/VALUE_DOCTRINE.md).
+
+---
+
+## ٣ · الوظائف الأربع، واختبار الحذف
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/four-functions-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/brand/four-functions-light.svg">
+  <img alt="الوظائف الأربع: قِس بصدق · رتّب الوقت · أجبر على التوليد · أثبت للدافع" src="docs/assets/brand/four-functions-light.svg" width="100%">
+</picture>
+
+كل ميزةٍ مقترحة تواجه سؤالاً واحداً: *لو حُذفت، أيٌّ من الأربع يتوقّف؟* فإن كان الجواب «لا شيء، لكنها تبدو متقدّمة» — **تُحذَف**. وتسع قدراتٍ محرَّمةٌ صراحةً على هذا الأساس بعينه، منها: مكتبة محتوى · نموذج مُدرَّب من الصفر · تتبّعٌ معرفي عميق قبل بياناتٍ ضخمة · جدارية تصنيف · وأيّ آلية تصميمٍ إدماني. المستخدمون قاصرون تحت ضغط امتحانٍ مصيري، فآليات الالتزام **يختارها الطالب ويستطيع فسخها** ([`SAFEGUARDING.md`](SAFEGUARDING.md)).
+
+---
+
+## ٤ · المعمارية في لمحة
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'fontFamily':'ui-sans-serif, system-ui, sans-serif','primaryColor':'#FBF2EC','primaryTextColor':'#24211C','primaryBorderColor':'#E08A66','lineColor':'#A78BE0','secondaryColor':'#F0E9FA','tertiaryColor':'#EAF3EC','clusterBkg':'#FBFAF7','clusterBorder':'#E2DED4'}}}%%
+flowchart LR
+    S["🎓 الطالب<br/>عربية · فرنسية · دارجة"] --> WS["WebSocket<br/>/api/chat/ws"]
+    WS --> M["مونوليث FastAPI :8000<br/>كاتبٌ واحد · إطارٌ نهائي واحد"]
+
+    M --> P{"استباقات حتمية<br/>بلا LLM"}
+    P -->|تحية| G["GreetingSkill"]
+    P -->|رمز| N["سجلّ الرموز"]
+    P -->|احتمالات| SYM["المحرّك الرمزي<br/>يُنهي المسار"]
+
+    P -->|غير ذلك| O["orchestrator-service :8006<br/>تركيب: تخطيط ← بحث ← استدلال"]
+    O --> GUARD["حارس المخرَج<br/>حجب · جدار ناري · قفل موضوع"]
+    SYM --> GUARD
+    G --> GUARD
+    N --> GUARD
+    GUARD --> OUT["إطارٌ نهائي واحد<br/>assistant_final | error"]
+    OUT --> LEARN["BKT · FSRS · tutor_state<br/>مُلحَق-فقط"]
+
+    style S fill:#FBF2EC,stroke:#E08A66,stroke-width:2px,color:#24211C
+    style SYM fill:#EAF3EC,stroke:#1F6B46,stroke-width:2px,color:#24211C
+    style GUARD fill:#F0E9FA,stroke:#7C5CBF,stroke-width:2px,color:#24211C
+    style LEARN fill:#F0E9FA,stroke:#7C5CBF,stroke-width:2px,color:#24211C
+    style OUT fill:#FBF2EC,stroke:#E08A66,stroke-width:2px,color:#24211C
+```
+
+**المحادثة عبر WebSocket حصراً** — لا وجود لـ`POST /api/chat/messages` (يُرجع 404 عمداً). المفتاح `question`، والمصادقة عبر `subprotocols=['jwt', TOKEN]`، وكل دورٍ يُصدِر **إطاراً نهائياً واحداً** من مُصدِرٍ وحيد. رسالة الطالب يكتبها المونوليث عند مدخل الـWebSocket، وكتابة ردّ المساعد تُنسَّق بعَلَم `persisted` صريح فتستحيل الكتابة المزدوجة ([`CLAUDE.md`](CLAUDE.md) §6.5).
+
+### طوبولوجيتان حقيقيتان — تُوثَّقان اثنتين لا واحدة
+
+<table>
+<tr><th align="right" width="50%">(أ) Codespaces / uvicorn — ما يخدم اليوم</th><th align="right" width="50%">(ب) Docker Compose — وجهة الهجرة</th></tr>
+<tr valign="top"><td>
+
+يُقلعها `.devcontainer/supervisor.sh`.
+
+`الواجهة :5000` · `المونوليث :8000` · `user :8001`
+`planning :8002` · `conversation :8003` · `orchestrator :8006`
+`research :8007` · `reasoning :8008` · `content-retrieval :8009`
+`foundations :8010` · `notation :8011`
+`Prometheus :9090` · `Grafana :3001`
+
+**كل دور طالبٍ اليوم يمرّ من هنا.**
+
+</td><td>
+
+`docker-compose.yml` يصف وجهة الـstrangler-fig: بوّابة API وقاعدة بيانات لكل خدمة، **والمونوليث غائبٌ عن قصد** (ثلاث بوّابات تمنع إعادته).
+
+المنافذ تختلف عن (أ) لخمس خدمات. والمصدر القانوني المحكوم ببوّابة هو [`docs/architecture/PORTS_SOURCE_OF_TRUTH.json`](docs/architecture/PORTS_SOURCE_OF_TRUTH.json) و[`config/microservice_catalog.json`](config/microservice_catalog.json) — **13 خدمة مصغّرة** مُعلَنة.
+
+**البناء ليس تشغيلاً.** الصور تُبنى ويُثبَت استيرادها في كل PR؛ ولا حاوية تطبيقية تُقلَع في CI.
+
+</td></tr>
+</table>
+
+### حدّ الخدمة عقدٌ لا لغة
+
+كل خدمة تحمل عقد OpenAPI مُلتزَماً، وبوّابة تكافؤٍ **دلالية** تقارن المسارات المُعلَنة بالتطبيق الحيّ — **API-first 13/13**، تفرضها `check_openapi_parity` في كل طلب دمج. والاستيراد بين الخدمات ممنوعٌ ومفحوصٌ بـAST؛ المنطق المشترك **يُوَرَّد ببوّابة تكافؤ** لا يُستورَد، فلا تمدّ خدمةٌ يدها إلى أحشاء أخرى.
+
+---
+
+## ٥ · النواة المعرفية
+
+| الطبقة | ما هي | لماذا تهمّ |
+|---|---|---|
+| **المحرّك الرمزي للاحتمالات** | [`app/services/skills/`](app/services/skills) — تركيبات وحساب شرطي ومتغيّرات عشوائية، حتمياً | صفر LLM في مسار الأرقام. معلّمٌ يخطئ حساباً مرّةً يفقد الطالب إلى الأبد |
+| **الأسس** | [`app/core/foundations/`](app/core/foundations) — منطق · نظرية أعداد · جبر خطّي · تفاضل · إحصاء · تحسين · نظرية بيان · لغات صورية · قابلية حساب · تعقيد | stdlib بلا تبعيات. كل بدائية ترفع عند خرق المجال بدل أن تُعيد `0` مضلِّلاً |
+| **نواة الاستدلال** | [`app/core/reasoning/`](app/core/reasoning) — أشجار حجاج باستلزامٍ مُتحقَّق · رسوم سببية (سببية مقابل ارتباط) · تفكيك · تجريد · نماذج ذهنية | الصحّة يقرّرها المحرّك لا النموذج. النموذج يسرد |
+| **BKT** | [`bkt_engine.py`](app/services/skills/bkt_engine.py) — تتبّع معرفة بايزي، سجلّ تفاعل مُلحَق-فقط | الإتقان احتماليةٌ بتاريخٍ زمني، لا درجةٌ تُكتَب فوق سابقتها |
+| **جدولة FSRS-5** | [`shared/scheduling/fsrs.py`](shared/scheduling/fsrs.py) | إجابةٌ صحيحة بسقالةٍ كاملة تُقيَّم `HARD` لا `GOOD`، و`EASY` تتطلّب استقلالاً **و**رسوخاً معاً — وإلّا أتمتنا وهم الطلاقة |
+| **منهاجٌ واحد** | [`shared/curriculum/registry.py`](shared/curriculum/registry.py) — **37 مفهوماً**، رياضيات وفيزياء وعلوم طبيعة، بحوافّ شروطٍ مسبقة | كانت ثلاثة تعاريف متنافرة لا يتّفق أيّ اثنين، فكانت أسئلة الفيزياء كلّها تسقط إلى `general`. رسمٌ واحد الآن، مفروضٌ ببوّابة |
+| **سجلّ الرموز** | [`shared/notation/registry.py`](shared/notation/registry.py) | النظام يُعرّف كل رمزٍ يطبعه — `C(n,k)` · `P_A(B)` · `Ω`. ورمزٌ يُبَثّ بلا إدخالٍ في السجلّ ⇒ CI أحمر |
+| **فجوة الوهم** | [`shared/illusion/`](shared/illusion) | دون حدّ الملاحظات تُرجِع `None`. وتقريرٌ يُلوّن المنهاج كلّه بعد جلستين **تقريرٌ كاذب** |
+
+**مهارات لا Prompt Spaghetti.** كل قدرة ذكاءٍ اصطناعي هي Skill: مسؤولية واحدة · عقد محدَّد · مقاييس Prometheus · اختبارات قابلة للتشغيل · وتدهور رشيق مستقلّ. **39 مهارة** مُسجَّلة في [`app/services/skills/registry.py`](app/services/skills/registry.py)، كلٌّ منها يرث `BaseSkill`؛ ومهارةٌ بلا مستهلكٍ حيّ **تُحذَف** ولا تُترَك stub.
+
+---
+
+## ٦ · انضباط الحقيقة
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/proof-ladder-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/brand/proof-ladder-light.svg">
+  <img alt="سلّم البرهان: ACTIVE تتطلّب استيراداً وسلسلة نداء ودليلاً تشغيلياً" src="docs/assets/brand/proof-ladder-light.svg" width="100%">
+</picture>
+
+جدول الحالة الحيّ هو [`.memory/runtime_truth.md`](.memory/runtime_truth.md) — **ولا يُنسَخ هنا عمداً**، لأن جدول حالةٍ منسوخاً في ملفٍّ ثانٍ ينحرف ثمّ يكذب. وبوّابة انحراف ([`scripts/runtime_truth.py`](scripts/runtime_truth.py) `--check`) تقارن الكود بقفلٍ مُلتزَم في كل طلب دمج.
+
+ثلاث نتائج نعيش بها:
+
+- **العملية الحيّة ليست خدمةً صحيحة.** افحص استجابة `/health` لا قائمة العمليات؛ وخدمةٌ تُقلع ويفشل تسخين رسمها **degraded**، ويقولها `startup_state`.
+- **لوحةٌ تعرض صفراً دائماً لا تُميَّز عن نظامٍ ميت.** فكل مقياسٍ يلزمه مُصدِرٌ مُتحقَّق في مصدر التطبيق.
+- **تقادم ملفّ القفل عطبٌ يُبلَّغ.** ملفّات القفل تسجّل تاريخ توليدها؛ وبوّابةٌ خضراء على قفلٍ بائت **خضرةٌ كاذبة**.
+
+---
+
+## ٧ · كل قانون يسمّي فارضه
+
+الملاحظة المؤسِّسة لهذا الكود: **البيت لا ينهار بقرارٍ واحد سيّئ، بل بحاصل جمع قراراتٍ صغيرة لم يحرسها شيء.** فقانونٌ بلا فارضٍ آلي **مرفوضٌ مرّتين**: مرّةً لأنه غير مفروض، ومرّةً لأن صمته يُقرأ انضباطاً.
+
+| القانون | الفارض | ما يُحمِّر الـCI |
+|---|---|---|
+| لا صدفة في تنفيذ العمليات الفرعية | [`check_no_shell_true.py`](scripts/fitness/check_no_shell_true.py) | أيّ `shell=True`. الدَّين المُجمَّد **فارغ** ويتقلّص فقط |
+| سياسة الحجب متطابقة في العقلين اللذين يفرضانها | [`check_redaction_parity.py`](scripts/fitness/check_redaction_parity.py) | مسارٌ يحجب الجواب وآخر يسرّبه |
+| علامات النيّة لها موطنٌ واحد | [`check_intent_single_source.py`](scripts/fitness/check_intent_single_source.py) | قائمةٌ ثانية لعلامات النيّة في أيّ مكان |
+| قدرة النموذج بيانٌ بدليلٍ مؤرَّخ | [`check_model_registry.py`](scripts/fitness/check_model_registry.py) | نموذجٌ محظور يُرقّى، أو إدخالٌ بلا دليل |
+| كل رمزٍ يطبعه المعلّم قابلٌ للتعريف | [`check_notation_definable.py`](scripts/fitness/check_notation_definable.py) | رمزٌ يُبَثّ بلا إدخالٍ في السجلّ |
+| رسمٌ واحد للشروط المسبقة لا اثنان | [`check_prerequisite_single_graph.py`](scripts/fitness/check_prerequisite_single_graph.py) | مجتازٌ ثانٍ يقرأ رسماً مختلفاً |
+| الحيرة لا تُهنَّأ | [`check_understanding_evidence.py`](scripts/fitness/check_understanding_evidence.py) | اعتبار **اسم** المفهوم داخل سؤال الطالب دليلاً على فهمه |
+| بوّابةٌ لا تقرأ ملفاً لا تُبلِّغ أنه نظيف | [`check_gate_parse_honesty.py`](scripts/fitness/check_gate_parse_honesty.py) | `except SyntaxError: return []` — عمىً صامت داخل فارض |
+| الدستور يساوي الواقع؛ الرقم يُشتَقّ ولا يُكتب | [`check_constitution_reality.py`](scripts/fitness/check_constitution_reality.py) | أيّ عددٍ مكتوبٍ يدوياً في وثيقة سلطة يخالف مصدره — **بما فيه هذا الملفّ** |
+| خرائط السلطة تصل | [`check_authority_links.py`](scripts/fitness/check_authority_links.py) | رابطٌ في هذا الملفّ أو `CLAUDE.md` أو فهرس التوثيق يشير إلى مسارٍ غير موجود |
+| كل مجالٍ حاسوبي يُصرِّح حالته ودليله | [`check_cs_knowledge_map.py`](scripts/fitness/check_cs_knowledge_map.py) | `ACTIVE` أمام ملفٍّ محذوف، أو خانة فجوةٍ فارغة |
+| القيم البصرية من الرموز بتباينٍ **محسوب** | [`check_design_tokens.py`](scripts/fitness/check_design_tokens.py) | لونٌ خام في مكوّن، أو زوجٌ يفشل WCAG AA عند **الحساب** |
+
+لتشغيل المجموعة كاملةً محلياً — تقرأ `ci.yml` فلا تنحرف عنها:
+
+```bash
+make gates
+```
+
+> **يُقال صراحةً:** اختبار الحذف في [§٣](#٣--الوظائف-الأربع-واختبار-الحذف) يفرضه **حكمٌ بشري في المراجعة — بلا فارضٍ آلي**. المفروض آلياً هو **تصنيف** كل وحدة وحالتها. وإعلان غياب الفارض قاعدةٌ هنا: الخانة الفارغة تُقرأ انضباطاً، أمّا الفجوة المنطوقة فلا.
+
+---
+
+## ٨ · طبقات التنسيق التسع
+
+انتقلت قيمة النظام من «اكتب Prompt أفضل» إلى «صمّم المنظومة التي تُنسّق عمل الوكلاء». الـPrompt مؤقّتٌ سياقيٌّ قابل للضياع؛ والمنظومة تُنتج مخرَجاً مستقرّاً قابلاً للاختبار وإعادة الاستعمال.
+
+```
+Knowledge → Skills → Agents → Orchestration → Memory → Evaluation → Governance → Infrastructure → Humans
+```
+
+المعرفةُ ما نعرفه · والمهارةُ كيف ننفّذه · والوكيلُ من ينفّذ · **والتنسيقُ من يفعل ماذا ومتى وبأيّ سياق ومن يراجع قبل الدمج.** القانون في [`docs/architecture/AGENTIC_ORCHESTRATION_DOCTRINE.md`](docs/architecture/AGENTIC_ORCHESTRATION_DOCTRINE.md)، والحالة الحيّة في [`.memory/agentic_runtime_doctrine.md`](.memory/agentic_runtime_doctrine.md). والفصل بينهما **إلزاميٌّ ومحروس**: وثيقة القانون تفشل في CI إن نبت لها عمود حالة، وجدول الحالة يفشل إن استشهد بدليلٍ لا وجود له.
+
+**والبشر طبقةٌ لا استثناء** (التاسعة): تبنّي تقنيةٍ جديدة يتطلّب ADR، ورفعُ أيّ مِسنَنٍ مُعلَن — سقف دَينٍ أو أرضية تغطية — يتطلّب قراراً مكتوباً يُسمّي السبب، فيصير التخفيف مكلفاً ومرئياً بدل أن يكون صامتاً.
+
+---
+
+## ٩ · ما لم يُبنَ عمداً
+
+هذا القسم موجودٌ لأن نظاماً لا يُعلن إلّا مواطن قوّته لا يمكن تدقيقه.
+
+| غير مبنيّ | الحالة | لماذا يُصرَّح به بدل أن يُخفى |
+|---|---|---|
+| **بوّابة دفع** | مقعد بصفر كود | الحقوق والقسائم المُجزَّأة موجودة؛ وSATIM/Chargily مقعدٌ موثَّق. لا تكامل نصفيّ يتظاهر بقبض المال |
+| **نموذج لغوي موصولٌ بمُنفِّذ الصندوق** | **مقفول** | الصندوق يُشغّل أوامر حقيقية والمستخدمون قاصرون. توصيل أيّ مُخطِّط أو نموذج بالأدوات محظورٌ حتى تكتمل عقود القدرات والمسابر الحيّة والميزانيات وسجلّ تدقيقٍ مُلحَق-فقط وحُرّاس التعديل الذاتي. وبندٌ في CI يُفشِل البناء إن جمعت وحدةٌ المُنفِّذ مع عميل نموذج |
+| **عامل Temporal** | الخادم مُثبَت، والعامل لم يتّصل قطّ | الخادم يُبلِّغ SERVING في CI؛ **ولم يُنفَّذ أيّ سير عمل**. الإقلاع ليس تنفيذاً، ونرفض تقريب ذلك |
+| **الاسترجاع المتّجهي** | DORMANT | التضمينات وإعادة الترتيب موجودة بصفر نداء وقت الطلب. والاسترجاع اليوم حتميٌّ معجمي |
+| **المونوليث في compose الافتراضي** | غائبٌ عن قصد | Strangler المرحلة 3؛ ثلاث بوّابات تمنع إعادته، وبيته ملفّ legacy |
+| **تتبّع معرفي عميق (DKT/SAKT)** | محرَّمٌ الآن | حجم البيانات لا يبرّره. ومعرفةُ **لماذا** رُفض الأحدث تشتري مصداقيةً أكثر من استعماله |
+| **حاويات تطبيقية في CI** | غير مُقلَعة | تُقلَع حزمة الأحداث وحدها (Redpanda وTemporal) في كل PR |
+
+> **حدّ المصداقية (D-227) مطبَّقاً على كلامنا نحن:** لا ادّعاء «قراءة الأفكار» ولا «دقّة ١٠٠٪» ولا «صفر أخطاء» ولا «تغيير البشرية». العبارة غير القابلة للتفنيد **دَينٌ لا طموح**: تُصدَّق مرّة، ثمّ تُكتشَف، ثمّ يسقط معها كلُّ ما هو صحيح. والمنصّة تخدم قاصرين وأولياءَ يقرّرون بناءً على ما نقول.
+
+---
+
+## ١٠ · البدء السريع
+
+### للمطوّرين والباحثين
+
+```bash
+git clone https://github.com/HOUSSAM16ai/NAAS-Agentic-Core.git
+cd NAAS-Agentic-Core
+
+python3.12 -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements-dev.txt -r requirements-test.txt
+
+# البوّابات التي تحسم قابلية الدمج — نفس المجموعة وبنفس الترتيب كما في CI
+ruff check . && ruff format --check .
+make gates                       # كل بوّابات اللياقة، مقروءةً من ci.yml
+pytest -v --cov=app --cov-report=term-missing --cov-fail-under=73
+```
+
+### تشغيل المنصّة
+
+```bash
+# Codespaces / devcontainer: المُشرِف يُقلع الخلفية والواجهة والخدمات
+.devcontainer/supervisor.sh
+
+# أو يدوياً
+python -m uvicorn app.main:app --host 0.0.0.0 --port 8000     # الخلفية
+cd frontend && npm run dev                                     # الواجهة على :5000
+
+# الصحّة — اقرأ الاستجابة، لا قائمة العمليات
+curl -s http://localhost:8000/health | python -m json.tool
+```
+
+> [!NOTE]
+> التطبيق لا يُقلع بلا `DATABASE_URL` (أو `APP_DATABASE_URL`)، والإعدادات تُقرأ من **بيئة العملية** وقت الاستيراد — فالتصدير إلى البيئة قبل تشغيل uvicorn **إلزامي**، وكتابة `.env` وحدها لا تكفي. استعمل `postgresql+asyncpg://` لا `postgresql://` المجرّدة. ابدأ بنسخ [`.env.example`](.env.example).
+
+### الحزمة الكاملة على Docker
+
+```bash
+docker compose -f docker-compose.yml up -d      # طوبولوجيا وجهة الهجرة
+make microservices-health
+```
+
+---
+
+## ١١ · خريطة المستودع
+
+```text
+.
+├── app/                    مونوليث FastAPI — routers · skills · محرّكات النواة · kernel
+│   ├── core/               foundations · reasoning · settings · database · prompts
+│   ├── services/skills/    39 مهارة مُسجَّلة، كلٌّ على BaseSkill
+│   └── api/routers/        مداخل HTTP + WebSocket (المحادثة WS حصراً)
+├── shared/                 محرّكات بلا تبعيات: curriculum · scheduling · notation
+│                           illusion · analytics · messaging · retrieval · ai_models
+├── microservices/          جزر الخدمات — لكلٍّ عقدها وDockerfile خاصّ بها
+├── frontend/               تطبيق Next.js · رموز التصميم · عقود الثيم
+├── scripts/fitness/        الفوارض — بوّابة لكل قانون
+├── tests/                  عقود · معمارية · حراسة · ترانسكريبت · أمن
+├── docs/                   عقيدة المعمارية · ADRs · العقود · الحوكمة
+│   ├── architecture/       عقيدة الهندسة · خريطة علوم الحاسوب · التنسيق
+│   └── contracts/openapi/  13 عقد خدمةٍ مُلتزَماً
+├── observability/          Prometheus · لوحات Grafana · توصيل التتبّع
+├── infra/                  Kubernetes · Terraform · ArgoCD
+├── .memory/                الذاكرة المؤسسية — الحقيقة التشغيلية · القرارات · البلاغات
+└── CLAUDE.md               الدستور التشغيلي (D-001 → D-227)
+```
+
+---
+
+## ١٢ · خارطة الطريق
+
+المصدر الحيّ الوحيد هو [`.memory/roadmap.md`](.memory/roadmap.md) — المراحل `M0 → M11` للمحرّك التربوي، ومساراتٌ موازية لطبقة المنتج وطبقة القيمة والإيراد ومحرّك التنفيذ المعرفي والتوأم الرقمي المعرفي. وكل وحدةٍ مخطّطة تحمل حالةً من سلّم البرهان ودليلاً ملفّياً وفجوةً مكتوبة وشرط ترقيةٍ صريحاً.
+
+**الطموح يُصنَّف ولا يُكتَم**: `PLANNED` و`SEAM` و`ABSENT` إعلانات مُتتبَّعة. والطموح غير المُصنَّف هو الذي يُنسى.
+
+سجلّ البلاغات والقرارات: [`.memory/decisions.md`](.memory/decisions.md) (D-001 → D-227) · [`.memory/issues.md`](.memory/issues.md) (ISS-001 → ISS-150). كلاهما سجلٌّ مُلحَق-فقط يشمل الإخفاقات — وبلاغُ كارثةٍ بلا جذرٍ مكتوب ليس مُغلَقاً.
+
+---
+
+## ١٣ · عقد الـCI
+
+حماية الفرع على `main` يجب أن تشترط فحصاً واحداً: **`required-ci`**. وهو يجمع **10 وظائف**:
+
+| الوظيفة | ما تفرضه |
+|---|---|
+| `lint` | `ruff check` · `ruff format --check` · `mypy` (بإصدارات مُثبَّتة — أداةُ فحصٍ تُحدِّث نفسها ليست بوّابة بل رمية عملة) |
+| `contracts` | تكافؤ البوّابة/المزوّد + اختبارات العقود |
+| `guardrails` | كل بوّابات اللياقة — تُشغَّل محلياً بـ`make gates` |
+| `test-monolith` | مجموعة الاختبارات بـ`--cov-fail-under=73` |
+| `test-microservices` | مجموعات كل خدمة + تكافؤ OpenAPI |
+| `frontend-tests` | اختبارات node · تزامن القفل · أنواع TS المولَّدة · typecheck · ميزانية الحجم |
+| `skills-structural` | تأكيدات سجلّ المهارات وبنيتها |
+| `event-stack-live` | يُقلع Redpanda وTemporal ويُثبت التسليم والتخطّي وDLQ |
+| `images-plan` + `images-build` | كل صورةٍ قابلة للبناء مُعلَنة ومبنيّة ومُثبَتة الاستيراد |
+
+وتعمل بجانبه وظائف غير مُجمَّعة: `doc-integrity` · `runtime-truth` · `skills-doctrine-gate` · `skills-architecture-gate` · `structure-validation` · `frontend-theme-ci` · `observability-validation`.
+
+التفصيل: [`.memory/ci-gates.md`](.memory/ci-gates.md) · [`.github/BRANCH_PROTECTION_GUIDE.md`](.github/BRANCH_PROTECTION_GUIDE.md) · [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+---
+
+## ١٤ · الحماية وحماية البيانات وحدّ المصداقية
+
+المستخدمون قاصرون يستعدّون لامتحانٍ يرسم حياتهم البالغة. وهذه حقيقةٌ قيدٌ تصميمي لا هامشُ امتثال.
+
+- **[`SAFEGUARDING.md`](SAFEGUARDING.md)** — سلامة القاصرين والإشراف والتصعيد. آليات الالتزام يختارها الطالب ويستطيع سحبها. لا جداريات تصنيف ولا آليات إدمان ولا تصميمٌ يُعظّم التفاعل.
+- **[`DATA_POLICY.md`](DATA_POLICY.md) · [`DATA_PROTECTION.md`](DATA_PROTECTION.md)** — الخصوصية بالتصميم والاحتفاظ والمعالجة.
+- **رؤية الوليّ محدودةٌ بنيوياً.** يرى الاتّجاه والالتزام والتوقّع. وتقرير الوليّ **لا يستعلم عن محتوى الرسائل إطلاقاً** — يفرضه اختبارٌ بنيوي يقرأ المصدر، لا مُرشِّحٌ قد يُساء ضبطه. فمقتطفٌ واحد يحوّل لوحة الوليّ إلى بابٍ خلفيّ نحو الجواب الممنوع على الطالب.
+- **الربط برضا الطالب.** يبدأ `NULL`، ولا مسار يربط حساب قاصرٍ بلا فعلٍ منه. وقراءةٌ غير مرتبطة تُرجِع **404 لا 403** — مُعرَّف المسار ليس تفويضاً.
+- **[`SECURITY.md`](SECURITY.md) · [`GOVERNANCE.md`](GOVERNANCE.md) · [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)** — الإفصاح وحقوق القرار ومعايير المجتمع.
+
+**حدود النطاق.** هذا المستودع لا يقدّم استشارةً قانونية للامتثال (GDPR · قانون الذكاء الاصطناعي الأوروبي · القوانين المحلية) — راجع مستشارك القانوني. والضوابط تُقلّل المخاطرة ولا تُلغيها، والإشراف البالغ يبقى إلزامياً في أيّ نشرٍ موجّه للقاصرين.
+
+---
+
+## ١٥ · خريطة سلطة التوثيق
+
+مصدران يحسمان الحقيقة التشغيلية. وما عداهما مرجعٌ مساند أو أرشيفٌ مُجمَّد.
+
+| المستوى | المصدر | الدور |
+|---|---|---|
+| 🏛️ الدستور | [`CLAUDE.md`](CLAUDE.md) | القانون التشغيلي الدائم (D-001 → D-227). لا يحمل سرداً مؤرَّخاً ولا جداول حالة |
+| 🧠 الذاكرة | [`.memory/`](.memory/README.md) | `runtime_truth` · `decisions` · `issues` · `roadmap` · `pedagogical_os` |
+| 📐 مواصفة البرنامج | [`spec.md`](spec.md) | هدف التبسيط API-first — **الهدف** لا الحقيقة الجارية |
+| 🎼 العقائد | [`ENGINEERING_DOCTRINE.md`](docs/architecture/ENGINEERING_DOCTRINE.md) · [`CS_KNOWLEDGE_MAP.md`](docs/architecture/CS_KNOWLEDGE_MAP.md) · [`AGENTIC_ORCHESTRATION_DOCTRINE.md`](docs/architecture/AGENTIC_ORCHESTRATION_DOCTRINE.md) · [`COGNITIVE_EXECUTION_ENGINE.md`](docs/architecture/COGNITIVE_EXECUTION_ENGINE.md) · [`COGNITIVE_DIGITAL_TWIN.md`](docs/architecture/COGNITIVE_DIGITAL_TWIN.md) | وثائق قانون، كلٌّ تُسمّي بوّابتها |
+| 💰 القيمة | [`VALUE_DOCTRINE.md`](docs/VALUE_DOCTRINE.md) · [`REVENUE_ENGINE_SPEC.md`](docs/REVENUE_ENGINE_SPEC.md) | لماذا يدفع أحد، وماذا يُكتب بالضبط |
+| 🗺️ الفهرس | [`docs/DOCUMENTATION_INDEX.md`](docs/DOCUMENTATION_INDEX.md) · [`docs/START_HERE.md`](docs/START_HERE.md) | الخريطة الكاملة · نقطة بداية القادم الجديد |
+| 🤖 الوكلاء | [`AGENTS.md`](AGENTS.md) | القواعد التي يرثها كل مساهمٍ آلي تلقائياً |
+
+عند أيّ تضارب: `CLAUDE.md` و`.memory/runtime_truth.md` يحسمان.
+
+---
+
+## ١٦ · المساهمة
+
+اقرأ [`CONTRIBUTING.md`](CONTRIBUTING.md) و[`docs/START_HERE.md`](docs/START_HERE.md) أوّلاً. والخلاصة:
+
+1. **افحص جدول الحقيقة قبل أن تُعدِّل.** المكوّن الذي تلمسه `ACTIVE` أم `PARTIAL` أم `DORMANT` أم `ZOMBIE`؟ تحرير كودٍ ميت بلا وصله بمسارٍ حيّ عملٌ ضائع.
+2. **قدرةٌ جديدة ⇒ Skill جديدة.** ترث `BaseSkill`، وتكشف مقاييسها، وتشحن اختبار المسار السعيد ومسار الخطأ، وتعمل مستقلّة. والمهارات لا تستدعي بعضها مباشرة — تُركَّب عبر المُنسِّق.
+3. **قانونٌ جديد ⇒ بوّابةٌ جديدة.** إن لم تستطع تسمية الملفّ الذي يُحمِّر الـCI حين تُخرَق قاعدتك، فالقاعدة لم توجد بعد.
+4. **`make gates` قبل الدفع.** تقرأ `ci.yml`، فما يمرّ محلياً هو ما يعمل عن بُعد.
+5. **الكارثة لا تُغلَق بلا عقد ترانسكريبت** في `tests/transcripts/` **مُثبَتٍ أحمر قبل الإصلاح**.
+
+وأيّ طلب دمجٍ يُنزِل هذا النظام إلى روبوت أسئلةٍ وأجوبةٍ نصّي **مرفوضٌ مهما حَسُنت كتابته**.
+
+---
+
+## ١٧ · الرخصة والاستشهاد والتواصل
+
+منشورٌ تحت [رخصة MIT](LICENSE). وللاستشهاد الأكاديمي استعمل [`CITATION.cff`](CITATION.cff).
+
+**الكيان المسجَّل:** Interactive Training Courses Platform (باسم NAAS AI Safety Lab) · **الاختصاص:** الجزائر (EMEA)
+**قائد المشروع:** حسام بن مراح — h.benmerah@univ-eltarf.dz
+**المستودع الأصلي:** https://github.com/HOUSSAM16ai/NAAS-Agentic-Core
+
+يَنشر المختبر مناهجه ونتائجه وتقييماته النقدية باستقلالٍ عن أيّ مزوّد نماذج أو شريك. وذكرُ أيّ منظمةٍ أو منتجٍ من طرفٍ ثالث لا يعني تأييداً ولا انتساباً.
+
+<div align="center">
+<br/>
+
+**«الطالب لا يرسل سؤالاً إلى النظام؛ الطالب يدخل مسار تعلّم حيّ.»**
+
+<sub>مبنيٌّ لثمانمئة ألف طالبٍ يستحقّون نظاماً يقول لهم الحقيقة عمّا يعرفونه.</sub>
+
+</div>

--- a/README.md
+++ b/README.md
@@ -1,175 +1,431 @@
-# 🛡️ North African AI Safety Lab (NAAS Lab)
-## Project: EL-NUKHBA (The Elite) | NAAS-Agentic-Core
+<div align="center">
 
-![Status](https://img.shields.io/badge/Status-Active_Research-success?style=for-the-badge) ![License](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge) ![Python](https://img.shields.io/badge/Python-3.12-blue?style=for-the-badge) ![CI](https://img.shields.io/badge/Required_Check-required--ci-brightgreen?style=for-the-badge) ![Governance](https://img.shields.io/badge/Governance-Safeguarding_%2B_Data_Policy-red?style=for-the-badge) ![Cite](https://img.shields.io/badge/Cite-CITATION.cff-lightgrey?style=for-the-badge)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/hero-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/brand/hero-light.svg">
+  <img alt="CogniForge — the Cognitive Lab: a verifiable learning engine" src="docs/assets/brand/hero-light.svg" width="100%">
+</picture>
 
-> **The "Elite" Verify-then-Reply Framework:** A safeguarding-first agentic tutoring framework for North African education that reduces AI-related harm in Arabic/French/Darija code-switching contexts through verification, risk screening, and measurable outcomes.
+<br/>
 
----
+**A learning engine that measures what a student actually knows — and refuses to hand over the answer.**
 
-## 🚨 Governance & Safeguarding (Strict Protocol)
+Repository `NAAS-Agentic-Core` · engine **CogniForge** · product **ETAALIM.AI** · built for the Algerian Baccalauréat, engineered to the standard the US and EU markets audit for.
 
-> **Why this matters:** North African youth frequently code-switch between Arabic, French, and Darija. Current safety filters often fail in these mixed-language contexts, exposing minors to harmful content. This toolkit provides a localized, rigorous "Verify-then-Reply" evaluation framework to bridge that gap.
+<br/>
 
-This repository is governed by strict ethical protocols for youth safety. All research involving human subjects or youth-facing data must strictly adhere to:
-*   [**SAFEGUARDING.md**](./SAFEGUARDING.md) (Youth safety, supervision, and escalation protocols)
-*   [**DATA_POLICY.md**](./DATA_POLICY.md) (Privacy-by-design and data handling rules)
+[![Cognitive Lab](https://img.shields.io/badge/Cognitive_Lab-not_a_chat_tutor-F4A98A?style=flat-square&labelColor=24211C)](#01--what-this-actually-is)
+[![Deterministic](https://img.shields.io/badge/Numbers-zero_LLM_in_the_path-7C5CBF?style=flat-square&labelColor=24211C)](#05--the-cognitive-core)
+[![Truth table](https://img.shields.io/badge/Runtime_truth-import_%2B_call_chain_%2B_evidence-A78BE0?style=flat-square&labelColor=24211C)](#06--truth-discipline)
+[![Enforced](https://img.shields.io/badge/Every_law-names_its_enforcer-FFC9B4?style=flat-square&labelColor=24211C)](#07--every-law-names-its-enforcer)
+<br/>
+[![Python](https://img.shields.io/badge/Python-3.12-7C5CBF?style=flat-square&labelColor=24211C)](pyproject.toml)
+[![FastAPI](https://img.shields.io/badge/FastAPI-monolith_%2B_service_islands-F4A98A?style=flat-square&labelColor=24211C)](app)
+[![Next.js](https://img.shields.io/badge/Next.js-frontend-A78BE0?style=flat-square&labelColor=24211C)](frontend)
+[![CI](https://img.shields.io/badge/required--ci-10_aggregated_jobs-1F6B46?style=flat-square&labelColor=24211C)](.github/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-MIT-FFC9B4?style=flat-square&labelColor=24211C)](LICENSE)
 
-> **Note:** "Verify-then-Reply" reduces risk but does not eliminate it. Adult supervision is mandatory for youth-facing deployments.
+**English** · [العربية](README.ar.md)
 
----
-
-## 🌟 Core Project Goals
-
-Safety is the absolute core of our mission. We prioritize **measurement before protection** through a rigorous, transparent, and data-driven approach:
-
-*   📊 **Robust Benchmarking:** Build a powerful benchmark to proactively discover and quantify risks across **Arabic, French, Darija, and Arabizi**.
-*   🗄️ **Unique Dataset Creation:** Curate an exclusive dataset focused specifically on complex linguistic evasion and jailbreak attempts.
-*   🧠 **Intent-Driven Reasoning:** Utilize advanced **Reasoning** to analyze true user intent, moving beyond simple keyword matching.
-*   🛡️ **Verify-then-Reply Architecture:** Enforce a strict **Verify-then-Reply** layer backed by detailed **Audit Logs** and **Reasoning Traces** to justify and prove every decision.
-*   🚫 **Evasion Resistance:** Fortify the system against evasion tactics through intelligent language unification and code-switching detection.
-*   📡 **Telemetry & Compliance:** Provide deep **Telemetry** and absolute transparency to align with strict regulatory standards like the **EU AI Act**.
-*   🌐 **Decentralized Resilience:** Architect the system to avoid any **Single Point of Failure** in centralized control mechanisms.
-*   🚀 **Enterprise Safety API:** Evolve the project into a comprehensive **Benchmark + Safety API** designed to serve and protect enterprise institutions.
-
-> **💎 The True Value:** Exceptional Data, Rigorous Measurement, and Fully Auditable Transparency.
+</div>
 
 ---
 
-## 🏛️ Executive Summary & Architecture
+> [!IMPORTANT]
+> **The system is not a chat tutor. It is a Cognitive Lab — a thinking engine that models, tests and improves student reasoning.**
+> Chat is a delivery surface. The core is: interactive object UI, cognitive modelling, error memory, adaptive generation, simulation.
+> — [`CLAUDE.md`](CLAUDE.md) §0, the operational constitution every contributor and every agent inherits.
 
-### The Mission
-A safeguarding-first agentic tutoring toolkit and evaluation framework that helps youth-serving organisations and educators reduce AI-related educational harm and improve wellbeing and AI literacy outcomes in North Africa.
+---
 
-### Architecture: The Verify-then-Reply Engine
-Our approach intercepts Model interactions to ensure safety before any content reaches the user.
+## Table of contents
+
+| | | |
+|---|---|---|
+| [01 · What this actually is](#01--what-this-actually-is) | [07 · Every law names its enforcer](#07--every-law-names-its-enforcer) | [13 · CI contract](#13--the-ci-contract) |
+| [02 · Why we withhold the answer](#02--why-we-withhold-the-answer-a-published-result-not-a-taste) | [08 · Nine orchestration layers](#08--nine-orchestration-layers) | [14 · Safeguarding & credibility](#14--safeguarding-data-protection-and-the-credibility-limit) |
+| [03 · The four functions](#03--the-four-functions-and-the-deletion-test) | [09 · What is deliberately NOT built](#09--what-is-deliberately-not-built) | [15 · Documentation authority map](#15--documentation-authority-map) |
+| [04 · Architecture](#04--architecture-at-a-glance) | [10 · Quick start](#10--quick-start) | [16 · Contributing](#16--contributing) |
+| [05 · The cognitive core](#05--the-cognitive-core) | [11 · Repository map](#11--repository-map) | [17 · License, citation, contact](#17--license-citation-and-contact) |
+| [06 · Truth discipline](#06--truth-discipline) | [12 · Roadmap](#12--roadmap) | |
+
+---
+
+## 01 · What this actually is
+
+Eight hundred thousand Algerian students sit the Baccalauréat. Content is already free — Dzexams, ONEFD, YouTube. Explanation became free the day general-purpose language models shipped. **Neither is scarce, so neither is worth paying for.**
+
+What does not exist, anywhere in this market, is a system that knows **what a specific student does not know**, ranks the remaining hours by what actually earns exam points, refuses to produce the step the student could still generate, and proves the return to the parent who pays.
+
+That is what this repository builds.
+
+> **الجملة الدستورية:** «الطالب لا يرسل سؤالاً إلى النظام؛ الطالب يدخل مسار تعلّم حيّ، والنظام مسؤول عن حفظ هذا المسار من الانهيار.»
+> *A student does not send a question to the system. A student enters a live learning path, and the system is responsible for keeping that path from collapsing.* — [`.memory/pedagogical_os.md`](.memory/pedagogical_os.md) (D-153)
+
+Three properties make it unusual, and all three are enforced by CI rather than promised in prose:
+
+1. **Numbers are never generated.** Every probability, count and combinatorial value comes from a deterministic symbolic engine. The language model narrates understanding; it never decides truth.
+2. **Answers are withheld by law.** The system will not reveal a result or a step the student can still produce. This is a published empirical result, not a stylistic preference — see [§02](#02--why-we-withhold-the-answer-a-published-result-not-a-taste).
+3. **No capability is claimed without proof.** A component is ACTIVE only with `import` + `call chain` + `runtime evidence`. Everything else is labelled PARTIAL, DORMANT or ZOMBIE — publicly, in [`.memory/runtime_truth.md`](.memory/runtime_truth.md).
+
+---
+
+## 02 · Why we withhold the answer: a published result, not a taste
+
+Bastani et al., *PNAS* (2025) — randomised field experiment, roughly a thousand secondary-school mathematics students:
+
+<div align="center">
+
+| Condition | While practising | On the unaided exam |
+|:---|:---:|:---:|
+| ChatGPT-style free access | **+48%** | **−17%** vs students who used nothing at all |
+| Same model, pedagogical guardrails (hints, not answers) | **+127%** | harm eliminated |
+
+</div>
+
+The free-access group *felt* far better and performed *worse* when the tool was taken away. That gap between felt fluency and durable ability has a name here — the **illusion gap** — and shrinking it is the only success metric this project optimises for.
+
+> **Banned optimisation targets, permanently:** session length, message count, momentary satisfaction. A system that maximises those maximises the illusion.
+
+**Illusion gap = assisted performance − unaided, delayed capability.** It is emitted as `cogniforge_tutor_illusion_gap` and rendered on [Grafana dashboard 180](observability/grafana/dashboards/180-illusion-gap.json). When a measurement is not mature enough to be honest — too few unaided observations — it returns `null`, never a zero. A zero reads as *"we lost them"*; the truth was *"we do not know yet"*.
+
+Full argument and citations: [`docs/VALUE_DOCTRINE.md`](docs/VALUE_DOCTRINE.md).
+
+---
+
+## 03 · The four functions, and the deletion test
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/four-functions-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/brand/four-functions-light.svg">
+  <img alt="Four functions: measure honestly, sequence the time, force generation, prove it to the payer" src="docs/assets/brand/four-functions-light.svg" width="100%">
+</picture>
+
+Every proposed feature faces one question: *if this were deleted, which of the four stops working?* If the answer is "none, but it looks advanced" — it is deleted. Nine capabilities are explicitly forbidden by doctrine on exactly these grounds, including a content library, a from-scratch trained model, deep knowledge tracing before we have the data volume to justify it, gamified leaderboards, and any addictive-by-design mechanic. The users are minors under existential exam pressure; commitment devices are opt-in and revocable ([`SAFEGUARDING.md`](SAFEGUARDING.md)).
+
+---
+
+## 04 · Architecture at a glance
 
 ```mermaid
-graph LR
-    Input[User Input] --> PreChecks[Pre-Checks (PII/Toxicity)]
-    PreChecks -->|Pass| Verification[Verification Loop]
-    PreChecks -->|Block| Refusal[Immediate Refusal]
-    Verification -->|Analyze| SafetyPolicy{Policy Decision}
-    SafetyPolicy -->|Safe| Output[Final Output]
-    SafetyPolicy -->|Unsafe| Refusal
-    Output --> Telemetry[Telemetry & Audit Logs]
-    Refusal --> Telemetry
+%%{init: {'theme':'base','themeVariables':{'fontFamily':'ui-sans-serif, system-ui, sans-serif','primaryColor':'#FBF2EC','primaryTextColor':'#24211C','primaryBorderColor':'#E08A66','lineColor':'#A78BE0','secondaryColor':'#F0E9FA','tertiaryColor':'#EAF3EC','clusterBkg':'#FBFAF7','clusterBorder':'#E2DED4'}}}%%
+flowchart LR
+    S["🎓 Student<br/>Arabic · French · Darija"] --> WS["WebSocket<br/>/api/chat/ws"]
+    WS --> M["FastAPI monolith :8000<br/>single writer · single terminal frame"]
+
+    M --> P{"Deterministic<br/>pre-empts<br/>(no LLM)"}
+    P -->|greeting| G["GreetingSkill"]
+    P -->|symbol| N["Notation registry"]
+    P -->|probability| SYM["Symbolic engine<br/>terminates the pipeline"]
+
+    P -->|otherwise| O["orchestrator-service :8006<br/>compose: Planning → Research → Reasoning"]
+    O --> GUARD["Response guard<br/>redaction · firewall · topic lock"]
+    SYM --> GUARD
+    G --> GUARD
+    N --> GUARD
+    GUARD --> OUT["One terminal frame<br/>assistant_final | error"]
+    OUT --> LEARN["BKT · FSRS · tutor_state<br/>append-only"]
+
+    style S fill:#FBF2EC,stroke:#E08A66,stroke-width:2px,color:#24211C
+    style SYM fill:#EAF3EC,stroke:#1F6B46,stroke-width:2px,color:#24211C
+    style GUARD fill:#F0E9FA,stroke:#7C5CBF,stroke-width:2px,color:#24211C
+    style LEARN fill:#F0E9FA,stroke:#7C5CBF,stroke-width:2px,color:#24211C
+    style OUT fill:#FBF2EC,stroke:#E08A66,stroke-width:2px,color:#24211C
 ```
 
-**How it works (Step-by-Step):**
-1.  **Retrieve:** Relevant context from curated sources (no general web retrieval by default).
-2.  **Draft:** A response using structured reasoning.
-3.  **Critique:** With a safety/quality check (accuracy, tone, age-appropriateness, misuse risks).
-4.  **Respond:** Only if the output meets defined thresholds; otherwise revise or abstain.
+**Chat is WebSocket-only** — there is no `POST /api/chat/messages`; it returns 404 by design. The payload key is `question`, authentication rides `subprotocols=['jwt', TOKEN]`, and each turn emits **exactly one** terminal frame from a single emitter. The user message is written by the monolith at the WebSocket entry point; assistant persistence is coordinated by an explicit `persisted` flag so a dual write cannot happen ([`CLAUDE.md`](CLAUDE.md) §6.5).
+
+### Two real topologies — documented as two, never as one
+
+<table>
+<tr><th align="left" width="50%">(a) Codespaces / uvicorn — what serves today</th><th align="left" width="50%">(b) Docker Compose — the migration destination</th></tr>
+<tr valign="top"><td>
+
+Launched by `.devcontainer/supervisor.sh`.
+
+`frontend :5000` · `monolith :8000` · `user :8001`
+`planning :8002` · `conversation :8003` · `orchestrator :8006`
+`research :8007` · `reasoning :8008` · `content-retrieval :8009`
+`foundations :8010` · `notation :8011`
+`Prometheus :9090` · `Grafana :3001`
+
+**Every student turn today goes through this path.**
+
+</td><td>
+
+`docker-compose.yml` describes the strangler-fig target: an API gateway, per-service Postgres, and the monolith **deliberately absent** (three CI gates prevent re-adding it).
+
+Ports differ from (a) for five services. The gated source of truth is [`docs/architecture/PORTS_SOURCE_OF_TRUTH.json`](docs/architecture/PORTS_SOURCE_OF_TRUTH.json) and [`config/microservice_catalog.json`](config/microservice_catalog.json) — **13 microservices** declared.
+
+**Building is not running.** Images are built and import-proven on every PR; no application container is booted in CI.
+
+</td></tr>
+</table>
+
+### Service boundaries are contracts, not languages
+
+Every service ships a committed OpenAPI contract, and a semantic parity gate compares declared endpoints against the live application — **API-first 13/13**, enforced by `check_openapi_parity` on every pull request. Cross-service imports are forbidden and checked by AST; shared logic is vendored with a parity gate rather than imported, so no service can reach into another's internals.
 
 ---
 
-## 🎯 Impact & Metrics
+## 05 · The cognitive core
 
-### Key Safety Metrics (Empirical)
-We empirically evaluate GenAI systems against four key safety metrics:
+| Layer | What it is | Why it matters |
+|---|---|---|
+| **Symbolic probability engine** | [`app/services/skills/`](app/services/skills) — deterministic combinatorics, conditional probability, random variables | Zero LLM in the number path. A tutor that miscalculates once loses a student permanently |
+| **Foundations** | [`app/core/foundations/`](app/core/foundations) — logic, number theory, linear algebra, calculus, statistics, optimisation, graph theory, formal languages, computability, complexity | Dependency-free stdlib. Every primitive raises on domain violation instead of returning a misleading `0` |
+| **Reasoning core** | [`app/core/reasoning/`](app/core/reasoning) — argument trees with verified entailment, causal graphs (causation vs correlation), decomposition, abstraction, mental models | Validity is decided by the engine, never by the model. The model narrates |
+| **BKT** | [`bkt_engine.py`](app/services/skills/bkt_engine.py) — Bayesian knowledge tracing, append-only interaction log | Mastery is a probability with a temporal record, not a score that gets overwritten |
+| **FSRS-5 scheduling** | [`shared/scheduling/fsrs.py`](shared/scheduling/fsrs.py) | A correct answer produced with full scaffolding is graded `HARD`, not `GOOD`. `EASY` requires independence *and* durability — otherwise we would automate the illusion of fluency |
+| **One curriculum** | [`shared/curriculum/registry.py`](shared/curriculum/registry.py) — **37 concepts**, maths + physics + natural sciences, with prerequisite edges | Three competing concept definitions once coexisted and no two agreed, so every physics question silently classified as `general`. One graph now, enforced |
+| **Notation registry** | [`shared/notation/registry.py`](shared/notation/registry.py) | The system can define every symbol it prints — `C(n,k)`, `P_A(B)`, `Ω`, `X̄`. A symbol emitted without a registry entry turns CI red |
+| **Illusion gap** | [`shared/illusion/`](shared/illusion) | Below the minimum observation count it returns `None`. A report that colours the whole curriculum after two sessions is a lying report |
 
-| Metric | Definition | Target |
-| :--- | :--- | :--- |
-| **Bypass Success Rate** | Percentage of adversarial prompts in mixed Arabic/French/Darija that successfully trigger unsafe generation. | 0% |
-| **Interception Rate** | Percentage of unsafe content correctly blocked by the Verify-then-Reply layer (pre/post-generation). | >95% |
-| **PII-Risk Events** | Number of potential PII leakage events detected per 100 interaction sessions. | 0 |
-| **Reliability Errors** | Rate of false positives/negatives in safety judgments, measured via blinded human audit. | <5% |
-
-### Broader Impact Indicators
-We also track simple, auditable indicators (definitions in `docs/IMPACT_MEASUREMENT_PLAN.md`):
-- **Curriculum alignment:** Agreement rate with curated curriculum sources.
-- **Wellbeing (non-clinical):** Learner confidence and help-seeking pathways.
-- **AI literacy:** Scenario-based judgement improvements.
-- **Adoption:** Uptake of “safe mode” workflows by partner sites.
+**Skills, not prompt spaghetti.** Every AI capability is a Skill: one responsibility, a typed contract, Prometheus metrics, runnable tests, and independent fallback. **39 skills** are registered in [`app/services/skills/registry.py`](app/services/skills/registry.py); each inherits `BaseSkill`, and a skill with no live consumer is deleted rather than left as a stub.
 
 ---
 
-## 📦 Deliverables & Toolkit
+## 06 · Truth discipline
 
-### 1) Practical Toolkit (Usable by Partners)
-- **Risk screening checklist:** For youth-facing AI use (privacy, misuse, harmful content).
-- **Safeguarding playbook:** Consent/assent guidance, escalation, incident response.
-- **AI literacy modules:** For youth, parents, and educators.
-- **Implementation templates:** Policies, training agendas, briefing notes.
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand/proof-ladder-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/brand/proof-ladder-light.svg">
+  <img alt="The proof ladder: ACTIVE requires import, call chain and runtime evidence" src="docs/assets/brand/proof-ladder-light.svg" width="100%">
+</picture>
 
-### 2) Independent Evidence
-- **Evaluation protocol:** For real-world deployments (pre/post + incident logging).
-- **Impact measurement plan:** Clear indicators and collection schedule.
-- **Stakeholder outputs:** Templates for policymakers/regulators, NGOs, and product teams.
+The live status table is [`.memory/runtime_truth.md`](.memory/runtime_truth.md) — deliberately **not** reproduced here, because a status table copied into a second file drifts and then lies. A drift gate ([`scripts/runtime_truth.py`](scripts/runtime_truth.py) `--check`) compares the codebase against a committed lock file on every pull request.
+
+Three consequences we live with:
+
+- **A running process is not a healthy service.** Check the `/health` response, not the process list; a service that boots but fails graph warmup is `DEGRADED`, and `startup_state` says so.
+- **A zero-valued dashboard panel is indistinguishable from a dead system.** Every metric must have a verified emitter in application source.
+- **A stale lock file is a finding.** Lock files record when they were generated; a green gate on a stale lock is a false green.
 
 ---
 
-## 🗺️ Repository Map (Current)
+## 07 · Every law names its enforcer
 
-```text
-.
-├── app/                        # Main FastAPI application + domain/core modules
-├── microservices/              # Service-island implementations (gateway, user, planning, etc.)
-├── tests/                      # Contract, architecture, guardrail, API, integration, security tests
-├── scripts/                    # CI guardrails, fitness checks, operational tooling
-├── docs/                       # Architecture constitution, ADRs, governance, contracts, guides
-├── infra/                      # Kubernetes, Terraform, ArgoCD, monitoring assets
-├── toolkit/                    # Partner-facing operational resources
-├── knowledge_base/             # Ingestion source documents
-├── frontend/                   # Frontend application modules
-└── .github/                    # Workflows, templates, governance automation
+The founding observation of this codebase: **a house does not collapse from one bad decision — it collapses from the sum of small decisions that nothing was guarding.** So a law without an automatic enforcer is rejected twice: once for being unenforced, once for the silence that reads as discipline.
+
+| Law | Enforcer | What turns CI red |
+|---|---|---|
+| No shell interpolation anywhere in subprocess execution | [`check_no_shell_true.py`](scripts/fitness/check_no_shell_true.py) | Any `shell=True`. Frozen debt is **empty** and only shrinks |
+| Redaction policy is identical in both brains that enforce it | [`check_redaction_parity.py`](scripts/fitness/check_redaction_parity.py) | One path withholding the answer while the other leaks it |
+| Intent markers have exactly one home | [`check_intent_single_source.py`](scripts/fitness/check_intent_single_source.py) | A second list of intent keywords anywhere in the tree |
+| A model's capabilities are a dated claim with evidence | [`check_model_registry.py`](scripts/fitness/check_model_registry.py) | A banned model promoted, or a registry entry with no evidence |
+| Every symbol the tutor prints is definable | [`check_notation_definable.py`](scripts/fitness/check_notation_definable.py) | A symbol emitted with no registry entry |
+| One prerequisite graph, not two | [`check_prerequisite_single_graph.py`](scripts/fitness/check_prerequisite_single_graph.py) | A second traversal reading a different graph |
+| Confusion is never congratulated | [`check_understanding_evidence.py`](scripts/fitness/check_understanding_evidence.py) | Treating a concept's *name* in a student question as evidence they understood it |
+| A gate that cannot parse a file may not report it clean | [`check_gate_parse_honesty.py`](scripts/fitness/check_gate_parse_honesty.py) | `except SyntaxError: return []` — silent blindness inside an enforcer |
+| Constitution equals reality; numbers are derived, never typed | [`check_constitution_reality.py`](scripts/fitness/check_constitution_reality.py) | Any hand-typed count in an authority doc that disagrees with its source — **including this README** |
+| Authority maps resolve | [`check_authority_links.py`](scripts/fitness/check_authority_links.py) | A link in this README, `CLAUDE.md` or the documentation index pointing at a path that does not exist |
+| Every CS domain declares status and file evidence | [`check_cs_knowledge_map.py`](scripts/fitness/check_cs_knowledge_map.py) | `ACTIVE` in front of a deleted file, or an empty gap cell |
+| Design values come from tokens, with computed WCAG contrast | [`check_design_tokens.py`](scripts/fitness/check_design_tokens.py) | A raw colour in a component, or a contrast pair that fails AA when **calculated** |
+
+Run the complete set locally — it reads `ci.yml`, so it cannot drift from CI:
+
+```bash
+make gates
 ```
 
+> **Said out loud:** the deletion test in [§03](#03--the-four-functions-and-the-deletion-test) is enforced by **human judgement in review — no automated gate.** What *is* automated is the classification of every unit and its status. Declaring the absence of an enforcer is itself a rule here (an empty cell reads as discipline; a stated gap does not).
+
 ---
 
-## 🚀 Quick Start
+## 08 · Nine orchestration layers
 
-### 👨‍💻 For Developers & Researchers
+The value of an AI system moved from *"write a better prompt"* to *"design the system that coordinates the agents"*. A prompt is contextual and disposable; an orchestration system produces a stable, testable, reusable output.
+
+```
+Knowledge → Skills → Agents → Orchestration → Memory → Evaluation → Governance → Infrastructure → Humans
+```
+
+Knowledge is what we know · Skills are how we execute · Agents are who executes · **Orchestration decides who does what, when, with which context, and who reviews before merge.** Law lives in [`docs/architecture/AGENTIC_ORCHESTRATION_DOCTRINE.md`](docs/architecture/AGENTIC_ORCHESTRATION_DOCTRINE.md); live status lives in [`.memory/agentic_runtime_doctrine.md`](.memory/agentic_runtime_doctrine.md). The separation is mandatory and gated: the law document fails CI if it grows a status column, and the status document fails if it cites evidence that does not exist.
+
+**Humans are layer nine, not an exception.** Adopting a new technology requires an ADR. Raising any declared ratchet — a debt ceiling, a coverage floor — requires a written decision naming the reason, which makes loosening a gate expensive and visible instead of silent.
+
+---
+
+## 09 · What is deliberately NOT built
+
+This section exists because a system that only advertises its strengths cannot be audited.
+
+| Not built | Status | Why it is stated rather than hidden |
+|---|---|---|
+| **Payment gateway** | Seam, zero code | Entitlements and hashed vouchers exist; SATIM/Chargily integration is a documented seam. No half-integration pretending to take money |
+| **LLM wired to the sandbox executor** | **Locked** | The sandbox runs real commands and the users are minors. Connecting any planner or model to tools is blocked until capability contracts, live probes, budgets, an append-only audit log and self-modification guards all land. A CI rule fails the build if one module imports both the executor and a model client |
+| **Temporal worker** | Server proven, worker never connected | The server reports SERVING in CI; **no workflow has ever executed.** Booting is not running, and we refuse to round that up |
+| **Vector retrieval** | DORMANT | Embeddings and rerankers exist in the tree with zero request-time calls. Ranked retrieval today is deterministic and lexical |
+| **Monolith in the default compose file** | Absent by design | Strangler-fig phase 3. Three gates prevent re-adding it; its home is the legacy profile |
+| **Deep knowledge tracing (DKT/SAKT)** | Forbidden for now | Data volume does not justify it. Knowing *why* the newest technique was rejected buys more credibility than deploying it |
+| **Application containers in CI** | Not booted | Only the event stack (Redpanda, Temporal) is started live on each PR |
+
+> **The credibility limit (D-227), applied to our own copy:** no claim of reading minds, of 100% accuracy, of zero errors, of changing humanity. An unfalsifiable statement is debt, not ambition — believed once, discovered later, and it takes everything true down with it. This platform serves minors and the parents who decide based on what we say.
+
+---
+
+## 10 · Quick start
+
+### Developers and researchers
 
 ```bash
 git clone https://github.com/HOUSSAM16ai/NAAS-Agentic-Core.git
 cd NAAS-Agentic-Core
-python3.12 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -r requirements-dev.txt
-pip install -r requirements-test.txt
 
-# Required local gates (mirror required-ci jobs)
-ruff check .
-ruff format --check .
-python scripts/ci_guardrails.py
-pytest -v --cov=app --cov-report=term-missing --tb=short
+python3.12 -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements-dev.txt -r requirements-test.txt
+
+# The gates that decide mergeability — same set, same order as CI
+ruff check . && ruff format --check .
+make gates                       # every fitness gate, read from ci.yml
+pytest -v --cov=app --cov-report=term-missing --cov-fail-under=73
 ```
 
-### ✅ Mergeability Rule
+### Running the platform
 
-For `main`, branch protection should require **only** `required-ci`.
-This check aggregates lint, contracts, guardrails, and tests.
+```bash
+# Codespaces / devcontainer: the supervisor launches backend, frontend and services
+.devcontainer/supervisor.sh
 
-### 🤝 For Partners & Educators
-1.  Read `toolkit/START_HERE.md`
-2.  Run `toolkit/RISK_SCREENING_CHECKLIST.md`
-3.  Adopt `SAFEGUARDING.md` and `DATA_PROTECTION.md` requirements
-4.  Use `docs/EVALUATION_PROTOCOL.md` and `docs/IMPACT_MEASUREMENT_PLAN.md` for measurement and reporting
+# Or manually
+python -m uvicorn app.main:app --host 0.0.0.0 --port 8000     # backend
+cd frontend && npm run dev                                     # frontend on :5000
+
+# Health — read the response, never the process list
+curl -s http://localhost:8000/health | python -m json.tool
+```
+
+> [!NOTE]
+> The application cannot start without `DATABASE_URL` (or `APP_DATABASE_URL`), and settings are read from the **process environment** at import time — exporting into the environment before launching uvicorn is required; writing `.env` alone is not enough. Use `postgresql+asyncpg://`, never bare `postgresql://`. Copy [`.env.example`](.env.example) to start.
+
+### Full stack in Docker
+
+```bash
+docker compose -f docker-compose.yml up -d      # migration-destination topology
+make microservices-health
+```
 
 ---
 
-## ⚖️ Independence, Scope & Legal
+## 11 · Repository map
 
-### Independence & Transparency
-The North African AI Safety Lab (NAAS Lab) operates with academic and operational independence. We reserve the right to publish our methods, findings, and critical safety evaluations independently of any model providers or partners. Open Science principles apply.
+```text
+.
+├── app/                    FastAPI monolith — routers, skills, core engines, kernel
+│   ├── core/               foundations · reasoning · settings · database · prompts
+│   ├── services/skills/    39 registered skills, each on BaseSkill
+│   └── api/routers/        HTTP + WebSocket entrypoints (chat is WS-only)
+├── shared/                 dependency-free engines: curriculum · scheduling · notation
+│                           illusion · analytics · messaging · retrieval · ai_models
+├── microservices/          service islands — each with its own contract and Dockerfile
+├── frontend/               Next.js app · design tokens · theme contracts
+├── scripts/fitness/        the enforcers — one gate per law
+├── tests/                  contract · architecture · guardrail · transcript · security
+├── docs/                   architecture doctrine · ADRs · contracts · governance
+│   ├── architecture/       engineering doctrine · CS knowledge map · orchestration
+│   └── contracts/openapi/  13 committed service contracts
+├── observability/          Prometheus · Grafana dashboards · telemetry wiring
+├── infra/                  Kubernetes · Terraform · ArgoCD
+├── .memory/                institutional memory — runtime truth · decisions · issues
+└── CLAUDE.md               the operational constitution (D-001 → D-227)
+```
 
-### Scope Boundaries
-*   **Not Legal Advice:** This toolkit and its documentation do not constitute legal compliance advice (e.g., GDPR, local laws). Consult your organization's legal counsel.
-*   **Not a Replacement for Human Oversight:** "Verify-then-Reply" reduces risk but does not eliminate it. Adult supervision is mandatory for youth-facing deployments as per [SAFEGUARDING.md](./SAFEGUARDING.md).
+---
 
-### Legal Host & Contact (EMEA)
-**Registered Entity:** Interactive Training Courses Platform (trading as NAAS AI Safety Lab)
-**Jurisdiction:** Algeria (EMEA)
-**Project Lead:** Houssam Benmerah (h.benmerah@univ-eltarf.dz)
-**Repository:** https://github.com/HOUSSAM16ai/NAAS-Agentic-Core
+## 12 · Roadmap
 
-> This repository is maintained by the project team. References to third-party organisations, platforms, or products do not imply endorsement or affiliation.
+The single live source is [`.memory/roadmap.md`](.memory/roadmap.md) — phases `M0 → M11` for the pedagogical engine, plus parallel tracks for the product, value and revenue layers, the cognitive execution engine, and the cognitive digital twin. Every planned unit carries a status from the proof ladder, a file-level evidence path, a written gap, and an explicit promotion condition.
 
+Ambition is classified, never concealed: `PLANNED`, `SEAM` and `ABSENT` are tracked declarations. Unclassified ambition is the kind that gets forgotten.
 
-### Chat & Mission Control Plane
-- جميع مسارات الدردشة (`/api/chat/*`, `/api/chat/ws`, `/admin/api/chat/ws`) تُدار عبر `orchestrator-service` من خلال API Gateway.
-- ملفات `app/api/routers/customer_chat.py` و`app/api/routers/admin.py` موجودة للتوافق المرحلي فقط (Compatibility Facades).
-- لا يجب إضافة منطق تشغيل محلي جديد داخل هذه الواجهات.
+Issue and decision history: [`.memory/decisions.md`](.memory/decisions.md) (D-001 → D-227) · [`.memory/issues.md`](.memory/issues.md) (ISS-001 → ISS-150). Both are append-only records, including the failures — a disaster with no written root cause is not closed.
+
+---
+
+## 13 · The CI contract
+
+Branch protection on `main` should require exactly one check: **`required-ci`**. It aggregates **10 jobs**:
+
+| Job | Enforces |
+|---|---|
+| `lint` | `ruff check` · `ruff format --check` · `mypy` (pinned versions — a linter that upgrades itself is a coin flip, not a gate) |
+| `contracts` | Gateway/provider parity and contract tests |
+| `guardrails` | Every fitness gate — run locally with `make gates` |
+| `test-monolith` | Test suite with `--cov-fail-under=73` |
+| `test-microservices` | Per-service suites plus OpenAPI parity |
+| `frontend-tests` | Node suites · lockfile sync · generated TS types · typecheck · bundle budget |
+| `skills-structural` | Skills registry and structure assertions |
+| `event-stack-live` | Boots Redpanda and Temporal and proves delivery, idempotent skip and DLQ |
+| `images-plan` + `images-build` | Every buildable image declared, built, and import-proven |
+
+Non-aggregated workflows run alongside: `doc-integrity`, `runtime-truth`, `skills-doctrine-gate`, `skills-architecture-gate`, `structure-validation`, `frontend-theme-ci`, `observability-validation`.
+
+Details: [`.memory/ci-gates.md`](.memory/ci-gates.md) · [`.github/BRANCH_PROTECTION_GUIDE.md`](.github/BRANCH_PROTECTION_GUIDE.md) · [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+---
+
+## 14 · Safeguarding, data protection, and the credibility limit
+
+The users are minors preparing for an exam that shapes their adult lives. That fact is a design constraint, not a compliance footnote.
+
+- **[`SAFEGUARDING.md`](SAFEGUARDING.md)** — youth safety, supervision, escalation. Commitment mechanics are chosen by the student and can be withdrawn by the student. No leaderboards, no addictive mechanics, no engagement-maximising design.
+- **[`DATA_POLICY.md`](DATA_POLICY.md) · [`DATA_PROTECTION.md`](DATA_PROTECTION.md)** — privacy by design, retention, and handling.
+- **Guardian visibility is structurally bounded.** A guardian sees direction, commitment and forecast. The guardian report **never queries message content** — enforced by a structural test that reads the source, not by a filter that could be misconfigured. One excerpt would turn the parent dashboard into a back door to the answer the student is not supposed to receive.
+- **Linking is consent-first.** A guardian link starts `NULL`; no path attaches a minor's account without an action by the minor. An unlinked read returns 404, not 403 — a path identifier is not an authorisation.
+- **[`SECURITY.md`](SECURITY.md) · [`GOVERNANCE.md`](GOVERNANCE.md) · [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)** — disclosure, decision rights, community standards.
+
+**Scope boundaries.** This repository does not provide legal compliance advice for GDPR, the EU AI Act or local law — consult counsel. Guardrails reduce risk; they do not eliminate it. Adult supervision remains mandatory in youth-facing deployments.
+
+---
+
+## 15 · Documentation authority map
+
+Two sources decide operational truth. Everything else is supporting reference or frozen archive.
+
+| Level | Source | Role |
+|---|---|---|
+| 🏛️ Constitution | [`CLAUDE.md`](CLAUDE.md) | Permanent operational law (D-001 → D-227). Holds no dated narrative and no status tables |
+| 🧠 Memory | [`.memory/`](.memory/README.md) | `runtime_truth` · `decisions` · `issues` · `roadmap` · `pedagogical_os` |
+| 📐 Programme spec | [`spec.md`](spec.md) | The API-first simplification target — an aim, not current reality |
+| 🎼 Doctrine | [`ENGINEERING_DOCTRINE.md`](docs/architecture/ENGINEERING_DOCTRINE.md) · [`CS_KNOWLEDGE_MAP.md`](docs/architecture/CS_KNOWLEDGE_MAP.md) · [`AGENTIC_ORCHESTRATION_DOCTRINE.md`](docs/architecture/AGENTIC_ORCHESTRATION_DOCTRINE.md) · [`COGNITIVE_EXECUTION_ENGINE.md`](docs/architecture/COGNITIVE_EXECUTION_ENGINE.md) · [`COGNITIVE_DIGITAL_TWIN.md`](docs/architecture/COGNITIVE_DIGITAL_TWIN.md) | Law documents; each names its gate |
+| 💰 Value | [`VALUE_DOCTRINE.md`](docs/VALUE_DOCTRINE.md) · [`REVENUE_ENGINE_SPEC.md`](docs/REVENUE_ENGINE_SPEC.md) | Why anyone pays, and exactly what gets written |
+| 🗺️ Index | [`docs/DOCUMENTATION_INDEX.md`](docs/DOCUMENTATION_INDEX.md) · [`docs/START_HERE.md`](docs/START_HERE.md) | Full map · newcomer entry point |
+| 🤖 Agents | [`AGENTS.md`](AGENTS.md) | Rules any AI contributor inherits automatically |
+
+On conflict, `CLAUDE.md` and `.memory/runtime_truth.md` win.
+
+---
+
+## 16 · Contributing
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/START_HERE.md`](docs/START_HERE.md) first. The short version:
+
+1. **Check the truth table before you edit.** Is the component you are touching ACTIVE, PARTIAL, DORMANT or ZOMBIE? Editing dead code without wiring it into a live path is wasted work.
+2. **New capability ⇒ new Skill.** Inherit `BaseSkill`, expose metrics, ship happy-path and error-path tests, work standalone. Skills never call each other directly — they compose through the orchestrator.
+3. **New law ⇒ new gate.** If you cannot name the file that turns CI red when your rule is broken, the rule does not exist yet.
+4. **`make gates` before you push.** It reads `ci.yml`, so what passes locally is what runs remotely.
+5. **A disaster is not closed without a transcript contract** in `tests/transcripts/` that is **proven red before the fix**.
+
+Any pull request that degrades this system into a standard text Q&A bot is rejected on sight, however well it is written.
+
+---
+
+## 17 · License, citation, and contact
+
+Released under the [MIT License](LICENSE). If you use this work academically, cite it via [`CITATION.cff`](CITATION.cff).
+
+**Registered entity:** Interactive Training Courses Platform (trading as NAAS AI Safety Lab) · **Jurisdiction:** Algeria (EMEA)
+**Project lead:** Houssam Benmerah — h.benmerah@univ-eltarf.dz
+**Upstream repository:** https://github.com/HOUSSAM16ai/NAAS-Agentic-Core
+
+The lab publishes methods, findings and critical evaluations independently of any model provider or partner. References to third-party organisations or products imply no endorsement or affiliation.
+
+<div align="center">
+<br/>
+
+**«الطالب لا يرسل سؤالاً إلى النظام؛ الطالب يدخل مسار تعلّم حيّ.»**
+
+<sub>Built for 800,000 students who deserve a system that tells them the truth about what they know.</sub>
+
+</div>

--- a/docs/assets/brand/four-functions-dark.svg
+++ b/docs/assets/brand/four-functions-dark.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300" role="img" aria-label="The four functions: measure honestly, sequence the time, force generation, prove it to the payer — and the deletion test">
+  <title>The value spine — four functions and the deletion test</title>
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#FFC9B4"/><stop offset="100%" stop-color="#F4A98A"/></linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#F0B0BE"/><stop offset="100%" stop-color="#D79BC8"/></linearGradient>
+    <linearGradient id="g3" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#C9B6F0"/><stop offset="100%" stop-color="#A78BE0"/></linearGradient>
+    <linearGradient id="g4" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#A78BE0"/><stop offset="100%" stop-color="#8E76CC"/></linearGradient>
+    <linearGradient id="spine" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFC9B4"/><stop offset="100%" stop-color="#A78BE0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="300" rx="16" fill="#1A1815"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="298.5" rx="15.25" fill="none" stroke="#3A352E" stroke-width="1.5"/>
+
+  <text x="32" y="34" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" letter-spacing="2" fill="#A49C8F">THE VALUE SPINE — FOUR FUNCTIONS · docs/VALUE_DOCTRINE.md</text>
+  <rect x="32" y="46" width="1136" height="2" rx="1" fill="url(#spine)" opacity="0.5"/>
+
+  <g font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+    <g transform="translate(32 68)">
+      <rect width="272" height="146" rx="12" fill="#221F1B" stroke="#3A352E"/>
+      <rect width="4" height="146" rx="2" fill="url(#g1)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g1)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#1A1815">1</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#EDE9E1">Measure honestly</text>
+      <text x="24" y="82" font-size="13.5" fill="#A49C8F">What the student actually masters —</text>
+      <text x="24" y="103" font-size="13.5" fill="#A49C8F">not what they believe they master.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#FFC9B4">BKTEngine · shared/illusion</text>
+    </g>
+
+    <g transform="translate(328 68)">
+      <rect width="272" height="146" rx="12" fill="#221F1B" stroke="#3A352E"/>
+      <rect width="4" height="146" rx="2" fill="url(#g2)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g2)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#1A1815">2</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#EDE9E1">Sequence the time</text>
+      <text x="24" y="82" font-size="13.5" fill="#A49C8F">Most exam points per remaining</text>
+      <text x="24" y="103" font-size="13.5" fill="#A49C8F">hour — by coefficient, not by mood.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#F0B0BE">shared/scheduling · curriculum</text>
+    </g>
+
+    <g transform="translate(624 68)">
+      <rect width="272" height="146" rx="12" fill="#221F1B" stroke="#3A352E"/>
+      <rect width="4" height="146" rx="2" fill="url(#g3)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g3)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#1A1815">3</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#EDE9E1">Force generation</text>
+      <text x="24" y="82" font-size="13.5" fill="#A49C8F">Never hand over a step the student</text>
+      <text x="24" y="103" font-size="13.5" fill="#A49C8F">could still produce themselves.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#C9B6F0">answer_redaction · D-113</text>
+    </g>
+
+    <g transform="translate(920 68)">
+      <rect width="272" height="146" rx="12" fill="#221F1B" stroke="#3A352E"/>
+      <rect width="4" height="146" rx="2" fill="url(#g4)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g4)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#1A1815">4</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#EDE9E1">Prove it to the payer</text>
+      <text x="24" y="82" font-size="13.5" fill="#A49C8F">The guardian sees the trend and the</text>
+      <text x="24" y="103" font-size="13.5" fill="#A49C8F">return — and never sees the answer.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#A78BE0">guardian/ · D-196</text>
+    </g>
+  </g>
+
+  <g transform="translate(32 234)">
+    <rect width="1136" height="46" rx="10" fill="#A78BE0" fill-opacity="0.10" stroke="#A78BE0" stroke-opacity="0.30"/>
+    <text x="20" y="29" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="14.5" fill="#EDE9E1"><tspan font-weight="700" fill="#C9B6F0">The deletion test —</tspan> if this feature were removed, which of the four stops? If the answer is “none, but it looks advanced” — it gets deleted.</text>
+  </g>
+</svg>

--- a/docs/assets/brand/four-functions-light.svg
+++ b/docs/assets/brand/four-functions-light.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300" role="img" aria-label="The four functions: measure honestly, sequence the time, force generation, prove it to the payer — and the deletion test">
+  <title>The value spine — four functions and the deletion test</title>
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#E08A66"/><stop offset="100%" stop-color="#C4785E"/></linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#C97A8E"/><stop offset="100%" stop-color="#A96B9C"/></linearGradient>
+    <linearGradient id="g3" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#8E63B4"/><stop offset="100%" stop-color="#7C5CBF"/></linearGradient>
+    <linearGradient id="g4" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#6B4FB0"/><stop offset="100%" stop-color="#5A3E96"/></linearGradient>
+    <linearGradient id="spine" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#E08A66"/><stop offset="100%" stop-color="#5A3E96"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="300" rx="16" fill="#FBFAF7"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="298.5" rx="15.25" fill="none" stroke="#E2DED4" stroke-width="1.5"/>
+
+  <text x="32" y="34" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" letter-spacing="2" fill="#5C564C">THE VALUE SPINE — FOUR FUNCTIONS · docs/VALUE_DOCTRINE.md</text>
+  <rect x="32" y="46" width="1136" height="2" rx="1" fill="url(#spine)" opacity="0.5"/>
+
+  <g font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+    <g transform="translate(32 68)">
+      <rect width="272" height="146" rx="12" fill="#FFFFFF" stroke="#E2DED4"/>
+      <rect width="4" height="146" rx="2" fill="url(#g1)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g1)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#FFFFFF">1</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#24211C">Measure honestly</text>
+      <text x="24" y="82" font-size="13.5" fill="#5C564C">What the student actually masters —</text>
+      <text x="24" y="103" font-size="13.5" fill="#5C564C">not what they believe they master.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#8A4A2C">BKTEngine · shared/illusion</text>
+    </g>
+
+    <g transform="translate(328 68)">
+      <rect width="272" height="146" rx="12" fill="#FFFFFF" stroke="#E2DED4"/>
+      <rect width="4" height="146" rx="2" fill="url(#g2)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g2)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#FFFFFF">2</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#24211C">Sequence the time</text>
+      <text x="24" y="82" font-size="13.5" fill="#5C564C">Most exam points per remaining</text>
+      <text x="24" y="103" font-size="13.5" fill="#5C564C">hour — by coefficient, not by mood.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#9A4B70">shared/scheduling · curriculum</text>
+    </g>
+
+    <g transform="translate(624 68)">
+      <rect width="272" height="146" rx="12" fill="#FFFFFF" stroke="#E2DED4"/>
+      <rect width="4" height="146" rx="2" fill="url(#g3)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g3)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#FFFFFF">3</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#24211C">Force generation</text>
+      <text x="24" y="82" font-size="13.5" fill="#5C564C">Never hand over a step the student</text>
+      <text x="24" y="103" font-size="13.5" fill="#5C564C">could still produce themselves.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#6B4FB0">answer_redaction · D-113</text>
+    </g>
+
+    <g transform="translate(920 68)">
+      <rect width="272" height="146" rx="12" fill="#FFFFFF" stroke="#E2DED4"/>
+      <rect width="4" height="146" rx="2" fill="url(#g4)"/>
+      <circle cx="38" cy="40" r="16" fill="url(#g4)"/>
+      <text x="38" y="46" text-anchor="middle" font-size="16" font-weight="700" fill="#FFFFFF">4</text>
+      <text x="68" y="46" font-size="19" font-weight="700" fill="#24211C">Prove it to the payer</text>
+      <text x="24" y="82" font-size="13.5" fill="#5C564C">The guardian sees the trend and the</text>
+      <text x="24" y="103" font-size="13.5" fill="#5C564C">return — and never sees the answer.</text>
+      <text x="24" y="128" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" fill="#5A3E96">guardian/ · D-196</text>
+    </g>
+  </g>
+
+  <g transform="translate(32 234)">
+    <rect width="1136" height="46" rx="10" fill="#7C5CBF" fill-opacity="0.07" stroke="#7C5CBF" stroke-opacity="0.28"/>
+    <text x="20" y="29" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="14.5" fill="#24211C"><tspan font-weight="700" fill="#5A3E96">The deletion test —</tspan> if this feature were removed, which of the four stops? If the answer is “none, but it looks advanced” — it gets deleted.</text>
+  </g>
+</svg>

--- a/docs/assets/brand/hero-dark.svg
+++ b/docs/assets/brand/hero-dark.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" width="1200" height="340" role="img" aria-label="CogniForge — the cognitive lab: a verifiable learning engine">
+  <title>CogniForge — The Cognitive Lab</title>
+  <defs>
+    <linearGradient id="wash" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F4A98A" stop-opacity="0.14"/>
+      <stop offset="55%" stop-color="#FFC9B4" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#A78BE0" stop-opacity="0.16"/>
+    </linearGradient>
+    <linearGradient id="mark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFC9B4"/>
+      <stop offset="50%" stop-color="#E4A6D0"/>
+      <stop offset="100%" stop-color="#A78BE0"/>
+    </linearGradient>
+    <linearGradient id="lattice" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFC9B4"/>
+      <stop offset="100%" stop-color="#A78BE0"/>
+    </linearGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFC9B4" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#A78BE0" stop-opacity="0.15"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="340" rx="18" fill="#1A1815"/>
+  <rect x="0" y="0" width="1200" height="340" rx="18" fill="url(#wash)"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="338.5" rx="17.25" fill="none" stroke="#3A352E" stroke-width="1.5"/>
+
+  <!-- cognitive lattice: prerequisite graph, root at the bottom -->
+  <g transform="translate(872 60)" opacity="0.95">
+    <g stroke="url(#lattice)" stroke-width="1.6" fill="none" opacity="0.5">
+      <path d="M110 196 L46 132"/>
+      <path d="M110 196 L110 128"/>
+      <path d="M110 196 L176 132"/>
+      <path d="M46 132 L46 66"/>
+      <path d="M46 132 L110 68"/>
+      <path d="M110 128 L110 68"/>
+      <path d="M176 132 L176 66"/>
+      <path d="M110 128 L176 66"/>
+      <path d="M46 66 L110 22"/>
+      <path d="M110 68 L110 22"/>
+      <path d="M176 66 L110 22"/>
+    </g>
+    <g fill="#1A1815" stroke="url(#lattice)" stroke-width="2.2">
+      <circle cx="46" cy="132" r="9"/>
+      <circle cx="110" cy="128" r="9"/>
+      <circle cx="176" cy="132" r="9"/>
+      <circle cx="46" cy="66" r="7"/>
+      <circle cx="110" cy="68" r="7"/>
+      <circle cx="176" cy="66" r="7"/>
+      <circle cx="110" cy="22" r="6"/>
+    </g>
+    <circle cx="110" cy="196" r="13" fill="url(#mark)"/>
+    <circle cx="110" cy="196" r="21" fill="none" stroke="#FFC9B4" stroke-width="1.2" opacity="0.4"/>
+    <text x="110" y="246" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" letter-spacing="1.6" fill="#A49C8F">ROOT CAUSE</text>
+  </g>
+
+  <!-- wordmark -->
+  <g transform="translate(72 96)">
+    <rect x="0" y="-30" width="5" height="60" rx="2.5" fill="url(#mark)"/>
+    <text x="26" y="16" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="60" font-weight="700" letter-spacing="-1.6" fill="#EDE9E1">Cogni<tspan fill="url(#mark)">Forge</tspan></text>
+  </g>
+
+  <text x="98" y="164" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="23" fill="#A49C8F">The Cognitive Lab — a <tspan fill="#EDE9E1" font-weight="600">verifiable</tspan> learning engine, not a chat tutor.</text>
+
+  <rect x="98" y="196" width="620" height="2" rx="1" fill="url(#rule)"/>
+
+  <text x="98" y="230" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13" letter-spacing="2.2" fill="#BFA6EC">DETERMINISTIC TRUTH · SOCRATIC WITHHOLDING · EVERY LAW NAMES ITS ENFORCER</text>
+
+  <g transform="translate(98 258)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="13">
+    <g>
+      <rect x="0" y="0" width="176" height="28" rx="14" fill="#F4A98A" fill-opacity="0.14" stroke="#FFC9B4" stroke-opacity="0.40"/>
+      <text x="88" y="19" text-anchor="middle" fill="#FFC9B4">Arabic · French · Darija</text>
+    </g>
+    <g transform="translate(188 0)">
+      <rect x="0" y="0" width="196" height="28" rx="14" fill="#A78BE0" fill-opacity="0.14" stroke="#A78BE0" stroke-opacity="0.40"/>
+      <text x="98" y="19" text-anchor="middle" fill="#C9B6F0">Algerian Baccalauréat</text>
+    </g>
+    <g transform="translate(396 0)">
+      <rect x="0" y="0" width="216" height="28" rx="14" fill="#7FC4A0" fill-opacity="0.12" stroke="#7FC4A0" stroke-opacity="0.35"/>
+      <text x="108" y="19" text-anchor="middle" fill="#7FC4A0">Zero LLM in the number path</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/brand/hero-light.svg
+++ b/docs/assets/brand/hero-light.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" width="1200" height="340" role="img" aria-label="CogniForge — the cognitive lab: a verifiable learning engine">
+  <title>CogniForge — The Cognitive Lab</title>
+  <defs>
+    <linearGradient id="wash" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F4A98A" stop-opacity="0.16"/>
+      <stop offset="55%" stop-color="#FFC9B4" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#7C5CBF" stop-opacity="0.14"/>
+    </linearGradient>
+    <linearGradient id="mark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#E08A66"/>
+      <stop offset="50%" stop-color="#B06BA6"/>
+      <stop offset="100%" stop-color="#6B4FB0"/>
+    </linearGradient>
+    <linearGradient id="lattice" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#F4A98A"/>
+      <stop offset="100%" stop-color="#7C5CBF"/>
+    </linearGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#F4A98A" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#7C5CBF" stop-opacity="0.15"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="340" rx="18" fill="#FBFAF7"/>
+  <rect x="0" y="0" width="1200" height="340" rx="18" fill="url(#wash)"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="338.5" rx="17.25" fill="none" stroke="#E2DED4" stroke-width="1.5"/>
+
+  <!-- cognitive lattice: prerequisite graph, root at the bottom -->
+  <g transform="translate(872 60)" opacity="0.95">
+    <g stroke="url(#lattice)" stroke-width="1.6" fill="none" opacity="0.55">
+      <path d="M110 196 L46 132"/>
+      <path d="M110 196 L110 128"/>
+      <path d="M110 196 L176 132"/>
+      <path d="M46 132 L46 66"/>
+      <path d="M46 132 L110 68"/>
+      <path d="M110 128 L110 68"/>
+      <path d="M176 132 L176 66"/>
+      <path d="M110 128 L176 66"/>
+      <path d="M46 66 L110 22"/>
+      <path d="M110 68 L110 22"/>
+      <path d="M176 66 L110 22"/>
+    </g>
+    <g fill="#FBFAF7" stroke="url(#lattice)" stroke-width="2.2">
+      <circle cx="46" cy="132" r="9"/>
+      <circle cx="110" cy="128" r="9"/>
+      <circle cx="176" cy="132" r="9"/>
+      <circle cx="46" cy="66" r="7"/>
+      <circle cx="110" cy="68" r="7"/>
+      <circle cx="176" cy="66" r="7"/>
+      <circle cx="110" cy="22" r="6"/>
+    </g>
+    <circle cx="110" cy="196" r="13" fill="url(#mark)"/>
+    <circle cx="110" cy="196" r="21" fill="none" stroke="#E08A66" stroke-width="1.2" opacity="0.45"/>
+    <text x="110" y="246" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" letter-spacing="1.6" fill="#5C564C">ROOT CAUSE</text>
+  </g>
+
+  <!-- wordmark -->
+  <g transform="translate(72 96)">
+    <rect x="0" y="-30" width="5" height="60" rx="2.5" fill="url(#mark)"/>
+    <text x="26" y="16" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="60" font-weight="700" letter-spacing="-1.6" fill="#24211C">Cogni<tspan fill="url(#mark)">Forge</tspan></text>
+  </g>
+
+  <text x="98" y="164" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="23" fill="#5C564C">The Cognitive Lab — a <tspan fill="#24211C" font-weight="600">verifiable</tspan> learning engine, not a chat tutor.</text>
+
+  <rect x="98" y="196" width="620" height="2" rx="1" fill="url(#rule)"/>
+
+  <text x="98" y="230" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13" letter-spacing="2.2" fill="#6B4FB0">DETERMINISTIC TRUTH · SOCRATIC WITHHOLDING · EVERY LAW NAMES ITS ENFORCER</text>
+
+  <g transform="translate(98 258)" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="13">
+    <g>
+      <rect x="0" y="0" width="176" height="28" rx="14" fill="#F4A98A" fill-opacity="0.18" stroke="#E08A66" stroke-opacity="0.45"/>
+      <text x="88" y="19" text-anchor="middle" fill="#8A4A2C">Arabic · French · Darija</text>
+    </g>
+    <g transform="translate(188 0)">
+      <rect x="0" y="0" width="196" height="28" rx="14" fill="#7C5CBF" fill-opacity="0.14" stroke="#7C5CBF" stroke-opacity="0.42"/>
+      <text x="98" y="19" text-anchor="middle" fill="#5A3E96">Algerian Baccalauréat</text>
+    </g>
+    <g transform="translate(396 0)">
+      <rect x="0" y="0" width="216" height="28" rx="14" fill="#1F6B46" fill-opacity="0.10" stroke="#1F6B46" stroke-opacity="0.35"/>
+      <text x="108" y="19" text-anchor="middle" fill="#1F6B46">Zero LLM in the number path</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/brand/proof-ladder-dark.svg
+++ b/docs/assets/brand/proof-ladder-dark.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 376" width="1200" height="376" role="img" aria-label="The proof ladder: a capability is ACTIVE only with import, call chain and runtime evidence; anything less is PARTIAL, DORMANT or ZOMBIE">
+  <title>The proof ladder — code presence is not runtime usage</title>
+  <defs>
+    <linearGradient id="hdr" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#FFC9B4"/><stop offset="100%" stop-color="#A78BE0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="376" rx="16" fill="#1A1815"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="374.5" rx="15.25" fill="none" stroke="#3A352E" stroke-width="1.5"/>
+
+  <text x="32" y="36" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="20" font-weight="700" fill="#EDE9E1">Code presence is not runtime usage.</text>
+  <text x="32" y="62" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="14" fill="#A49C8F">A capability is real only when all three legs hold. Anything less is labelled honestly — live table: <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#C9B6F0">.memory/runtime_truth.md</tspan></text>
+  <rect x="32" y="76" width="1136" height="2" rx="1" fill="url(#hdr)" opacity="0.5"/>
+
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" letter-spacing="1.4" fill="#A49C8F">
+    <text x="32" y="106">STATUS</text>
+    <text x="342" y="106" text-anchor="middle">IMPORT</text>
+    <text x="472" y="106" text-anchor="middle">CALL CHAIN</text>
+    <text x="612" y="106" text-anchor="middle">RUNTIME EVIDENCE</text>
+    <text x="700" y="106">WHAT IT MEANS</text>
+  </g>
+
+  <g font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+    <!-- ACTIVE -->
+    <g transform="translate(0 118)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#7FC4A0" fill-opacity="0.10"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#7FC4A0"/>
+      <text x="52" y="28" font-size="15" font-weight="700" fill="#7FC4A0">ACTIVE</text>
+      <circle cx="342" cy="22" r="8" fill="#7FC4A0"/>
+      <circle cx="472" cy="22" r="8" fill="#7FC4A0"/>
+      <circle cx="612" cy="22" r="8" fill="#7FC4A0"/>
+      <text x="700" y="27" font-size="13.5" fill="#EDE9E1">Proven on a live path — the only status claimable as capability.</text>
+    </g>
+    <!-- ACTIVE (no-op) -->
+    <g transform="translate(0 168)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#D9A441" fill-opacity="0.10"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#D9A441"/>
+      <text x="52" y="27" font-size="15" font-weight="700" fill="#D9A441">ACTIVE (no-op)</text>
+      <circle cx="342" cy="22" r="8" fill="#D9A441"/>
+      <circle cx="472" cy="22" r="8" fill="#D9A441"/>
+      <path d="M604 22 a8 8 0 0 1 16 0 a8 8 0 0 1 -16 0" fill="none" stroke="#D9A441" stroke-width="2"/>
+      <path d="M612 14 a8 8 0 0 1 0 16 z" fill="#D9A441"/>
+      <text x="700" y="27" font-size="13.5" fill="#EDE9E1">Called, but inert without a specific env var. Said out loud.</text>
+    </g>
+    <!-- PARTIAL -->
+    <g transform="translate(0 218)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#A78BE0" fill-opacity="0.12"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#A78BE0"/>
+      <text x="52" y="27" font-size="15" font-weight="700" fill="#C9B6F0">PARTIAL</text>
+      <circle cx="342" cy="22" r="8" fill="#A78BE0"/>
+      <path d="M464 22 a8 8 0 0 1 16 0 a8 8 0 0 1 -16 0" fill="none" stroke="#A78BE0" stroke-width="2"/>
+      <path d="M472 14 a8 8 0 0 1 0 16 z" fill="#A78BE0"/>
+      <circle cx="612" cy="22" r="8" fill="none" stroke="#A78BE0" stroke-width="2"/>
+      <text x="700" y="27" font-size="13.5" fill="#EDE9E1">Fallback-only. “Loaded but never invoked” lives here.</text>
+    </g>
+    <!-- DORMANT -->
+    <g transform="translate(0 268)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#A49C8F" fill-opacity="0.10"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#A49C8F"/>
+      <text x="52" y="27" font-size="15" font-weight="700" fill="#A49C8F">DORMANT</text>
+      <circle cx="342" cy="22" r="8" fill="#A49C8F"/>
+      <circle cx="472" cy="22" r="8" fill="none" stroke="#A49C8F" stroke-width="2"/>
+      <circle cx="612" cy="22" r="8" fill="none" stroke="#A49C8F" stroke-width="2"/>
+      <text x="700" y="27" font-size="13.5" fill="#EDE9E1">Real code behind a service nobody starts. Declared absent.</text>
+    </g>
+    <!-- ZOMBIE -->
+    <g transform="translate(0 318)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#E8938A" fill-opacity="0.10"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#E8938A"/>
+      <text x="52" y="28" font-size="15" font-weight="700" fill="#E8938A">ZOMBIE</text>
+      <circle cx="342" cy="22" r="8" fill="none" stroke="#E8938A" stroke-width="2"/>
+      <circle cx="472" cy="22" r="8" fill="none" stroke="#E8938A" stroke-width="2"/>
+      <circle cx="612" cy="22" r="8" fill="none" stroke="#E8938A" stroke-width="2"/>
+      <text x="700" y="28" font-size="13.5" fill="#EDE9E1">No live call chain anywhere. Deleted, never left as a stub.</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/brand/proof-ladder-light.svg
+++ b/docs/assets/brand/proof-ladder-light.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 376" width="1200" height="376" role="img" aria-label="The proof ladder: a capability is ACTIVE only with import, call chain and runtime evidence; anything less is PARTIAL, DORMANT or ZOMBIE">
+  <title>The proof ladder — code presence is not runtime usage</title>
+  <defs>
+    <linearGradient id="hdr" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#E08A66"/><stop offset="100%" stop-color="#5A3E96"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="376" rx="16" fill="#FBFAF7"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="374.5" rx="15.25" fill="none" stroke="#E2DED4" stroke-width="1.5"/>
+
+  <text x="32" y="36" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="20" font-weight="700" fill="#24211C">Code presence is not runtime usage.</text>
+  <text x="32" y="62" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="14" fill="#5C564C">A capability is real only when all three legs hold. Anything less is labelled honestly — live table: <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13" fill="#6B4FB0">.memory/runtime_truth.md</tspan></text>
+  <rect x="32" y="76" width="1136" height="2" rx="1" fill="url(#hdr)" opacity="0.5"/>
+
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="11.5" letter-spacing="1.4" fill="#5C564C">
+    <text x="32" y="106">STATUS</text>
+    <text x="342" y="106" text-anchor="middle">IMPORT</text>
+    <text x="472" y="106" text-anchor="middle">CALL CHAIN</text>
+    <text x="612" y="106" text-anchor="middle">RUNTIME EVIDENCE</text>
+    <text x="700" y="106">WHAT IT MEANS</text>
+  </g>
+
+  <g font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif">
+    <!-- ACTIVE -->
+    <g transform="translate(0 118)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#1F6B46" fill-opacity="0.07"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#1F6B46"/>
+      <text x="52" y="28" font-size="15" font-weight="700" fill="#1F6B46">ACTIVE</text>
+      <circle cx="342" cy="22" r="8" fill="#1F6B46"/>
+      <circle cx="472" cy="22" r="8" fill="#1F6B46"/>
+      <circle cx="612" cy="22" r="8" fill="#1F6B46"/>
+      <text x="700" y="27" font-size="13.5" fill="#24211C">Proven on a live path — the only status claimable as capability.</text>
+    </g>
+    <!-- ACTIVE (no-op) -->
+    <g transform="translate(0 168)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#8A5A12" fill-opacity="0.07"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#8A5A12"/>
+      <text x="52" y="27" font-size="15" font-weight="700" fill="#8A5A12">ACTIVE (no-op)</text>
+      <circle cx="342" cy="22" r="8" fill="#8A5A12"/>
+      <circle cx="472" cy="22" r="8" fill="#8A5A12"/>
+      <path d="M604 22 a8 8 0 0 1 16 0 a8 8 0 0 1 -16 0" fill="none" stroke="#8A5A12" stroke-width="2"/>
+      <path d="M612 14 a8 8 0 0 1 0 16 z" fill="#8A5A12"/>
+      <text x="700" y="27" font-size="13.5" fill="#24211C">Called, but inert without a specific env var. Said out loud.</text>
+    </g>
+    <!-- PARTIAL -->
+    <g transform="translate(0 218)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#7C5CBF" fill-opacity="0.07"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#7C5CBF"/>
+      <text x="52" y="27" font-size="15" font-weight="700" fill="#5A3E96">PARTIAL</text>
+      <circle cx="342" cy="22" r="8" fill="#7C5CBF"/>
+      <path d="M464 22 a8 8 0 0 1 16 0 a8 8 0 0 1 -16 0" fill="none" stroke="#7C5CBF" stroke-width="2"/>
+      <path d="M472 14 a8 8 0 0 1 0 16 z" fill="#7C5CBF"/>
+      <circle cx="612" cy="22" r="8" fill="none" stroke="#7C5CBF" stroke-width="2"/>
+      <text x="700" y="27" font-size="13.5" fill="#24211C">Fallback-only. “Loaded but never invoked” lives here.</text>
+    </g>
+    <!-- DORMANT -->
+    <g transform="translate(0 268)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#5C564C" fill-opacity="0.07"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#5C564C"/>
+      <text x="52" y="27" font-size="15" font-weight="700" fill="#5C564C">DORMANT</text>
+      <circle cx="342" cy="22" r="8" fill="#5C564C"/>
+      <circle cx="472" cy="22" r="8" fill="none" stroke="#5C564C" stroke-width="2"/>
+      <circle cx="612" cy="22" r="8" fill="none" stroke="#5C564C" stroke-width="2"/>
+      <text x="700" y="27" font-size="13.5" fill="#24211C">Real code behind a service nobody starts. Declared absent.</text>
+    </g>
+    <!-- ZOMBIE -->
+    <g transform="translate(0 318)">
+      <rect x="32" y="0" width="1136" height="44" rx="9" fill="#A8332A" fill-opacity="0.07"/>
+      <rect x="32" y="0" width="4" height="44" rx="2" fill="#A8332A"/>
+      <text x="52" y="28" font-size="15" font-weight="700" fill="#A8332A">ZOMBIE</text>
+      <circle cx="342" cy="22" r="8" fill="none" stroke="#A8332A" stroke-width="2"/>
+      <circle cx="472" cy="22" r="8" fill="none" stroke="#A8332A" stroke-width="2"/>
+      <circle cx="612" cy="22" r="8" fill="none" stroke="#A8332A" stroke-width="2"/>
+      <text x="700" y="28" font-size="13.5" fill="#24211C">No live call chain anywhere. Deleted, never left as a stub.</text>
+    </g>
+  </g>
+</svg>

--- a/scripts/fitness/check_authority_links.py
+++ b/scripts/fitness/check_authority_links.py
@@ -33,10 +33,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 #: ملفّات السلطة — من يقرأها يبني عليها قراراً.
+#: ⚠️ `README.md` و`README.ar.md` أُضيفا بعد أن تبيّن أن الواجهة الأولى للمستودع كانت
+#: تُحيل إلى **ثلاثة مسارات لا وجود لها** (`docs/EVALUATION_PROTOCOL.md` ·
+#: `docs/IMPACT_MEASUREMENT_PLAN.md` · `toolkit/START_HERE.md`) وتعرض في خريطتها
+#: مجلّداً غير موجود — أي نفس صنف ISS-149 بالضبط، في **أوّل ملفّ يفتحه كل قادمٍ من
+#: خارج المستودع**. البوّابة كانت تحرس ما يقرأه المطوّرون وتترك ما يقرأه العالَم.
 _AUTHORITY_DOCS: tuple[str, ...] = (
     "docs/DOCUMENTATION_INDEX.md",
     ".memory/README.md",
     "CLAUDE.md",
+    "README.md",
+    "README.ar.md",
 )
 
 _LINK = re.compile(r"\]\((?!https?:|mailto:)([^)\s#]+)")

--- a/scripts/fitness/check_constitution_reality.py
+++ b/scripts/fitness/check_constitution_reality.py
@@ -69,6 +69,9 @@ _AUTHORITY_DOCS: tuple[str, ...] = (
     "spec.md",
     "AGENTS.md",
     "README.md",
+    # المرآة العربية للواجهة الأولى: الأرقام فيها مكتوبة بالخانات نفسها، والبوّابة
+    # تُترجم الأرقام العربية-الهندية — فلا تصير النسخة الثانية موطناً لرقمٍ بائت.
+    "README.ar.md",
     "replit.md",
     ".memory/README.md",
     ".memory/context.md",


### PR DESCRIPTION
## Summary

`README.md` described a **different project** than the documentation. It branded the repository as a safeguarding evaluation framework, while `CLAUDE.md`, `.memory/`, `AGENTS.md`, `docs/START_HERE.md` and even the frontend title all describe **CogniForge** — a cognitive lab for Algerian BAC students built on a deterministic symbolic engine, Bayesian knowledge tracing, FSRS scheduling, and a Socratic withholding law enforced gate by gate in CI.

Worse, it was the exact failure class this repository condemns in ISS-149 — *a map that lies*. It linked to `docs/EVALUATION_PROTOCOL.md`, `docs/IMPACT_MEASUREMENT_PLAN.md` and `toolkit/START_HERE.md` — **none of which exist** — and its repository map listed a `toolkit/` directory that is not in the tree. Nothing caught it, because `check_authority_links` guarded the files developers read and left unguarded the one file everyone outside the repository opens first.

So this is not only a rewrite. **`README.md` and `README.ar.md` now sit inside `_AUTHORITY_DOCS` of both doc-integrity gates**: every local link must resolve, and every quantity must equal the value derived from its source. Both enforcers were proven red before being left green.

What changed:

- **`README.md`** — full rewrite, English-first for US/EU readers: the published PNAS 2025 result behind the withholding law, the four value functions and the deletion test, the two real runtime topologies (documented as two, never as one), the cognitive core, the proof ladder, a law→enforcer table, and a section stating **what is deliberately not built**.
- **`README.ar.md`** — full Arabic mirror, Arabic-native prose, same assets.
- **`docs/assets/brand/*.svg`** — six hand-authored assets (light + dark pairs) on the warm-paper palette the design tokens already use, extended with peach and plum accents. No external fonts, no raster, no remote references.
- **`scripts/fitness/check_authority_links.py`** — `README.md` + `README.ar.md` added; frozen debt stays **empty**.
- **`scripts/fitness/check_constitution_reality.py`** — `README.ar.md` added, so numbers in the mirror are derived-checked too.

## Change Type
- [x] governance / documentation

## Affected Areas
- [x] contracts / guardrails
- [x] docs / governance

## Risk & Rollback
- **Risk level:** low — no application code, no workflow files, no `CLAUDE.md` or `.memory/` edits.
- **Rollback plan:** revert the commit. The only behavioural change is two gates gaining reach; reverting restores their previous scope.

## Validation Evidence

```
$ python scripts/fitness/check_authority_links.py
✅ كل روابط ملفّات السلطة الـ5 تصل إلى مسارات موجودة.

$ python scripts/fitness/check_constitution_reality.py
✅ constitution = reality عبر 15 وثيقة سلطة: بلا تناقض ذاتي · الأرقام مشتقّة
   (39 مهارة · 13 عقداً · 13 خدمة · D-227 · تغطية 73 · 10 وظائف required-ci) ·
   5 ادّعاءات رموز مُتحقَّقة · دَينٌ مُجمَّد: 0.

$ python scripts/fitness/check_memory_coherence.py
✅ memory coherence: index fresh, recent order strict, constitution bounded, lock current.

$ python scripts/run_fitness_gates.py     # 36/38 pass; the 2 failures are the
                                          # sandbox interpreter missing pytest and
                                          # pydantic — identical on a clean checkout
```

**Negative tests — an enforcer that cannot fail is a slogan:**

```
# dead link appended to README.md
❌ README.md: الرابط 'docs/THIS_DOES_NOT_EXIST.md' لا يُشير إلى شيء.   → exit 1

# stale skill count appended to README.ar.md
❌ README.ar.md:432: «عدد المهارات» مكتوبةً '٢٧' بينما المُشتَقّ 39.    → exit 1
```

Both files restored; both gates green again.

Assets were rendered in headless Chromium against white and `#0d1117` backgrounds and inspected — no clipped text, both themes deliberate.

## Governance Checklist (Required)
- [x] I updated docs when runtime/CI behavior changed.
- [x] I did not add duplicate CI truth layers — the READMEs join existing gates rather than adding a new one. No status table or derived number is restated; both point at `.memory/runtime_truth.md`.
- [x] I confirmed mergeability depends on `required-ci`.
- [x] I removed or justified any skipped tests — none touched.
- [x] I verified no PII or sensitive secrets were added.

## Safeguarding Impact

Strengthened, not weakened. The safeguarding substance is kept and expanded — only links to files that do not exist were removed. The new §14 states the structural guarantees plainly: the guardian report never queries message content, linking is consent-first, an unlinked read returns 404 rather than 403, and no addictive or leaderboard mechanics are permitted. §09 applies D-227's credibility limit to our own copy: no unfalsifiable marketing claims, because this platform serves minors and the parents who decide based on what we say.

## Reviewer Guide

Start with the two gate diffs — they are five lines and they are the part that cannot rot. Then read §07 (law → enforcer) and §09 (what is not built) in `README.md`; those two sections are where an outside auditor will look first, and they are the ones that must not overstate. Everything else is prose over facts already committed in `CLAUDE.md` and `.memory/runtime_truth.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EinqsMAjsRg2xcBGvQCgqX)_